### PR TITLE
Refactor ExecutionContext init out of triggers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
  "anyhow",
  "http 0.2.6",
  "hyper",
+ "spin-engine",
  "spin-http-engine",
  "spin-manifest",
 ]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -39,7 +39,7 @@ impl From<Application<CoreComponent>> for ExecutionContextConfiguration {
         Self {
             components: app.components,
             label: app.info.name,
-            config_resolver: app.config_resolver.map(Arc::new),
+            config_resolver: app.config_resolver,
             ..Default::default()
         }
     }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -139,6 +139,7 @@ impl<T: Default> Builder<T> {
     /// Builds a new instance of the execution context.
     #[instrument(skip(self))]
     pub async fn build(&mut self) -> Result<ExecutionContext<T>> {
+        let _sloth_warning = warn_if_slothful();
         let mut components = HashMap::new();
         for c in &self.config.components {
             let core = c.clone();
@@ -186,18 +187,16 @@ impl<T: Default> Builder<T> {
         })
     }
 
+    /// Configures default host interface implementations.
+    pub fn link_defaults(&mut self) -> Result<&mut Self> {
+        self.link_wasi()?.link_http()?.link_config()
+    }
+
     /// Builds a new default instance of the execution context.
     pub async fn build_default(
         config: ExecutionContextConfiguration,
     ) -> Result<ExecutionContext<T>> {
-        let _sloth_warning = warn_if_slothful();
-        Self::new(config)?
-            .link_wasi()?
-            .link_http()?
-            .link_config()?
-            .link_redis()?
-            .build()
-            .await
+        Self::new(config)?.link_defaults()?.build().await
     }
 }
 

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -23,7 +23,7 @@ use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, CoreComponent, ModuleSource,
     SpinVersion, WasmConfig,
 };
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 use tracing::log;
 pub use utils::{BindleTokenManager, SPIN_MANIFEST_MEDIA_TYPE};
 
@@ -72,7 +72,7 @@ async fn prepare(
             config_root.merge_defaults(&path, config)?;
         }
     }
-    let config_resolver = Some(spin_config::Resolver::new(config_root)?);
+    let config_resolver = Some(Arc::new(spin_config::Resolver::new(config_root)?));
 
     let info = info(&raw, &invoice, url);
     log::trace!("Application information from bindle: {:?}", info);

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -18,7 +18,7 @@ use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, CoreComponent, ModuleSource,
     SpinVersion, WasmConfig,
 };
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 use tokio::{fs::File, io::AsyncReadExt};
 
 /// Given the path to a spin.toml manifest file, prepare its assets locally and
@@ -80,7 +80,7 @@ async fn prepare(
             config_root.merge_defaults(&path, config)?;
         }
     }
-    let config_resolver = Some(spin_config::Resolver::new(config_root)?);
+    let config_resolver = Some(Arc::new(spin_config::Resolver::new(config_root)?));
 
     let component_triggers = raw
         .components

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -8,10 +8,11 @@ use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
     path::PathBuf,
+    sync::Arc,
 };
 
 /// Application configuration.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Application<T> {
     /// General application information.
     pub info: ApplicationInformation,
@@ -20,7 +21,7 @@ pub struct Application<T> {
     /// Configuration for the components' triggers.
     pub component_triggers: ComponentMap<TriggerConfig>,
     /// Application-specific configuration resolver.
-    pub config_resolver: Option<Resolver>,
+    pub config_resolver: Option<Arc<Resolver>>,
 }
 
 /// Spin API version.

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::StreamExt;
 use redis::{Client, ConnectionLike};
+use spin_engine::Builder;
 use spin_manifest::{
     Application, ComponentMap, CoreComponent, RedisConfig, RedisTriggerConfiguration,
 };
