### PR TITLE
feat(deploy): add spin deploy command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hippo-openapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccdd4ea8f4de601a7a88363fef1b19dea97c69f13d292aa96872f3220cc92cf2"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,6 +2619,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
@@ -3094,9 +3108,11 @@ dependencies = [
  "dunce",
  "env_logger",
  "futures",
+ "hippo-openapi",
  "hyper",
  "lazy_static",
  "path-absolutize",
+ "reqwest",
  "semver",
  "serde",
  "spin-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ dirs = "4.0"
 dunce = "1.0"
 env_logger = "0.9"
 futures = "0.3"
+hippo-openapi = "0.4"
 lazy_static = "1.4.0"
 path-absolutize = "3.0.11"
+reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 spin-config = { path = "crates/config" }

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -1,7 +1,8 @@
 use anyhow::Error;
 use lazy_static::lazy_static;
 use spin_cli::commands::{
-    bindle::BindleCommands, new::NewCommand, templates::TemplateCommands, up::UpCommand,
+    bindle::BindleCommands, deploy::DeployCommand, new::NewCommand, templates::TemplateCommands,
+    up::UpCommand,
 };
 use structopt::{clap::AppSettings, StructOpt};
 
@@ -38,6 +39,7 @@ enum SpinApp {
     New(NewCommand),
     Up(UpCommand),
     Bindle(BindleCommands),
+    Deploy(DeployCommand),
 }
 
 impl SpinApp {
@@ -48,6 +50,7 @@ impl SpinApp {
             SpinApp::Up(cmd) => cmd.run().await,
             SpinApp::New(cmd) => cmd.run().await,
             SpinApp::Bindle(cmd) => cmd.run().await,
+            SpinApp::Deploy(cmd) => cmd.run().await,
         }
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,8 @@
 
 /// Command for creating bindles.
 pub mod bindle;
+/// Command for deploying a Spin app to Hippo
+pub mod deploy;
 /// Command for creating a new application.
 pub mod new;
 /// Commands for working with templates.

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,0 +1,249 @@
+use anyhow::{Context, Result};
+use bindle::Id;
+use core::panic;
+use hippo_openapi::apis::{
+    account_api::api_account_createtoken_post,
+    app_api::{api_app_post, ApiAppPostError},
+    channel_api::api_channel_post,
+    configuration::{ApiKey, Configuration},
+    revision_api::{api_revision_post, ApiRevisionPostError},
+    Error,
+};
+use hippo_openapi::models::{
+    ChannelRevisionSelectionStrategy, CreateAppCommand, CreateChannelCommand, CreateTokenCommand,
+    RegisterRevisionCommand,
+};
+use reqwest::header;
+use std::path::PathBuf;
+use structopt::{clap::AppSettings, StructOpt};
+
+const APP_CONFIG_FILE_OPT: &str = "APP_CONFIG_FILE";
+const BINDLE_SERVER_URL_OPT: &str = "BINDLE_SERVER_URL";
+const BINDLE_URL_ENV: &str = "BINDLE_URL";
+const HIPPO_SERVER_URL_OPT: &str = "HIPPO_SERVER_URL";
+const HIPPO_URL_ENV: &str = "HIPPO_URL";
+const STAGING_DIR_OPT: &str = "STAGING_DIR";
+const JSON_MIME_TYPE: &str = "application/json";
+
+/// Package and upload Spin artifacts, notifying Hippo
+#[derive(StructOpt, Debug)]
+#[structopt(
+    about = "Deploy a Spin application",
+    global_settings = &[AppSettings::ColoredHelp, AppSettings::ArgRequiredElseHelp]
+)]
+pub struct DeployCommand {
+    /// Path to spin.toml
+    #[structopt(
+        name = APP_CONFIG_FILE_OPT,
+        short = "f",
+        long = "file",
+        default_value = "spin.toml"
+    )]
+    pub app: PathBuf,
+
+    /// URL of bindle server
+    #[structopt(
+        name = BINDLE_SERVER_URL_OPT,
+        long = "bindle-server",
+        env = BINDLE_URL_ENV,
+    )]
+    pub bindle_server_url: String,
+
+    /// URL of hippo server
+    #[structopt(
+        name = HIPPO_SERVER_URL_OPT,
+        long = "hippo-server",
+        env = HIPPO_URL_ENV,
+        default_value = "https://localhost:5309",
+
+    )]
+    pub hippo_server_url: String,
+
+    /// Path to assemble the bindle before pushing (defaults to
+    /// a temporary directory)
+    #[structopt(
+        name = STAGING_DIR_OPT,
+        long = "staging-dir",
+        short = "-d", 
+    )]
+    pub staging_dir: Option<PathBuf>,
+
+    /// Hippo username
+    #[structopt(
+        name = "HIPPO_USERNAME",
+        long = "hippo-username",
+        env = "HIPPO_USERNAME"
+    )]
+    pub hippo_username: String,
+
+    /// Hippo password
+    #[structopt(
+        name = "HIPPO_PASSWORD",
+        long = "hippo-password",
+        env = "HIPPO_PASSWORD"
+    )]
+    pub hippo_password: String,
+}
+
+impl DeployCommand {
+    pub async fn run(self) -> Result<()> {
+        let bindle_id = self
+            .create_and_push_bindle()
+            .await
+            .expect("Unable to create and push bindle from app {}");
+
+        let hippo_client_config = self.create_hippo_client_config().await;
+
+        let app_id = self
+            .create_hippo_app(&hippo_client_config, &bindle_id)
+            .await
+            .expect("Unable to create Hippo App");
+
+        self.create_spin_deploy_channel(&hippo_client_config, app_id.as_ref())
+            .await
+            .expect("Unable to create Hippo Channel");
+
+        self.deploy(&hippo_client_config, &bindle_id).await?;
+        println!("Successfully deployed application! See Traefik dashboard for IP address of app.");
+
+        Ok(())
+    }
+
+    async fn deploy(
+        &self,
+        hippo_client_config: &Configuration,
+        bindle_id: &Id,
+    ) -> Result<(), Error<ApiRevisionPostError>> {
+        api_revision_post(
+            hippo_client_config,
+            Some(RegisterRevisionCommand {
+                app_storage_id: bindle_id.name().to_string(),
+                revision_number: bindle_id.version_string(),
+            }),
+        )
+        .await
+    }
+
+    async fn create_spin_deploy_channel(
+        &self,
+        hippo_client_config: &Configuration,
+        app_id: &str,
+    ) -> Result<String, anyhow::Error> {
+        api_channel_post(
+            hippo_client_config,
+            Some(CreateChannelCommand {
+                app_id: app_id.to_string(),
+                name: "spin-deploy".to_string(),
+                domain: None,
+                revision_selection_strategy: ChannelRevisionSelectionStrategy::_0,
+                range_rule: None,
+                active_revision_id: None,
+                certificate_id: None,
+            }),
+        )
+        .await
+        .map_err(|e| match e {
+            Error::ResponseError(r) => {
+                anyhow::anyhow!("Unable to create Hippo App: {}", r.content)
+            }
+            _ => anyhow::anyhow!("Unable to create hippo app"),
+        })
+    }
+
+    async fn create_and_push_bindle(&self) -> Result<Id> {
+        let source_dir = crate::app_dir(&self.app)?;
+        let client = crate::create_bindle_client(true, &self.bindle_server_url)?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let dest_dir = match &self.staging_dir {
+            None => temp_dir.path(),
+            Some(path) => path.as_path(),
+        };
+        let (invoice, sources) = spin_publish::expand_manifest(&self.app, None, &dest_dir)
+            .await
+            .with_context(|| format!("Failed to expand '{}' to a bindle", self.app.display()))?;
+
+        let bindle_id = &invoice.bindle.id;
+
+        spin_publish::write(&source_dir, &dest_dir, &invoice, &sources)
+            .await
+            .with_context(|| crate::write_failed_msg(bindle_id, dest_dir))?;
+
+        spin_publish::push_all(&dest_dir, bindle_id, &client, &self.bindle_server_url)
+            .await
+            .context("Failed to push bindle to server")?;
+
+        Ok(bindle_id.clone())
+    }
+
+    async fn create_hippo_app(
+        &self,
+        hippo_client_config: &Configuration,
+        bindle_id: &Id,
+    ) -> Result<String, Error<ApiAppPostError>> {
+        let app_name = bindle_id.name().to_string();
+        let bindle_storage_id = bindle_id.name().to_string();
+
+        api_app_post(
+            hippo_client_config,
+            Some(CreateAppCommand {
+                name: app_name.clone(),
+                storage_id: bindle_storage_id.clone(),
+            }),
+        )
+        .await
+    }
+
+    async fn create_hippo_client_config(&self) -> Configuration {
+        let mut hippo_client_config = Configuration {
+            base_path: self.hippo_server_url.clone(),
+            ..Default::default()
+        };
+
+        hippo_client_config.base_path = self.hippo_server_url.clone();
+
+        let mut headers = header::HeaderMap::new();
+        headers.insert(header::ACCEPT, JSON_MIME_TYPE.parse().unwrap());
+        headers.insert(header::CONTENT_TYPE, JSON_MIME_TYPE.parse().unwrap());
+
+        hippo_client_config.client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .default_headers(headers)
+            .build()
+            .unwrap();
+
+        match self.get_hippo_token(&hippo_client_config).await {
+            Ok(t) => {
+                hippo_client_config.api_key = Some(ApiKey {
+                    prefix: Some("Bearer".to_owned()),
+                    key: t,
+                });
+            }
+            Err(e) => panic!("Unable to log into Hippo: {}", e),
+        }
+        hippo_client_config
+    }
+
+    // Do the auth dance
+    // if username/password provided: (1) request token (2) use token to set API_KEY
+    // TODO: if username/password not provided: Check file for token
+    //      (1) If token is not expired, use.
+    //      (2) If token is expired, prompt user for basic auth, request token, use token.
+
+    async fn get_hippo_token(&self, hippo_client_config: &Configuration) -> Result<String> {
+        let token = api_account_createtoken_post(
+            hippo_client_config,
+            Some(CreateTokenCommand {
+                user_name: self.hippo_username.clone(),
+                password: self.hippo_password.clone(),
+            }),
+        )
+        .await?
+        .token;
+
+        match token {
+            Some(t) => Ok(t),
+            None => panic!("Unable to log into Hippo"),
+        }
+    }
+}

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -54,8 +54,6 @@ pub struct DeployCommand {
         name = HIPPO_SERVER_URL_OPT,
         long = "hippo-server",
         env = HIPPO_URL_ENV,
-        default_value = "https://localhost:5309",
-
     )]
     pub hippo_server_url: String,
 
