### PR TITLE
sip: Application Configuration

### DIFF
--- a/docs/content/sips/000-app-config.md
+++ b/docs/content/sips/000-app-config.md
@@ -1,0 +1,161 @@
+title = "SIP xxx - Application Configuration"
+template = "main"
+date = "2022-03-22T14:53:30Z"
+
+---
+
+Summary: A configuration system for Spin applications.
+
+Owner: lann.martin@fermyon.com
+
+Created: March 22, 2022
+
+## Background
+
+It is common for applications to require configuration at runtime that isn't known at build time or is too sensitive to be stored with build artifacts.
+
+A few examples:
+
+- Logging configuration
+- Per-channel (production, staging, etc) service dependency URLs
+- Database secrets
+
+## Proposal
+
+### Configuration is a tree, with the app at its root
+
+e.g.:
+- app_key
+- component1
+  - key1
+  - key2
+- component2
+  - key3
+  - nested-component
+    - key4
+
+### Each key has a "path" corresponding to its position in the tree
+
+- e.g. `component2.nested-component.key4`
+
+- Config keys are restricted to allow unambiguous encoding as environment variables
+  / file paths:
+  - Start with a letter (required for env vars)
+  - Only lowercase ascii alphanum and `-` (could be `_` instead but only one of those)
+    - Only one `-` at a time (to allow joining paths as env vars with `__`)
+
+### Configuration "schema" is defined by the app and components
+```toml
+[config] # [application.config]?
+key1 = "default_value"
+# ...is equivalent to:
+key1 = { default = "default_value" }
+
+# "required" fields must be given a value
+key2 = { required = true }
+
+# "secret" field values should be handled with care (e.g. not logged)
+key3 = { required = true, secret = true }
+
+[[component]]
+id = "component1"
+...
+# Reusable components would define their config in their own component manifest
+[[component.config]]
+key1 = "value"  # Path: component1.key1
+...
+# Component dependency config can be overridden
+[[component.dependencies.nested-component]]
+key4 = "override"
+```
+
+### Configuration defaults can reference other keys
+```toml
+[config]
+app_key = "app_value"
+app_key2 = "prefix-{{ app_key }}-suffix"  # "prefix-app_value-suffix"
+
+[[component.config]]
+key1 = "value1"
+# Component config can reference root (app) keys:
+key2 = "root_ref={{ app_key }}"   # "root_ref=app_value"
+# and its own keys:
+key3 = "self_ref={{ .key1 }}"     # "self_ref=value1"
+
+[[component.dependencies.nested-component.config]]
+own_key = ""
+# Dependency config can reference root, parent (dependant), and own keys:
+root_ref = "{{ app_key }}"
+parent_ref = "{{ ..key1 }}"
+self_ref = "{{ .own_key }}
+```
+
+### Configuration "providers" populate configuration
+
+_I haven't thought this through too much. Would this live in `spin.toml`? How is config resolved across multiple providers?_
+```toml
+[[config_provider]]
+type = "toml_file"
+path = "config.toml"
+
+[[config_provider]]
+type = "environment"
+# Some config might not be appropriate for some providers
+exclude = "component2.*"
+```
+
+#### Example providers
+
+- Environment provider
+  - `component2.nested-component.key4` -> `SPIN_APP__COMPONENT2__NESTED_COMPONENT__KEY4`
+  - 😬 _Boy howdy thats ugly! Better ideas?_
+- File provider
+  ```toml
+  [component2.nested-component]
+  key4 = "value"
+  ```
+- Vault provider
+
+### Configuration is exposed via component interface
+
+`spin-config.wit`
+```
+// Missing key is a runtime error
+get_config: function(key: string) -> string
+```
+- Since each component gets its own instance of the `spin-config` import, the executor can resolve paths automatically and only expose a component's own config to it.
+
+### Other design options
+
+#### Typed configuration
+
+The above assumes only string values, but we could include some typing:
+```toml
+# Simple form is typed implicitly from its default value
+string_key = "value"
+string_key = { type = "string", default = "value" }
+
+number_key = 123
+number_key = { type = "number", default = 123 }
+
+required_string = { type = "string", required = true }
+# Would require e.g. base64 encoding in some places
+encryption_key = { type = "bytes", required = true, secret = true}
+```
+
+- This would complicate everything for _us_ but is nicer for users.
+
+#### WASI "configfs"
+
+For languages without component support, we could expose config as synthetic mounted files:
+
+```ruby
+key1_value = File.read("/config/key1")
+
+# Typed config
+key1_value = JSON.parse(File.read("/config/key1.json"))
+
+# "bytes" type
+encryption_key = File.read("/config/encryption_key.raw")
+```
+  

