### PR TITLE
Hello, Fermyon!

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -101,7 +101,7 @@ We can build this component using the regular Rust toolchain, targeting
 `spin.toml`:
 
 ```
-$ cargo build --target wasm32-wasi --release
+$ cargo build --release
 ```
 
 > We are [working on templates](https://github.com/fermyon/spin/pull/186)

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "anyhow",
  "wit-parser",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "heck",
  "wit-bindgen-gen-core",
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust-wasm"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "heck",
  "wit-bindgen-gen-core",
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -336,7 +336,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-impl"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -347,7 +347,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/examples/http-rust/src/lib.rs
+++ b/examples/http-rust/src/lib.rs
@@ -11,5 +11,5 @@ fn hello_world(req: Request) -> Result<Response> {
     Ok(http::Response::builder()
         .status(200)
         .header("foo", "bar")
-        .body(Some("Hello, Fermyon".into()))?)
+        .body(Some("Hello, Fermyon!\n".into()))?)
 }

--- a/examples/spin-wagi-http/http-rust/Cargo.lock
+++ b/examples/spin-wagi-http/http-rust/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "anyhow",
  "wit-parser",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "heck",
  "wit-bindgen-gen-core",
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust-wasm"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "heck",
  "wit-bindgen-gen-core",
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -336,7 +336,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-impl"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -347,7 +347,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=e9c7c0a3405845cecd3fe06f3c20ab413302fc73#e9c7c0a3405845cecd3fe06f3c20ab413302fc73"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=2f46ce4cc072107153da0cefe15bdc69aa5b84d0#2f46ce4cc072107153da0cefe15bdc69aa5b84d0"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/examples/spin-wagi-http/http-rust/src/lib.rs
+++ b/examples/spin-wagi-http/http-rust/src/lib.rs
@@ -11,5 +11,5 @@ fn goodbye_world(req: Request) -> Result<Response> {
     Ok(http::Response::builder()
         .status(200)
         .header("foo", "bar")
-        .body(Some("Goodbye".into()))?)
+        .body(Some("Goodbye, Fermyon!\n".into()))?)
 }

--- a/examples/spin-wagi-http/wagi-http-cpp/main.cpp
+++ b/examples/spin-wagi-http/wagi-http-cpp/main.cpp
@@ -1,7 +1,7 @@
 #include<iostream>
 
 int main() {
-    std::cout << "Content-Type: application/text\n\nHello\n" << std::endl;
+    std::cout << "Content-Type: application/text\n\nHello, Fermyon!\n" << std::endl;
     return 0;
 
 }


### PR DESCRIPTION
This standardizes the output of most helloworld examples to match the output in the quickstart: https://spin.fermyon.dev/quickstart/

I also removed a redundant flag in the quickstart as [.cargo/config.toml](https://github.com/fermyon/spin/blob/main/examples/http-rust/.cargo/config.toml) sets this as the default target.