### PR TITLE
Improve config error formatting

### DIFF
--- a/crates/config/src/host_component.rs
+++ b/crates/config/src/host_component.rs
@@ -40,7 +40,7 @@ impl From<Error> for wit::spin_config::Error {
             Error::InvalidKey(msg) => Self::InvalidKey(msg),
             Error::InvalidSchema(msg) => Self::InvalidSchema(msg),
             Error::Provider(msg) => Self::Provider(msg.to_string()),
-            other => Self::Other(format!("{:?}", other)),
+            other => Self::Other(format!("{}", other)),
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -35,7 +35,7 @@ pub enum Error {
     Provider(anyhow::Error),
 
     /// Unknown config path.
-    #[error("unknown config path {0}")]
+    #[error("unknown config path: {0}")]
     UnknownPath(String),
 }
 
@@ -75,7 +75,7 @@ impl Resolver {
         let depth = depth + 1;
         if depth > Self::RECURSION_LIMIT {
             return Err(Error::InvalidTemplate(format!(
-                "hit recursion limit at path {:?}",
+                "hit recursion limit at path: {}",
                 path
             )));
         }
@@ -94,7 +94,7 @@ impl Resolver {
             self.resolve_template(path, template, depth)
         } else {
             Err(Error::InvalidPath(format!(
-                "missing value at required path {:?}",
+                "missing value at required path: {}",
                 path
             )))
         }

--- a/crates/config/src/tree.rs
+++ b/crates/config/src/tree.rs
@@ -15,7 +15,7 @@ impl Tree {
     pub(crate) fn get(&self, path: &Path) -> Result<&Slot> {
         self.0
             .get(path)
-            .ok_or_else(|| Error::InvalidPath(format!("no slot at path {:?}", path)))
+            .ok_or_else(|| Error::InvalidPath(format!("no slot at path: {}", path)))
     }
 
     pub fn merge(&mut self, base: &Path, other: Tree) -> Result<()> {
@@ -40,7 +40,10 @@ impl Tree {
 
     fn merge_slot(&mut self, path: Path, slot: Slot) -> Result<()> {
         if self.0.contains_key(&path) {
-            return Err(Error::InvalidPath(format!("duplicate key at {:?}", path)));
+            return Err(Error::InvalidPath(format!(
+                "duplicate key at path: {}",
+                path
+            )));
         }
         self.0.insert(path, slot);
         Ok(())
@@ -84,7 +87,7 @@ impl Path {
             Some((idx, _)) => format!("{}.{}", &self.0[..idx], key),
             None => {
                 return Err(Error::InvalidPath(format!(
-                    "rel has too many dots relative to base path {:?}",
+                    "rel has too many dots relative to base path {}",
                     self
                 )))
             }
@@ -101,6 +104,12 @@ impl Path {
 impl AsRef<str> for Path {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
+    }
+}
+
+impl std::fmt::Display for Path {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
     }
 }
 
@@ -241,6 +250,12 @@ mod tests {
         for rel in ["", "x", "....x"] {
             path.resolve_relative(rel).expect_err(rel);
         }
+    }
+
+    #[test]
+    fn path_display() {
+        let path = Path::new("a.b.c").unwrap();
+        assert_eq!(format!("{}", path), "a.b.c");
     }
 
     #[test]


### PR DESCRIPTION
`impl Display for Path` and use it in errors.

Fixes #397