--- a/docs/content/sips/000-app-config.md
+++ b/docs/content/sips/000-app-config.md
@@ -27,9 +27,8 @@ It is common for applications to require configuration at runtime that isn't kno
 Configuration within a "parent" (component or application) consists of a number of configuration "slots":
 - slots are uniquely identified within their parent by a string "key"; in order to allow unambiguous conversion to environment variables or file paths, keys are constrained:
   - must start with a letter (required for env vars)
-  - consisting of only lowercase ascii alphanum and `-`
-    - only one `-` at a time and not at the end (to allow separating env vars with `__`)
-    - `-` matches WIT syntax but `_` might be more familiar to users
+  - consisting of only lowercase ascii alphanum and `_` (`[a-z0-9_]`)
+    - only one `_` at a time and not at the end (to allow delimiting in env vars with `__`)
 - a slot must _either_ be marked as "required" _or_ must be given a default value
 - a slot may be marked as "secret", in which case any associated value should be handled with care (e.g. not logged)
 
@@ -56,13 +55,13 @@ In dependency configuration, templates can reference the app config and "ancesto
 `spin.toml`:
 ```toml
 [config]
-app-root = "/app"
+app_root = "/app"
 ...
 [[component.config]]
 # Note: no '.'s needed when referencing top-level app config
-work-root = "{{ app-root }}/work"  # -> "/app/work"
+work_root = "{{ app_root }}/work"  # -> "/app/work"
 [[component.dependencies.dep1.config]]
-dep-root = "{{ ..work-root }}/dep" # -> "/app/work/dep"
+dep_root = "{{ ..work_root }}/dep" # -> "/app/work/dep"
 ```
 
 ### Configuration "providers" resolve application configuration
@@ -74,11 +73,11 @@ Provider configuration is handled by spin at instantiation time (`spin up`).
 _Note: Provider configuration is TBD; as TOML it could look like:_
 
 ```toml
-[[config_provider]]
+[[config-provider]]
 type = "json_file"
 path = "config.json"
 
-[[config_provider]]
+[[config-provider]]
 type = "env"
 prefix = "MY_APP_"
 ```
@@ -87,10 +86,10 @@ prefix = "MY_APP_"
 
 - Environment provider
   - Configured with a prefix, e.g. `SPIN_APP_`
-  - `key-one` -> `SPIN_APP_KEY_ONE`
+  - `key_one` -> `SPIN_APP_KEY_ONE`
 - File provider
   ```json
-  {"key-one": "value-one"}
+  {"key_one": "value-one"}
   ```
 - Vault provider
 
@@ -110,15 +109,15 @@ get-config: function(key: string) -> expect<string>
 The above assumes only string values, but we could include some typing:
 ```toml
 # Simple form is typed implicitly from its default value
-string-key = "value"
-string-key = { type = "string", default = "value" }
+string_key = "value"
+string_key = { type = "string", default = "value" }
 
-number-key = 123
-number-key = { type = "number", default = 123 }
+number_key = 123
+number_key = { type = "number", default = 123 }
 
-required-string = { type = "string", required = true }
+required_string = { type = "string", required = true }
 # "bytes" would require e.g. base64 encoding in some places
-encryption-key = { type = "bytes", required = true, secret = true}
+encryption_key = { type = "bytes", required = true, secret = true}
 ```
 - This would complicate the implementation but might be nice for users.
 
@@ -127,12 +126,12 @@ encryption-key = { type = "bytes", required = true, secret = true}
 For languages without component support, we could expose config as synthetic mounted files:
 
 ```ruby
-key1-value = File.read("/config/key1")
+key1_value = File.read("/config/key1")
 
 # Typed config; `.json` encodes values to JSON
-key1-value = JSON.parse(File.read("/config/key1.json"))
+key1_value = JSON.parse(File.read("/config/key1.json"))
 
 # "bytes" type; `.raw` decodes from base64
-encryption-key = File.read("/config/encryption_key.raw")
+encryption_key = File.read("/config/encryption_key.raw")
 ```
   

