### PR TITLE
chore: go version suggestion in docs, go v1.17.9 in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ ARG BINDLE_URL="https://github.com/deislabs/bindle/releases/download/v0.8.0/bind
 RUN curl -sL "$BINDLE_URL" | tar -xzf - -C /usr/local/bin bindle bindle-server
 
 # Go installation, see https://go.dev/doc/install
-ARG GO_URL="https://go.dev/dl/go1.18.1.linux-amd64.tar.gz"
+ARG GO_URL="https://go.dev/dl/go1.17.9.linux-amd64.tar.gz"
 RUN curl -sL "$GO_URL" | tar -xzf - -C /usr/local
 ENV PATH "$PATH:/usr/local/go/bin"
 

--- a/docs/content/go-components.md
+++ b/docs/content/go-components.md
@@ -19,6 +19,12 @@ Using TinyGo to compile components for Spin is currently required, as the
 
 > All examples from this page can be found in [the Spin repository on GitHub](https://github.com/fermyon/spin/tree/main/examples).
 
+## Versions
+
+TinyGo currently requires Go versions `1.15.x` through `1.17.x`. The recommendation is to use
+Go version `1.17.9`, and TinyGo version `0.22.0`. Go `1.18.x` support will be added in an upcoming
+TinyGo release `0.22.x`.
+
 ## HTTP components
 
 In Spin, HTTP components are triggered by the occurrence of an HTTP request, and


### PR DESCRIPTION
close #386