### PR TITLE
chore(ci): stop cancelling concurrent runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,8 +94,3 @@ jobs:
         env:
           RUST_LOG: spin=trace
 
-    # Cancel in-progress runs for PRs
-    # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
-    concurrency:
-      group: ${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true


### PR DESCRIPTION
https://github.com/fermyon/spin/pull/170 introduced cancelling in-progress
workflow runs for builds, which made sense when we were constrained on build
minutes.

However, this seems to cancel in-progress runs quite often for both in-flight
PRs *and* for builds on `main`, which means that we regularly have to manually
re-run builds for both PRs and on main (when the overall status of the repository
is failed, because a job was cancelled).

This commit removes the "cancel-in-progress" condition for builds.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>