@@ -33,7 +34,10 @@ pub struct RedisTrigger {
 
 impl RedisTrigger {
     /// Create a new Spin Redis trigger.
-    pub async fn new(engine: ExecutionContext, app: Application<CoreComponent>) -> Result<Self> {
+    pub async fn new(
+        mut builder: Builder<SpinRedisData>,
+        app: Application<CoreComponent>,
+    ) -> Result<Self> {
         let trigger_config = app
             .info
             .trigger
@@ -55,7 +59,7 @@ impl RedisTrigger {
             .filter_map(|(idx, c)| component_triggers.get(c).map(|c| (c.channel.clone(), idx)))
             .collect();
 
-        let engine = Arc::new(engine);
+        let engine = Arc::new(builder.build().await?);
 
         log::trace!("Created new Redis trigger.");
 

--- a/crates/redis/src/tests.rs
+++ b/crates/redis/src/tests.rs
@@ -27,7 +27,7 @@ async fn test_pubsub() -> Result<()> {
             executor: Some(RedisExecutor::Spin),
         });
     let app = cfg.build_application();
-    let engine = cfg.build_execution_context(app.clone()).await;
+    let engine = cfg.prepare_builder(app.clone()).await;
 
     let trigger = RedisTrigger::new(engine, app).await?;
 

--- a/crates/redis/src/tests.rs
+++ b/crates/redis/src/tests.rs
@@ -20,15 +20,16 @@ pub(crate) fn init() {
 async fn test_pubsub() -> Result<()> {
     init();
 
-    let cfg = TestConfig::default()
-        .test_program("redis-rust.wasm")
+    let mut cfg = TestConfig::default();
+    cfg.test_program("redis-rust.wasm")
         .redis_trigger(RedisConfig {
             channel: "messages".to_string(),
             executor: Some(RedisExecutor::Spin),
-        })
-        .build_application();
+        });
+    let app = cfg.build_application();
+    let engine = cfg.build_execution_context(app.clone()).await;
 
-    let trigger = RedisTrigger::new(cfg, None).await?;
+    let trigger = RedisTrigger::new(engine, app).await?;
 
     // TODO
     // use redis::{FromRedisValue, Msg, Value};

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -8,5 +8,6 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 anyhow = "1.0"
 http = "0.2"
 hyper = "0.14"
+spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
 spin-http-engine = { path = "../http" }

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 
 use http::{Request, Response};
 use hyper::Body;
+use spin_engine::{Builder, ExecutionContext};
 use spin_http_engine::HttpTrigger;
 use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, ApplicationTrigger, CoreComponent,
@@ -95,8 +96,17 @@ impl TestConfig {
         }
     }
 
+    pub async fn build_execution_context<T: Default>(
+        &self,
+        app: Application<CoreComponent>,
+    ) -> ExecutionContext<T> {
+        Builder::build_default(app.into()).await.expect("foo")
+    }
+
     pub async fn build_http_trigger(&self) -> HttpTrigger {
-        HttpTrigger::new("".to_string(), self.build_application(), None, None)
+        let app = self.build_application();
+        let engine = self.build_execution_context(app.clone()).await;
+        HttpTrigger::new(engine, app, "".to_string(), None)
             .await
             .expect("failed to build HttpTrigger")
     }

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 
 use http::{Request, Response};
 use hyper::Body;
-use spin_engine::{Builder, ExecutionContext};
+use spin_engine::Builder;
 use spin_http_engine::HttpTrigger;
 use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, ApplicationTrigger, CoreComponent,
@@ -96,17 +96,16 @@ impl TestConfig {
         }
     }
 
-    pub async fn build_execution_context<T: Default>(
-        &self,
-        app: Application<CoreComponent>,
-    ) -> ExecutionContext<T> {
-        Builder::build_default(app.into()).await.expect("foo")
+    pub async fn prepare_builder<T: Default>(&self, app: Application<CoreComponent>) -> Builder<T> {
+        let mut builder = Builder::new(app.into()).expect("Builder::new failed");
+        builder.link_defaults().expect("link_defaults failed");
+        builder
     }
 
     pub async fn build_http_trigger(&self) -> HttpTrigger {
         let app = self.build_application();
-        let engine = self.build_execution_context(app.clone()).await;
-        HttpTrigger::new(engine, app, "".to_string(), None)
+        let builder = self.prepare_builder(app.clone()).await;
+        HttpTrigger::new(builder, app, "".to_string(), None)
             .await
             .expect("failed to build HttpTrigger")
     }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -1,8 +1,12 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use spin_engine::{Builder, ExecutionContext, ExecutionContextConfiguration};
 use spin_http_engine::{HttpTrigger, TlsConfig};
 use spin_manifest::{Application, ApplicationTrigger, CoreComponent};
 use spin_redis_engine::RedisTrigger;
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use structopt::{clap::AppSettings, StructOpt};
 use tempfile::TempDir;
 
@@ -112,11 +116,14 @@ impl UpCommand {
         append_env(&mut app, &self.env)?;
 
         if let Some(ref mut resolver) = app.config_resolver {
+            // TODO(lann): This should be safe but ideally this get_mut would be refactored away.
+            let resolver = Arc::get_mut(resolver)
+                .context("Internal error: app.config_resolver unexpectedly shared")?;
             // TODO(lann): Make config provider(s) configurable.
             resolver.add_provider(spin_config::provider::env::EnvProvider::default());
         }
 
-        let tls = match (self.tls_key, self.tls_cert) {
+        let tls = match (self.tls_key.clone(), self.tls_cert.clone()) {
             (Some(key_path), Some(cert_path)) => {
                 if !cert_path.is_file() {
                     bail!("TLS certificate file does not exist or is not a file")
@@ -135,11 +142,13 @@ impl UpCommand {
 
         match &app.info.trigger {
             ApplicationTrigger::Http(_) => {
-                let trigger = HttpTrigger::new(self.address, app, tls, self.log).await?;
+                let engine = self.build_execution_context(app.clone()).await?;
+                let trigger = HttpTrigger::new(engine, app, self.address, tls).await?;
                 trigger.run().await?;
             }
             ApplicationTrigger::Redis(_) => {
-                let trigger = RedisTrigger::new(app, self.log).await?;
+                let engine = self.build_execution_context(app.clone()).await?;
+                let trigger = RedisTrigger::new(engine, app).await?;
                 trigger.run().await?;
             }
         }
@@ -149,6 +158,17 @@ impl UpCommand {
         drop(working_dir_holder);
 
         Ok(())
+    }
+
+    async fn build_execution_context<T: Default>(
+        &self,
+        app: Application<CoreComponent>,
+    ) -> Result<ExecutionContext<T>> {
+        let config = ExecutionContextConfiguration {
+            log_dir: self.log.clone(),
+            ..app.into()
+        };
+        Builder::build_default(config).await
     }
 }
 


### PR DESCRIPTION
Move the ExecutionContext construction out of HttpTrigger/RedisTrigger
and into the `spin up` handler. This helps deduplicate this
initialization and allows custom trigger executors to customize the
ExecutionContext.

Make Application clone-able (again) by wrapping config_resolver in Arc.

Fixes #376
