### PR TITLE
fix(http): Make spin http headers optional

### DIFF
--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -113,6 +113,13 @@ impl SpinHttpExecutor {
         })
         .await??;
 
+        if res.status < 100 || res.status > 600 {
+            log::error!("malformed HTTP status code");
+            return Ok(Response::builder()
+                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())?);
+        };
+
         let mut response = http::Response::builder().status(res.status);
         if let Some(headers) = response.headers_mut() {
             Self::append_headers(headers, res.headers)?;

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -114,7 +114,9 @@ impl SpinHttpExecutor {
         .await??;
 
         let mut response = http::Response::builder().status(res.status);
-        Self::append_headers(response.headers_mut().unwrap(), res.headers)?;
+        if let Some(headers) = response.headers_mut() {
+            Self::append_headers(headers, res.headers)?;
+        }
 
         let body = match res.body {
             Some(b) => Body::from(b),


### PR DESCRIPTION
Spin http response headers are optional in the wit files.

https://github.com/fermyon/spin/blob/14603bb71f9592fbfe3d10f5deb961fddb89f58c/wit/ephemeral/http-types.wit#L47