### PR TITLE
Mitigate issue #337

### DIFF
--- a/crates/config/src/host_component.rs
+++ b/crates/config/src/host_component.rs
@@ -15,7 +15,10 @@ pub struct ComponentConfig {
 
 impl ComponentConfig {
     pub fn new(component_id: impl Into<String>, resolver: Arc<Resolver>) -> crate::Result<Self> {
-        let component_root = Path::new(component_id)?;
+        let component_root = Path::new(component_id).or_else(|_| {
+            // Temporary mitigation for https://github.com/fermyon/spin/issues/337
+            Path::new("invalid.path.issue_337")
+        })?;
         Ok(Self {
             component_root,
             resolver,


### PR DESCRIPTION
A previous iteration of config design intentionally restricted component
IDs to be valid config keys. That restriction isn't necessary in the
current design but still exists.

This removes the restriction for components that don't use config.

ref #337