### PR TITLE
fix(docs): remove the content_encoding config for docs

### DIFF
--- a/docs/config/site.toml
+++ b/docs/config/site.toml
@@ -1,7 +1,6 @@
 title = "Spin Documentation"
 base_url = "http://localhost:3000"
 about = "Spin — a framework for building fast, secure, and composable microservices with WebAssembly"
-content_encoding = "gzip"
 
 [extra]
 copyright = "Fermyon"


### PR DESCRIPTION
Removes the `gzip` config from the `site.toml`, which was breaking the site locally. 

Spin was running, but hitting localhost:3000 the browser couldn't render the site. It was showing a "Content Encoding Error"  that I've never seen before.

Signed-off-by: flynnduism <ronan@fermyon.com>