### PR TITLE
ci(.github): add dispatch workflow

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,35 @@
+name: Dispatch Event
+
+on:
+  push:
+    branches: [main, "v*"]
+    tags: ["v*"]
+
+jobs:
+  changes:
+    name: Detect files changed
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+
+  dispatch:
+    name: Dispatch spin-docs-updated event
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DEST_REPO_ACCESS_TOKEN }}
+          repository: ${{ secrets.DEST_REPO }}
+          event-type: spin-docs-updated
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
- Adds a dispatch.yml GH workflow for detecting file changes and dispatching an event as appropriate
- First use case is to detect doc updates and then dispatch an event to a destination repo (which handles (re-)deploying the docs site)

Tested on fork: https://github.com/vdice/spin/actions/runs/2111223700