--- a/docs/content/sips/000-app-config.md
+++ b/docs/content/sips/000-app-config.md
@@ -10,11 +10,11 @@ Owner: lann.martin@fermyon.com
 
 Created: March 22, 2022
 
+Updated: April 1, 2022
+
 ## Background
 
-It is common for applications to require configuration at runtime that isn't known at build time or is too sensitive to be stored with build artifacts.
-
-A few examples:
+It is common for applications to require configuration at runtime that isn't known at build time or is too sensitive to be stored with build artifacts:
 
 - Logging configuration
 - Per-channel (production, staging, etc) service dependency URLs
@@ -22,97 +22,75 @@ A few examples:
 
 ## Proposal
 
-### Configuration is a tree, with the app at its root
+### Configuration is defined by components and applications
 
-e.g.:
-- app_key
-- component1
-  - key1
-  - key2
-- component2
-  - key3
-  - nested-component
-    - key4
+Configuration within a "parent" (component or application) consists of a number of configuration "slots":
+- slots are uniquely identified within their parent by a string "key"; in order to allow unambiguous conversion to environment variables or file paths, keys are constrained:
+  - must start with a letter (required for env vars)
+  - consisting of only lowercase ascii alphanum and `-`
+    - only one `-` at a time and not at the end (to allow separating env vars with `__`)
+    - `-` matches WIT syntax but `_` might be more familiar to users
+- a slot must _either_ be marked as "required" _or_ must be given a default value
+- a slot may be marked as "secret", in which case any associated value should be handled with care (e.g. not logged)
 
-### Each key has a "path" corresponding to its position in the tree
-
-- e.g. `component2.nested-component.key4`
-
-- Config keys are restricted to allow unambiguous encoding as environment variables
-  / file paths:
-  - Start with a letter (required for env vars)
-  - Only lowercase ascii alphanum and `-` (could be `_` instead but only one of those)
-    - Only one `-` at a time (to allow joining paths as env vars with `__`)
-
-### Configuration "schema" is defined by the app and components
 ```toml
-[config] # [application.config]?
+[config]
+# This simple form...
 key1 = "default_value"
 # ...is equivalent to:
 key1 = { default = "default_value" }
-
-# "required" fields must be given a value
-key2 = { required = true }
-
-# "secret" field values should be handled with care (e.g. not logged)
-key3 = { required = true, secret = true }
-
-[[component]]
-id = "component1"
-...
-# Reusable components would define their config in their own component manifest
-[[component.config]]
-key1 = "value"  # Path: component1.key1
-...
-# Component dependency config can be overridden
-[[component.dependencies.nested-component]]
-key4 = "override"
+# required & secret slot 
+key2 = { required = true, secret = true }
 ```
 
-### Configuration defaults can reference other keys
+Defaults can use template strings to reference other slots.
+```toml
+key1 = { required = true }
+key2 = "prefix-{{ .key1 }}-suffix"
+```
+
+### Components and applications can set configuration of their direct dependencies
+
+In dependency configuration, templates can reference the app config and "ancestor" dependant configs:
+
+`spin.toml`:
 ```toml
 [config]
-app_key = "app_value"
-app_key2 = "prefix-{{ app_key }}-suffix"  # "prefix-app_value-suffix"
-
+app-root = "/app"
+...
 [[component.config]]
-key1 = "value1"
-# Component config can reference root (app) keys:
-key2 = "root_ref={{ app_key }}"   # "root_ref=app_value"
-# and its own keys:
-key3 = "self_ref={{ .key1 }}"     # "self_ref=value1"
-
-[[component.dependencies.nested-component.config]]
-own_key = ""
-# Dependency config can reference root, parent (dependant), and own keys:
-root_ref = "{{ app_key }}"
-parent_ref = "{{ ..key1 }}"
-self_ref = "{{ .own_key }}
+# Note: no '.'s needed when referencing top-level app config
+work-root = "{{ app-root }}/work"  # -> "/app/work"
+[[component.dependencies.dep1.config]]
+dep-root = "{{ ..work-root }}/dep" # -> "/app/work/dep"
 ```
 
