### PR TITLE
Add additional languages and toolchains

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,28 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 ARG BINDLE_URL="https://github.com/deislabs/bindle/releases/download/v0.8.0/bindle-v0.8.0-linux-amd64.tar.gz"
 RUN curl -sL "$BINDLE_URL" | tar -xzf - -C /usr/local/bin bindle bindle-server
+
+# Go installation, see https://go.dev/doc/install
+ARG GO_URL="https://go.dev/dl/go1.18.1.linux-amd64.tar.gz"
+RUN curl -sL "$GO_URL" | tar -xzf - -C /usr/local
+ENV PATH "$PATH:/usr/local/go/bin"
+
+# TinyGo installation, see https://tinygo.org/getting-started/install/linux/ for instructions
+ARG TINYGO_URL="https://github.com/tinygo-org/tinygo/releases/download/v0.22.0/tinygo_0.22.0_amd64.deb"
+RUN curl -sL "$TINYGO_URL" -o tinygo_amd64.deb && dpkg -i tinygo_amd64.deb && rm tinygo_amd64.deb
+
+# Install the gopls Go Language Server, see https://github.com/golang/tools/tree/master/gopls
+RUN go install golang.org/x/tools/gopls@latest
+
+# Install additional rust components (rust-analyzer)
+ARG RUST_ANALYZER_URL="https://github.com/rust-lang/rust-analyzer/releases/download/2022-04-11/rust-analyzer-x86_64-unknown-linux-gnu.gz"
+RUN curl -sL "$RUST_ANALYZER_URL" | gunzip -c - > /usr/local/bin/rust-analyzer && chmod +x /usr/local/bin/rust-analyzer
+
+# Install Grain, see https://grain-lang.org/docs/getting_grain
+ARG GRAIN_URL="https://github.com/grain-lang/grain/releases/download/grain-v0.4.7/grain-linux-x64"
+RUN curl -sL "$GRAIN_URL" -o /usr/local/bin/grain && chmod +x /usr/local/bin/grain
+
+# Install AssemblyScript (Node.js dependency), see https://www.assemblyscript.org/getting-started.html
+ARG NODEJS_URL="https://nodejs.org/dist/v17.9.0/node-v17.9.0-linux-x64.tar.xz"
+RUN curl -sL "$NODEJS_URL" | tar -xJf - -C /usr/local --strip-components=1 --no-same-owner
+RUN npm install -g assemblyscript

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,10 @@
     "matklad.rust-analyzer",
     "tamasfe.even-better-toml",
     "serayuzgur.crates",
-    "fermyon.autobindle"
+    "fermyon.autobindle",
+    "golang.Go",
+    "grain-lang.vscode-grain",
+    "saulecabrera.asls"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
This PR adds a couple of languages and toolchains that support WebAssembly. See https://github.com/fermyon/spin/issues/198.

- [x] Go
- [x] Go Language Server (`gopls`)
- [x] TinyGo
- [x] rust-analyzer
- [x] Grain
- [x] AssemblyScript