### PR TITLE
Add support for "host components"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,6 +2145,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "redis",
+ "spin-engine",
+ "spin-manifest",
  "wit-bindgen-wasmtime",
 ]
 
@@ -3096,6 +3098,7 @@ dependencies = [
  "futures",
  "hyper",
  "lazy_static",
+ "outbound-redis",
  "path-absolutize",
  "semver",
  "serde",
@@ -3135,7 +3138,6 @@ dependencies = [
  "anyhow",
  "bytes 1.1.0",
  "dirs 4.0.0",
- "outbound-redis",
  "sanitize-filename",
  "spin-config",
  "spin-manifest",
@@ -3251,6 +3253,8 @@ dependencies = [
  "async-trait",
  "cap-std",
  "serde",
+ "spin-engine",
+ "spin-manifest",
  "tracing",
  "wasmtime",
  "wit-bindgen-wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ dunce = "1.0"
 env_logger = "0.9"
 futures = "0.3"
 lazy_static = "1.4.0"
+outbound-redis = { path = "crates/outbound-redis" }
 path-absolutize = "3.0.11"
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 anyhow = "1.0.44"
 bytes = "1.1.0"
 dirs = "4.0"
-outbound-redis = { path = "../outbound-redis" }
 sanitize-filename = "0.3.0"
 spin-config = { path = "../config" }
 spin-manifest = { path = "../manifest" }

--- a/crates/engine/src/host_component.rs
+++ b/crates/engine/src/host_component.rs
@@ -1,0 +1,89 @@
+use std::{any::Any, marker::PhantomData};
+
+use spin_manifest::CoreComponent;
+use wasmtime::Linker;
+
+use crate::RuntimeContext;
+
+/// Represents a host implementation of a Wasm interface.
+pub trait HostComponent: Send + Sync {
+    /// Host component runtime state.
+    type Data: Any + Send;
+
+    /// Add this component to the given Linker, using the given runtime state-getting closure.
+    fn add_to_linker<T>(
+        linker: &mut Linker<RuntimeContext<T>>,
+        data_handle: HostComponentsDataHandle<Self::Data>,
+    ) -> anyhow::Result<()>;
+
+    /// Build a new runtime state object for the given component.
+    fn build_data(&self, component: &CoreComponent) -> anyhow::Result<Self::Data>;
+}
+type HostComponentData = Box<dyn Any + Send>;
+
+type DataBuilder = Box<dyn Fn(&CoreComponent) -> anyhow::Result<HostComponentData> + Send + Sync>;
+
+#[derive(Default)]
+pub(crate) struct HostComponents {
+    data_builders: Vec<DataBuilder>,
+}
+
+impl HostComponents {
+    pub(crate) fn insert<'a, T: 'static, Component: HostComponent + 'static>(
+        &mut self,
+        linker: &'a mut Linker<RuntimeContext<T>>,
+        host_component: Component,
+    ) -> anyhow::Result<()> {
+        let handle = HostComponentsDataHandle {
+            idx: self.data_builders.len(),
+            _phantom: PhantomData,
+        };
+        Component::add_to_linker(linker, handle)?;
+        self.data_builders.push(Box::new(move |c| {
+            Ok(Box::new(host_component.build_data(c)?))
+        }));
+        Ok(())
+    }
+
+    pub(crate) fn build_data(&self, c: &CoreComponent) -> anyhow::Result<HostComponentsData> {
+        Ok(HostComponentsData(
+            self.data_builders
+                .iter()
+                .map(|build_data| build_data(c))
+                .collect::<anyhow::Result<_>>()?,
+        ))
+    }
+}
+
+/// A collection of host component data.
+#[derive(Default)]
+pub struct HostComponentsData(Vec<HostComponentData>);
+
+/// A handle to component data, used in HostComponent::add_to_linker.
+pub struct HostComponentsDataHandle<T> {
+    idx: usize,
+    _phantom: PhantomData<fn(T) -> T>,
+}
+
+impl<T: 'static> HostComponentsDataHandle<T> {
+    /// Get the component data associated with this handle from the RuntimeContext.
+    pub fn get_mut<'a, U>(&self, ctx: &'a mut RuntimeContext<U>) -> &'a mut T {
+        ctx.host_components_data
+            .0
+            .get_mut(self.idx)
+            .unwrap()
+            .downcast_mut()
+            .unwrap()
+    }
+}
+
+impl<T> Clone for HostComponentsDataHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            idx: self.idx,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Copy for HostComponentsDataHandle<T> {}

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -62,7 +62,7 @@ pub struct HttpTrigger {
 impl HttpTrigger {
     /// Creates a new Spin HTTP trigger.
     pub async fn new(
-        mut builder: Builder<SpinHttpData>,
+        builder: Builder<SpinHttpData>,
         app: Application<CoreComponent>,
         address: String,
         tls: Option<TlsConfig>,

--- a/crates/object-store/Cargo.toml
+++ b/crates/object-store/Cargo.toml
@@ -12,6 +12,8 @@ anyhow = "1.0"
 async-trait = "0.1"
 cap-std = "0.24.1"
 serde = { version = "1.0", features = ["derive"] }
+spin-engine = { path = "../engine" }
+spin-manifest = { path = "../manifest" }
 tracing = { version = "0.1", features = ["log"] }
 wasmtime = "0.34"
 wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -9,4 +9,6 @@ doctest = false
 [dependencies]
 anyhow = "1.0"
 redis = { version = "0.21", features = [ "tokio-comp" ] }
+spin-engine = { path = "../engine" }
+spin-manifest = { path = "../manifest" }
 wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -2,12 +2,28 @@ use outbound_redis::*;
 use redis::Commands;
 
 pub use outbound_redis::add_to_linker;
+use spin_engine::host_component::HostComponent;
 
 wit_bindgen_wasmtime::export!("../../wit/ephemeral/outbound-redis.wit");
 
 /// A simple implementation to support outbound Redis commands.
 #[derive(Default, Clone)]
 pub struct OutboundRedis;
+
+impl HostComponent for OutboundRedis {
+    type Data = Self;
+
+    fn add_to_linker<T>(
+        linker: &mut wit_bindgen_wasmtime::wasmtime::Linker<spin_engine::RuntimeContext<T>>,
+        data_handle: spin_engine::host_component::HostComponentsDataHandle<Self::Data>,
+    ) -> anyhow::Result<()> {
+        add_to_linker(linker, move |ctx| data_handle.get_mut(ctx))
+    }
+
+    fn build_data(&self, _component: &spin_manifest::CoreComponent) -> anyhow::Result<Self::Data> {
+        Ok(Self)
+    }
+}
 
 impl outbound_redis::OutboundRedis for OutboundRedis {
     fn publish(&mut self, address: &str, channel: &str, payload: &[u8]) -> Result<(), Error> {

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -35,7 +35,7 @@ pub struct RedisTrigger {
 impl RedisTrigger {
     /// Create a new Spin Redis trigger.
     pub async fn new(
-        mut builder: Builder<SpinRedisData>,
+        builder: Builder<SpinRedisData>,
         app: Application<CoreComponent>,
     ) -> Result<Self> {
         let trigger_config = app

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -96,7 +96,10 @@ impl TestConfig {
         }
     }
 
-    pub async fn prepare_builder<T: Default>(&self, app: Application<CoreComponent>) -> Builder<T> {
+    pub async fn prepare_builder<T: Default + 'static>(
+        &self,
+        app: Application<CoreComponent>,
+    ) -> Builder<T> {
         let mut builder = Builder::new(app.into()).expect("Builder::new failed");
         builder.link_defaults().expect("link_defaults failed");
         builder

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -160,7 +160,7 @@ impl UpCommand {
         Ok(())
     }
 
-    async fn prepare_ctx_builder<T: Default>(
+    async fn prepare_ctx_builder<T: Default + 'static>(
         &self,
         app: Application<CoreComponent>,
     ) -> Result<Builder<T>> {
@@ -170,6 +170,7 @@ impl UpCommand {
         };
         let mut builder = Builder::new(config)?;
         builder.link_defaults()?;
+        builder.add_host_component(outbound_redis::OutboundRedis)?;
         Ok(builder)
     }
 }


### PR DESCRIPTION
Host components are a way to add host implementations of component
interfaces with a dependency injection pattern. Host components
implement the HostComponent trait which defines how the host
implementation is linked and how the component's state is constructed.

Fixes #311