-### Configuration "providers" populate configuration
+### Configuration "providers" resolve application configuration
 
-_I haven't thought this through too much. Would this live in `spin.toml`? How is config resolved across multiple providers?_
+When resolving the value of an application configuration slot, providers will be queried in-order for a value. If no value is returned by any provider, the resolution will either use the default value or fail (if the slot is "required").
+
+Provider configuration is handled by spin at instantiation time (`spin up`).
+
+_Note: Provider configuration is TBD; as TOML it could look like:_
+
 ```toml
 [[config_provider]]
-type = "toml_file"
-path = "config.toml"
+type = "json_file"
+path = "config.json"
 
 [[config_provider]]
-type = "environment"
-# Some config might not be appropriate for some providers
-exclude = "component2.*"
+type = "env"
+prefix = "MY_APP_"
 ```
 
 #### Example providers
 
 - Environment provider
-  - `component2.nested-component.key4` -> `SPIN_APP__COMPONENT2__NESTED_COMPONENT__KEY4`
-  - 😬 _Boy howdy thats ugly! Better ideas?_
+  - Configured with a prefix, e.g. `SPIN_APP_`
+  - `key-one` -> `SPIN_APP_KEY_ONE`
 - File provider
-  ```toml
-  [component2.nested-component]
-  key4 = "value"
+  ```json
+  {"key-one": "value-one"}
   ```
 - Vault provider
 
@@ -120,42 +98,41 @@ exclude = "component2.*"
 
 `spin-config.wit`
 ```
-// Missing key is a runtime error
-get_config: function(key: string) -> string
+// Unknown key is a runtime error
+get-config: function(key: string) -> expect<string>
 ```
-- Since each component gets its own instance of the `spin-config` import, the executor can resolve paths automatically and only expose a component's own config to it.
+- Since each component gets its own instance of the `spin-config` import, the executor can resolve keys automatically and only expose a component's own config to it.
 
-### Other design options
+### Future design options
 
 #### Typed configuration
 
 The above assumes only string values, but we could include some typing:
 ```toml
 # Simple form is typed implicitly from its default value
-string_key = "value"
-string_key = { type = "string", default = "value" }
+string-key = "value"
+string-key = { type = "string", default = "value" }
 
-number_key = 123
-number_key = { type = "number", default = 123 }
+number-key = 123
+number-key = { type = "number", default = 123 }
 
-required_string = { type = "string", required = true }
-# Would require e.g. base64 encoding in some places
-encryption_key = { type = "bytes", required = true, secret = true}
+required-string = { type = "string", required = true }
+# "bytes" would require e.g. base64 encoding in some places
+encryption-key = { type = "bytes", required = true, secret = true}
 ```
-
-- This would complicate everything for _us_ but is nicer for users.
+- This would complicate the implementation but might be nice for users.
 
 #### WASI "configfs"
 
 For languages without component support, we could expose config as synthetic mounted files:
 
 ```ruby
-key1_value = File.read("/config/key1")
+key1-value = File.read("/config/key1")
 
-# Typed config
-key1_value = JSON.parse(File.read("/config/key1.json"))
+# Typed config; `.json` encodes values to JSON
+key1-value = JSON.parse(File.read("/config/key1.json"))
 
-# "bytes" type
-encryption_key = File.read("/config/encryption_key.raw")
+# "bytes" type; `.raw` decodes from base64
+encryption-key = File.read("/config/encryption_key.raw")
 ```
   

--- a/docs/content/sips/002-app-config.md
+++ b/docs/content/sips/002-app-config.md
@@ -10,7 +10,7 @@ Owner: lann.martin@fermyon.com
 
 Created: March 22, 2022
 
-Updated: April 1, 2022
+Updated: April 4, 2022
 
 ## Background
 
@@ -22,46 +22,45 @@ It is common for applications to require configuration at runtime that isn't kno
 
 ## Proposal
 
-### Configuration is defined by components and applications
+### Configuration schema is defined by components and applications
 
 Configuration within a "parent" (component or application) consists of a number of configuration "slots":
-- Slots are uniquely identified within their parent by a string "key"; in order to allow unambiguous conversion to environment variables or file paths, keys are constrained:
+- Slots are identified by a string "key"; in order to allow unambiguous conversion to environment variables or file paths, keys are constrained:
   - Keys must start with a letter (required for env vars)
   - Keys consist of only lowercase ascii alphanum and `_` (`[a-z0-9_]`)
     - Only one `_` at a time and not at the end (to allow delimiting in env vars with `__`)
+- Slot keys must be unique within their parent, but to allow independent development of components different parents may have identical keys
 - A slot must _either_ be marked as "required" _or_ must be given a default value
 - A slot may be marked as "secret", in which case any associated value should be handled with care (e.g. not logged)
 
 ```toml
 [config]
