### PR TITLE
chore(tinygo): Add -no-debug build flag in examples

### DIFF
--- a/docs/content/go-components.md
+++ b/docs/content/go-components.md
@@ -93,7 +93,7 @@ func main() {
 The component can be built using the `tingygo` toolchain:
 
 ```bash
-$ tinygo build -wasm-abi=generic -target=wasi -o main.wasm main.go
+$ tinygo build -wasm-abi=generic -target=wasi -no-debug -o main.wasm main.go
 ```
 
 Before we can execute this component, we need to add the

--- a/examples/http-tinygo-outbound-http/Makefile
+++ b/examples/http-tinygo-outbound-http/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -no-debug -o main.wasm main.go
 
 . PHONY: serve
 serve:

--- a/examples/http-tinygo-outbound-http/readme.md
+++ b/examples/http-tinygo-outbound-http/readme.md
@@ -25,7 +25,7 @@ Building this as a WebAssembly module can be done using the `tinygo` compiler:
 
 ```shell
 $ make build
-tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+tinygo build -wasm-abi=generic -target=wasi -gc=leaking -no-debug -o main.wasm main.go
 ```
 
 The component configuration must contain a list of all hosts allowed to send

--- a/examples/http-tinygo/Makefile
+++ b/examples/http-tinygo/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -no-debug -o main.wasm main.go
 
 .PHONY: serve
 serve:

--- a/examples/http-tinygo/readme.md
+++ b/examples/http-tinygo/readme.md
@@ -28,7 +28,7 @@ Building this as a WebAssembly module can be done using the `tinygo` compiler:
 
 ```shell
 $ make build
-tinygo build -wasm-abi=generic -target=wasi -o main.wasm main.go
+tinygo build -wasm-abi=generic -target=wasi -no-debug -o main.wasm main.go
 ```
 
 Finally, we can create a Spin application configuration to execute this

--- a/examples/tinygo-outbound-redis/Makefile
+++ b/examples/tinygo-outbound-redis/Makefile
@@ -5,7 +5,7 @@ export GOROOT = $(shell $(GO) env GOROOT)
 
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -no-debug -o main.wasm main.go
 
 .PHONY: serve
 serve:

--- a/examples/tinygo-redis/Makefile
+++ b/examples/tinygo-redis/Makefile
@@ -5,7 +5,7 @@ export GOROOT = $(shell $(GO) env GOROOT)
 
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -no-debug -o main.wasm main.go
 
 .PHONY: serve
 serve:


### PR DESCRIPTION
Adding the --no-debug build flag reduces the wasm binary file size
significantly.

For example building examples/http-tinygo before was 764K.  Now it's
reduced to 221K.