### PR TITLE
Validate component IDs are unique

### DIFF
--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -139,3 +139,25 @@ fn test_wagi_executor_with_custom_entrypoint() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_duplicate_component_id_is_rejected() -> Result<()> {
+    const MANIFEST: &str = "tests/invalid-manifest-duplicate-id.toml";
+
+    let temp_dir = tempfile::tempdir()?;
+    let dir = temp_dir.path();
+    let app = from_file(MANIFEST, dir).await;
+
+    assert!(
+        app.is_err(),
+        "Expected component IDs to be unique, but there were duplicates"
+    );
+
+    let e = app.unwrap_err().to_string();
+    assert!(
+        e.contains("hello"),
+        "Expected error to contain duplicate component ID `hello`"
+    );
+
+    Ok(())
+}

--- a/crates/loader/tests/invalid-manifest-duplicate-id.toml
+++ b/crates/loader/tests/invalid-manifest-duplicate-id.toml
@@ -1,0 +1,16 @@
+spin_version = "1"
+name = "spin-hello-world-duplicate"
+version = "1.0.0"
+trigger = { type = "http", base = "/" }
+
+[[component]]
+id = "hello"
+source = "path/to/wasm/file.wasm"
+[component.trigger]
+route = "/hello"
+
+[[component]]
+id = "hello"
+source = "path/to/wasm/file.wasm"
+[component.trigger]
+route = "/hello"


### PR DESCRIPTION
The `spin.toml` configuration file currently loads without error when multiple components use the same `id`. This PR adds a uniqueness constraint in the `loader` crate which will fail to load a configuration file with multiple defined components sharing an identifier.

See https://github.com/fermyon/spin/issues/340 for more details.