-# This simple form...
-key1 = "default_value"
-# ...is equivalent to:
-key1 = { default = "default_value" }
-# required & secret slot 
-key2 = { required = true, secret = true }
+required_key = { required = true }
+optional_key = { default = "default_value" }
+secret_key = { required = true, secret = true }
 ```
 
 Default values can use template strings to reference other slots.
 ```toml
 [config]
 key1 = { required = true }
-key2 = "prefix-{{ key1 }}-suffix"
+key2 = { default = "prefix-{{ key1 }}-suffix" }
 ```
 
-### Components and applications can set configuration of their direct dependencies
+### Components and applications set configuration values of their dependencies
 
-In dependency configuration, templates can reference top-level config keys (those in `[config]`), "sibling" keys within the same dependency, and "ancestor" dependant configs.
+In dependency configuration, templates strings can reference top-level config keys (those in `[config]`), "sibling" keys within the same dependency, and "ancestor" dependant configs.
 
 - Top-level references use just the key name: `{{ top_level_key }}`
 - "Sibling" references use a single `.` prefix: `{{ .sibling_key }}`
 - "Ancestor" references use multiple `.`s: `{{ ..parent_dep_key }}`, `{{ ...grandparent_key }}`
+- Circular / infinitely recursive references are not permitted
 
 `spin.toml`:
 ```toml
 [config]
-app_root = "/app"
-log_file = "{{ app_root }}/log.txt"    # -> "/app/log.txt"
+app_root = { default = "/app" }
+log_file = { default = "{{ app_root }}/log.txt" }
 ...
 [[component.config]]
 work_root = "{{ app_root }}/work"      # -> "/app/work"
@@ -110,22 +109,21 @@ get-config: function(key: string) -> expect<string>
 
 ### Future design options
 
+_This section contains possible future features which are not fully defined here._
+
 #### Typed configuration
 
 The above assumes only string values, but we could include some typing:
 ```toml
-# Simple form is typed implicitly from its default value
-string_key = "value"
-string_key = { type = "string", default = "value" }
-
-number_key = 123
+# Type can be inferred from default value:
+number_key = { default = 123 }
+# equivalent to:
 number_key = { type = "number", default = 123 }
 
 required_string = { type = "string", required = true }
 # "bytes" would require e.g. base64 encoding in some places
 encryption_key = { type = "bytes", required = true, secret = true}
 ```
-- This would complicate the implementation but might be nice for users.
 
 #### WASI "configfs"
 

--- a/docs/content/sips/index.md
+++ b/docs/content/sips/index.md
@@ -1,0 +1,11 @@
+title = "Spin Improvement Proposals"
+template = "main"
+date = "2022-03-22T14:53:30Z"
+
+---
+
+# Spin Improvement Proposals
+
+## WIP SIPs
+
+[Application Configuration](000-app-config.md)

--- a/docs/content/sips/index.md
+++ b/docs/content/sips/index.md
@@ -6,6 +6,4 @@ date = "2022-03-22T14:53:30Z"
 
 # Spin Improvement Proposals
 
-## WIP SIPs
-
-[Application Configuration](000-app-config.md)
+[Application Configuration](002-app-config.md)


### PR DESCRIPTION
[Rendered](https://github.com/fermyon/spin/blob/config-sip/docs/content/sips/000-app-config.md)

Issues to resolve:
- [x] Document that circular references are invalid
- [x] Document rationale for config "tree" (to support third-party components w/ external schema)
- [x] Clarify split between "schema" and "value" sections; maybe don't use "simple" form for schema (?)