### PR TITLE
feat: print available routes at startup of spin up

### DIFF
--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -217,6 +217,11 @@ impl HttpTrigger {
         println!("Serving HTTP on address http://{:?}", addr);
         log::info!("Serving HTTP on address {:?}", addr);
 
+        println!("Available Routes:");
+        for (route, _) in &self.router.routes {
+            println!("  http://{:?}{}", addr, route);
+        }
+
         let shutdown_signal = on_ctrl_c()?;
 
         tokio::select! {

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Result};
 use http::Uri;
 use indexmap::IndexMap;
 use spin_manifest::{Application, CoreComponent};
-use std::fmt::Debug;
+use std::fmt;
 use tracing::log;
 
 // TODO
@@ -61,7 +61,7 @@ impl Router {
     /// if no component matches.
     /// If there are multiple possible components registered for the same route or
     /// wildcard, this returns the last one in the components vector.
-    pub(crate) fn route<S: Into<String> + Debug>(&self, p: S) -> Result<CoreComponent> {
+    pub(crate) fn route<S: Into<String> + fmt::Debug>(&self, p: S) -> Result<CoreComponent> {
         let p = p.into();
 
         let matches = &self
@@ -143,6 +143,15 @@ impl RoutePattern {
         match s.strip_suffix('/') {
             Some(s) => s.into(),
             None => s,
+        }
+    }
+}
+
+impl fmt::Display for RoutePattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            RoutePattern::Exact(path) => write!(f, "{}", path),
+            RoutePattern::Wildcard(pattern) => write!(f, "{} (wildcard)", pattern),
         }
     }
 }


### PR DESCRIPTION
I'm not sure this is a preferred way to print available routes to stdout, but implement `Display` for `RoutePattern` enum and combine it with base url.

Add some dummy routes to `examples/http-rust/spin.toml`:

```toml
spin_version = "1"
authors = ["Fermyon Engineering <engineering@fermyon.com>"]
description = "A simple application that returns hello."
name = "spin-hello-world"
trigger = { type = "http", base = "/v1" }
version = "1.0.0"

[[component]]
id = "hello"
source = "target/wasm32-wasi/release/spinhelloworld.wasm"
[component.trigger]
route = "/hello"

[[component]]
id = "goodby"
source = "target/wasm32-wasi/release/spinhelloworld.wasm"
[component.trigger]
route = "/goodby"

[[component]]
id = "goodnight"
source = "target/wasm32-wasi/release/spinhelloworld.wasm"
[component.trigger]
route = "/goodnight"
```

Run `spin up`:

```sh
❯ ../../target/release/spin up
Serving HTTP on address http://127.0.0.1:3000
Available Routes:
  http://127.0.0.1:3000/v1/hello
  http://127.0.0.1:3000/v1/goodby
  http://127.0.0.1:3000/v1/goodnight
```

Fixes: #385