### PR TITLE
Migrate outbound-http to a HostComponent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,6 +3134,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber 0.3.9",
  "vergen",
+ "wasi-outbound-http",
 ]
 
 [[package]]
@@ -3163,8 +3164,6 @@ dependencies = [
  "tracing-futures",
  "wasi-cap-std-sync",
  "wasi-common",
- "wasi-experimental-http-wasmtime 0.9.0 (git+https://github.com/deislabs/wasi-experimental-http?rev=4ed321d6943f75546e38bba80e14a59797aa29de)",
- "wasi-outbound-http",
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-wasmtime",
@@ -4296,10 +4295,13 @@ dependencies = [
  "futures",
  "http 0.2.6",
  "reqwest",
+ "spin-engine",
+ "spin-manifest",
  "tokio",
  "tracing",
  "tracing-futures",
  "url 2.2.2",
+ "wasi-experimental-http-wasmtime 0.9.0 (git+https://github.com/deislabs/wasi-experimental-http?rev=4ed321d6943f75546e38bba80e14a59797aa29de)",
  "wit-bindgen-wasmtime",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ toml = "0.5"
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
+wasi-outbound-http = { path = "crates/outbound-http" }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = [ "full" ] }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -17,8 +17,6 @@ tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 wasi-cap-std-sync = "0.34"
 wasi-common = "0.34"
-wasi-experimental-http-wasmtime = { git = "https://github.com/deislabs/wasi-experimental-http", rev = "4ed321d6943f75546e38bba80e14a59797aa29de" }
-wasi-outbound-http = { path = "../outbound-http" }
 wasmtime = "0.34"
 wasmtime-wasi = "0.34"
 

--- a/crates/engine/src/host_component.rs
+++ b/crates/engine/src/host_component.rs
@@ -67,7 +67,17 @@ pub struct HostComponentsStateHandle<T> {
 }
 
 impl<T: 'static> HostComponentsStateHandle<T> {
-    /// Get the component state associated with this handle from the RuntimeContext.
+    /// Get a ref to the component state associated with this handle from the RuntimeContext.
+    pub fn get<'a, U>(&self, ctx: &'a RuntimeContext<U>) -> &'a T {
+        ctx.host_components_state
+            .0
+            .get(self.idx)
+            .unwrap()
+            .downcast_ref()
+            .unwrap()
+    }
+
+    /// Get a mutable ref to the component state associated with this handle from the RuntimeContext.
     pub fn get_mut<'a, U>(&self, ctx: &'a mut RuntimeContext<U>) -> &'a mut T {
         ctx.host_components_state
             .0

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -13,8 +13,11 @@ bytes = "1"
 futures = "0.3"
 http = "0.2"
 reqwest = { version = "0.11", default-features = true, features = [ "json", "blocking" ] }
+spin-engine = { path = "../engine" }
+spin-manifest = { path = "../manifest" }
 tokio = { version = "1.4.0", features = [ "full" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 url = "2.2.1"
+wasi-experimental-http-wasmtime = { git = "https://github.com/deislabs/wasi-experimental-http", rev = "4ed321d6943f75546e38bba80e14a59797aa29de" }
 wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }

--- a/crates/outbound-http/src/host_component.rs
+++ b/crates/outbound-http/src/host_component.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use spin_engine::{
+    host_component::{HostComponent, HostComponentsStateHandle},
+    RuntimeContext,
+};
+use spin_manifest::CoreComponent;
+use wasi_experimental_http_wasmtime::{HttpCtx as ExperimentalHttpCtx, HttpState};
+use wit_bindgen_wasmtime::wasmtime::Linker;
+
+use crate::OutboundHttp;
+
+pub struct OutboundHttpComponent;
+
+impl HostComponent for OutboundHttpComponent {
+    type State = (OutboundHttp, ExperimentalHttpCtx);
+
+    fn add_to_linker<T>(
+        linker: &mut Linker<RuntimeContext<T>>,
+        data_handle: HostComponentsStateHandle<Self::State>,
+    ) -> Result<()> {
+        crate::add_to_linker(linker, move |ctx| &mut data_handle.get_mut(ctx).0)?;
+        HttpState::new()
+            .expect("HttpState::new failed")
+            .add_to_linker(linker, move |ctx| &data_handle.get(ctx).1)?;
+        Ok(())
+    }
+
+    fn build_state(&self, component: &CoreComponent) -> Result<Self::State> {
+        let outbound_http = OutboundHttp {
+            allowed_hosts: Some(component.wasm.allowed_http_hosts.clone()),
+        };
+        let experimental_http = ExperimentalHttpCtx {
+            allowed_hosts: Some(component.wasm.allowed_http_hosts.clone()),
+            max_concurrent_requests: None,
+        };
+        Ok((outbound_http, experimental_http))
+    }
+}

--- a/crates/outbound-http/src/lib.rs
+++ b/crates/outbound-http/src/lib.rs
@@ -1,3 +1,5 @@
+mod host_component;
+
 use futures::executor::block_on;
 use http::HeaderMap;
 use reqwest::{Client, Url};
@@ -5,6 +7,7 @@ use std::str::FromStr;
 use tokio::runtime::Handle;
 use wasi_outbound_http::*;
 
+pub use host_component::OutboundHttpComponent;
 pub use wasi_outbound_http::add_to_linker;
 
 wit_bindgen_wasmtime::export!("../../wit/ephemeral/wasi-outbound-http.wit");

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -170,6 +170,7 @@ impl UpCommand {
         };
         let mut builder = Builder::new(config)?;
         builder.link_defaults()?;
+        builder.add_host_component(wasi_outbound_http::OutboundHttpComponent)?;
         builder.add_host_component(outbound_redis::OutboundRedis)?;
         Ok(builder)
     }


### PR DESCRIPTION
Add HostComponentsStateHandle::get to support wasi-experimental-http's
slightly different add_to_linker signature.