### PR TITLE
fix(spin/http): use URI with query as request URI

### DIFF
--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -94,10 +94,14 @@ impl SpinHttpExecutor {
                 .collect();
 
             let body = Some(&bytes[..]);
+            let uri = match parts.uri.path_and_query() {
+                Some(u) => u.to_string(),
+                None => parts.uri.to_string(),
+            };
 
             let req = crate::spin_http::Request {
                 method,
-                uri: parts.uri.path(),
+                uri: &uri,
                 headers: &headers,
                 params: &params,
                 body,


### PR DESCRIPTION
This commit updates the request URI to contain the query parameters
as well.

This immediately addresses #313 by including including the query 
parameters in the request URI.
However, a more thorough re-assessment of the HTTP data we pass 
into the handler would most likely be a good idea.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>