@@ -90,7 +88,7 @@ impl DeployCommand {
         let bindle_id = self
             .create_and_push_bindle()
             .await
-            .expect("Unable to create and push bindle from app {}");
+            .expect("Unable to create and push bindle from Spin app");
 
         let hippo_client_config = self.create_hippo_client_config().await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,53 @@
 pub mod commands;
+
+use anyhow::Context;
+use bindle::client::Client as BindleClient;
+use bindle::client::ClientBuilder as BindleClientBuilder;
+use semver::{BuildMetadata, Error};
+use spin_loader::bindle::BindleTokenManager;
+use std::path::Path;
+
+pub(crate) fn app_dir(app_file: impl AsRef<Path>) -> Result<std::path::PathBuf, anyhow::Error> {
+    let path_buf = app_file
+        .as_ref()
+        .parent()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Failed to get containing directory for app file '{}'",
+                app_file.as_ref().display()
+            )
+        })?
+        .to_owned();
+    Ok(path_buf)
+}
+
+pub(crate) fn write_failed_msg(bindle_id: &bindle::Id, dest_dir: &Path) -> String {
+    format!(
+        "Failed to write bindle '{}' to {}",
+        bindle_id,
+        dest_dir.display()
+    )
+}
+
+pub(crate) fn create_bindle_client(
+    insecure: bool,
+    bindle_server_url: &str,
+) -> Result<BindleClient<BindleTokenManager>, anyhow::Error> {
+    BindleClientBuilder::default()
+        .danger_accept_invalid_certs(insecure)
+        .build(
+            bindle_server_url,
+            // TODO: pick up auth options from the command line
+            BindleTokenManager::NoToken(bindle::client::tokens::NoToken),
+        )
+        .with_context(|| {
+            format!(
+                "Failed to create client for bindle server '{}'",
+                bindle_server_url,
+            )
+        })
+}
+
+pub(crate) fn parse_buildinfo(buildinfo: &str) -> Result<BuildMetadata, Error> {
+    BuildMetadata::new(buildinfo)
+}


