### PR TITLE
ci(dispatch.yml): only dispatch event if from fermyon/spin

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -9,6 +9,7 @@ jobs:
   changes:
     name: Detect files changed
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'fermyon' }}
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:


### PR DESCRIPTION
Only run the dispatch event workflow if the event originates from this origin repo.  Prevents this action from running on forks.