### PR TITLE
Add build info to spin version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env-file-reader"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1242,19 @@ dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -1608,6 +1653,30 @@ name = "libc"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.13.2+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3017,6 +3086,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hyper",
+ "lazy_static",
  "path-absolutize",
  "semver",
  "serde",
@@ -3034,6 +3104,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber 0.3.9",
+ "vergen",
 ]
 
 [[package]]
@@ -3927,6 +3998,22 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db743914c971db162f35bf46601c5a63ec4452e61461937b4c1ab817a60c12e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustversion",
+ "thiserror",
+ "time 0.3.7",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dirs = "4.0"
 dunce = "1.0"
 env_logger = "0.9"
 futures = "0.3"
+lazy_static = "1.4.0"
 path-absolutize = "3.0.11"
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
@@ -37,9 +38,10 @@ hyper = { version = "0.14", features = [ "full" ] }
 
 [build-dependencies]
 cargo-target-dep = { git = "https://github.com/fermyon/cargo-target-dep", rev = "b7b1989fe0984c0f7c4966398304c6538e52fe49" }
+vergen = { version = "7", default-features = false, features = [ "build", "git" ] }
 
 [workspace]
-members = [ 
+members = [
     "crates/config",
     "crates/engine",
     "crates/http",
@@ -49,7 +51,7 @@ members = [
     "crates/templates",
     "crates/testing",
     "examples/spin-timer",
-    "sdk/rust", 
+    "sdk/rust",
     "sdk/rust/macro"
 ]
 

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,11 @@ fn main() {
 
     cargo_build(RUST_HTTP_INTEGRATION_TEST);
     cargo_build(RUST_HTTP_INTEGRATION_ENV_TEST);
+
+    let mut config = vergen::Config::default();
+    *config.git_mut().sha_kind_mut() = vergen::ShaKind::Short;
+    *config.git_mut().commit_timestamp_kind_mut() = vergen::TimestampKind::DateOnly;
+    vergen::vergen(config).expect("failed to extract build information");
 }
 
 fn build_wasm_test_program(name: &'static str, root: &'static str) {

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use lazy_static::lazy_static;
 use spin_cli::commands::{
     bindle::BindleCommands, new::NewCommand, templates::TemplateCommands, up::UpCommand,
 };
@@ -14,11 +15,20 @@ async fn main() -> Result<(), Error> {
     SpinApp::from_args().run().await
 }
 
+lazy_static! {
+    pub static ref VERSION: String = build_info();
+}
+
+/// Helper for passing VERSION to structopt.
+fn version() -> &'static str {
+    &VERSION
+}
+
 /// The Spin CLI
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "spin",
-    version = env!("CARGO_PKG_VERSION"),
+    version = version(),
     global_settings = &[
         AppSettings::VersionlessSubcommands,
         AppSettings::ColoredHelp
@@ -40,4 +50,14 @@ impl SpinApp {
             SpinApp::Bindle(cmd) => cmd.run().await,
         }
     }
+}
+
+/// Returns build information, similar to: 0.1.0 (2be4034 2022-03-31).
+fn build_info() -> String {
+    format!(
+        "{} ({} {})",
+        env!("VERGEN_BUILD_SEMVER"),
+        env!("VERGEN_GIT_SHA_SHORT"),
+        env!("VERGEN_GIT_COMMIT_DATE")
+    )
 }


### PR DESCRIPTION
This patch adds build information (Git SHA and commit date) to
spin version output, similar to: spin 0.1.0 (2be4034 2022-03-31).

Fixes #129.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>