### PR DESCRIPTION
This is an MVP for the spin deploy command. Given
a bindle server url, hippo server url, and hippo
username/password, this command will create
(1) and push a bindle containing the app to the bindle server
(2) a Hippo App with the name provided in the Spin.toml
(3) a Hippo channel in the Hippo App called "spin-deploy"
and create a post request to register a revision in Hippo.
If an app with the same name already exists, this command will
return an error. If a channel with the name spin-deploy exists,
this will return an error. These errors will be handled more
gracefully with prompts/helpful error messages in subsequent PRs.

This commit it meant to lay the groundwork for the deploy command
so folks can start playing with it and collect opinions.

To play with this command:
1. Use the[ nomad-local-demo](https://github.com/fermyon/nomad-local-demo) to deploy nomad (+ Consul, Traefik, Vault) and bindle.
2. Clone Hippo and in `Infrastructure/Jobs/NomadJob.cs`, change the driver setting from "exec" to "raw_exec". Remove the artifact stanza so that Nomad uses your local Spin binary. Be sure to set the bindle url env variable given in the `./run_servers.sh` output 
3. Start hippo with the nomad scheduler and bindle url.
```
$ dotnet build
$ dotnet run \
--Scheduler:Driver=nomad \
  --Bindle:Url="${BINDLE_URL}"
```
4. Create a hippo account. Use these creds in the next step
5. Build the wasm module for an example app and then `spin deploy --bindle-server <bindle-url> --hippo-username <username> --hippo-password <password>`
