### PR TITLE
chore (devcontainer): remove the third-party as extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,8 +31,7 @@
     "serayuzgur.crates",
     "fermyon.autobindle",
     "golang.Go",
-    "grain-lang.vscode-grain",
-    "saulecabrera.asls"
+    "grain-lang.vscode-grain"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
I followed up with folks on the AssemblyScript Discord and their recommendation was to always use the vanilla JS/TS VS Code extension. Removing this so it doesn't cause any unnecessary issues for new users.

See also: https://github.com/fermyon/spin/pull/368#discussion_r851807188