### PR TITLE
ci(release.yml): update canary release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,10 +163,6 @@ jobs:
     needs: checksums
     if: github.ref == 'refs/heads/main'
     steps:
-      - name: Set the release version
-        shell: bash
-        run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
-
       - name: Download release assets
         uses: actions/download-artifact@v3
         with:
@@ -185,7 +181,7 @@ jobs:
           tag: canary
           allowUpdates: true
           prerelease: true
-          artifacts: "checksums-${{ env.RELEASE_VERSION }}.txt,spin-${{ env.RELEASE_VERSION }}*"
+          artifacts: "checksums-canary.txt,spin-canary*"
           body: |
             This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
             It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
           tag_name: canary
 
       - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.10.0
         with:
           tag: canary
           allowUpdates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,36 +129,6 @@ jobs:
           name: spin
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
 
-      # TODO: actually update/override the canary release each time
-      # See https://github.com/fermyon/spin/issues/128
-      - name: upload binary to canary GitHub release
-        uses: svenstaro/upload-release-action@2.2.1
-        if: github.ref == 'refs/heads/main' && runner.os != 'Windows'
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-          asset_name: spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-          tag: canary
-          overwrite: true
-          prerelease: true
-          body: |
-            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
-            It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.
-
-      - name: upload binary to canary GitHub release
-        uses: svenstaro/upload-release-action@2.2.1
-        if: github.ref == 'refs/heads/main' && runner.os == 'Windows'
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
-          asset_name: spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
-          tag: canary
-          overwrite: true
-          prerelease: true
-          body: |
-            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
-            It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.
-
   checksums:
     name: generate release checksums
     runs-on: ubuntu-latest
@@ -187,16 +157,35 @@ jobs:
           name: spin
           path: checksums-${{ env.RELEASE_VERSION }}.txt
 
-      - name: upload checksums to canary GitHub release
-        uses: svenstaro/upload-release-action@2.2.1
-        if: github.ref == 'refs/heads/main'
+  update-canary:
+    name: update canary release
+    runs-on: ubuntu-latest
+    needs: checksums
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Set the release version
+        shell: bash
+        run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+      - name: Download release assets
+        uses: actions/download-artifact@v3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: checksums-${{ env.RELEASE_VERSION }}.txt
-          asset_name: checksums-${{ env.RELEASE_VERSION }}.txt
+          name: spin
+
+      - name: Delete canary tag
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: canary
+
+      - name: Recreate canary tag and release
+        uses: ncipollo/release-action@v1
+        with:
           tag: canary
-          overwrite: true
+          allowUpdates: true
           prerelease: true
+          artifacts: "checksums-${{ env.RELEASE_VERSION }}.txt,spin-${{ env.RELEASE_VERSION }}*"
           body: |
             This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
             It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.


### PR DESCRIPTION
- updates release.yml to recreate the canary release on each merge to main

We delete and recreate was we wish for the commit to be up-to-date for the canary tag/release.

Tested on fork, e.g. https://github.com/vdice/spin/actions/runs/2174271817 and https://github.com/vdice/spin/releases/tag/canary

Closes https://github.com/fermyon/spin/issues/128