### PR TITLE
Add execution context as a parameter to trigger constructor

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -39,7 +39,7 @@ impl From<Application<CoreComponent>> for ExecutionContextConfiguration {
         Self {
             components: app.components,
             label: app.info.name,
-            config_resolver: app.config_resolver.map(Arc::new),
+            config_resolver: app.config_resolver,
             ..Default::default()
         }
     }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -4,7 +4,6 @@ mod routes;
 mod spin;
 mod tls;
 mod wagi;
-use futures::Future;
 pub use tls::TlsConfig;
 
 use crate::{

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -23,7 +23,7 @@ use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, CoreComponent, ModuleSource,
     SpinVersion, WasmConfig,
 };
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 use tracing::log;
 pub use utils::{BindleTokenManager, SPIN_MANIFEST_MEDIA_TYPE};
 
@@ -72,7 +72,7 @@ async fn prepare(
             config_root.merge_defaults(&path, config)?;
         }
     }
-    let config_resolver = Some(spin_config::Resolver::new(config_root)?);
+    let config_resolver = Some(Arc::new(spin_config::Resolver::new(config_root)?));
 
     let info = info(&raw, &invoice, url);
     log::trace!("Application information from bindle: {:?}", info);

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -18,7 +18,7 @@ use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, CoreComponent, ModuleSource,
     SpinVersion, WasmConfig,
 };
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 use tokio::{fs::File, io::AsyncReadExt};
 
 /// Given the path to a spin.toml manifest file, prepare its assets locally and
@@ -80,7 +80,7 @@ async fn prepare(
             config_root.merge_defaults(&path, config)?;
         }
     }
-    let config_resolver = Some(spin_config::Resolver::new(config_root)?);
+    let config_resolver = Some(Arc::new(spin_config::Resolver::new(config_root)?));
 
     let component_triggers = raw
         .components

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -8,10 +8,11 @@ use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
     path::PathBuf,
+    sync::Arc,
 };
 
 /// Application configuration.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Application<T> {
     /// General application information.
     pub info: ApplicationInformation,
@@ -20,7 +21,7 @@ pub struct Application<T> {
     /// Configuration for the components' triggers.
     pub component_triggers: ComponentMap<TriggerConfig>,
     /// Application-specific configuration resolver.
-    pub config_resolver: Option<Resolver>,
+    pub config_resolver: Option<Arc<Resolver>>,
 }
 
 /// Spin API version.

--- a/crates/redis/src/tests.rs
+++ b/crates/redis/src/tests.rs
@@ -28,7 +28,7 @@ async fn test_pubsub() -> Result<()> {
         })
         .build_application();
 
-    let trigger = RedisTrigger::new(cfg, None).await?;
+    let trigger = RedisTrigger::new(cfg, None, None).await?;
 
     // TODO
     // use redis::{FromRedisValue, Msg, Value};

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -96,7 +96,7 @@ impl TestConfig {
     }
 
     pub async fn build_http_trigger(&self) -> HttpTrigger {
-        HttpTrigger::new("".to_string(), self.build_application(), None, None)
+        HttpTrigger::new("".to_string(), self.build_application(), None, None, None)
             .await
             .expect("failed to build HttpTrigger")
     }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
-use spin_http_engine::{HttpTrigger, TlsConfig};
+use spin_engine::{Builder, ExecutionContext, ExecutionContextConfiguration};
+use spin_http_engine::{spin_http::SpinHttpData, HttpTrigger, TlsConfig};
 use spin_manifest::{Application, ApplicationTrigger, CoreComponent};
 use spin_redis_engine::RedisTrigger;
 use std::path::{Path, PathBuf};
@@ -111,10 +112,10 @@ impl UpCommand {
         };
         append_env(&mut app, &self.env)?;
 
-        if let Some(ref mut resolver) = app.config_resolver {
-            // TODO(lann): Make config provider(s) configurable.
-            resolver.add_provider(spin_config::provider::env::EnvProvider::default());
-        }
+        // if let Some(ref mut resolver) = app.config_resolver {
+        //     // TODO(lann): Make config provider(s) configurable.
+        //     resolver.add_provider(spin_config::provider::env::EnvProvider::default());
+        // }
 
         let tls = match (self.tls_key, self.tls_cert) {
             (Some(key_path), Some(cert_path)) => {
@@ -139,7 +140,7 @@ impl UpCommand {
                 trigger.run().await?;
             }
             ApplicationTrigger::Redis(_) => {
-                let trigger = RedisTrigger::new(app, self.log).await?;
+                let trigger = RedisTrigger::new(app, self.log, None).await?;
                 trigger.run().await?;
             }
         }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -135,7 +135,7 @@ impl UpCommand {
 
         match &app.info.trigger {
             ApplicationTrigger::Http(_) => {
-                let trigger = HttpTrigger::new(self.address, app, tls, self.log).await?;
+                let trigger = HttpTrigger::new(self.address, app, tls, self.log, None).await?;
                 trigger.run().await?;
             }
             ApplicationTrigger::Redis(_) => {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Result};
-use spin_engine::{Builder, ExecutionContext, ExecutionContextConfiguration};
-use spin_http_engine::{spin_http::SpinHttpData, HttpTrigger, TlsConfig};
+use spin_http_engine::{HttpTrigger, TlsConfig};
 use spin_manifest::{Application, ApplicationTrigger, CoreComponent};
 use spin_redis_engine::RedisTrigger;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This PR fixes the issue #376 

1. Makes `Application` clonable
2. Adds a new parameter `execution_context` to triggers so that users can customize different wasmtime configurations. 

@radu-matei 