### PR TITLE
feat: print component id when spin up

### DIFF
--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -220,6 +220,9 @@ impl HttpTrigger {
         println!("Available Routes:");
         for (route, component) in &self.router.routes {
             println!("  {}: http://{:?}{}", component.id, addr, route);
+            if let Some(description) = &component.description {
+                println!("    {}", description);
+            }
         }
 
         let shutdown_signal = on_ctrl_c()?;

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -218,8 +218,8 @@ impl HttpTrigger {
         log::info!("Serving HTTP on address {:?}", addr);
 
         println!("Available Routes:");
-        for (route, _) in &self.router.routes {
-            println!("  http://{:?}{}", addr, route);
+        for (route, component) in &self.router.routes {
+            println!("  {}: http://{:?}{}", component.id, addr, route);
         }
 
         let shutdown_signal = on_ctrl_c()?;

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -342,6 +342,7 @@ mod route_tests {
     fn named_component(id: &str) -> CoreComponent {
         CoreComponent {
             id: id.to_string(),
+            description: None,
             source: spin_manifest::ModuleSource::FileReference("FAKE".into()),
             wasm: spin_manifest::WasmConfig::default(),
         }

--- a/crates/loader/src/bindle/config.rs
+++ b/crates/loader/src/bindle/config.rs
@@ -25,6 +25,8 @@ pub struct RawComponentManifest {
     /// ID of the component. Used at runtime to select between
     /// multiple components of the same application.
     pub id: String,
+    /// Description of the component(Optional).
+    pub description: Option<String>,
     /// Per-component WebAssembly configuration.
     #[serde(flatten)]
     pub wasm: RawWasmConfig,

--- a/crates/loader/src/bindle/config.rs
+++ b/crates/loader/src/bindle/config.rs
@@ -25,7 +25,7 @@ pub struct RawComponentManifest {
     /// ID of the component. Used at runtime to select between
     /// multiple components of the same application.
     pub id: String,
-    /// Description of the component(Optional).
+    /// Description of the component.
     pub description: Option<String>,
     /// Per-component WebAssembly configuration.
     #[serde(flatten)]

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -114,6 +114,7 @@ async fn core(
 
     let source = ModuleSource::Buffer(bytes, format!("parcel {}", raw.source));
     let id = raw.id;
+    let description = raw.description;
     let mounts = match raw.wasm.files {
         Some(group) => {
             let parcels = parcels_in_group(invoice, &group);
@@ -131,7 +132,12 @@ async fn core(
         mounts,
         allowed_http_hosts,
     };
-    Ok(CoreComponent { source, id, wasm })
+    Ok(CoreComponent {
+        source,
+        id,
+        description,
+        wasm,
+    })
 }
 
 /// Converts the raw application manifest from the bindle invoice into the

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -61,7 +61,7 @@ pub struct RawComponentManifest {
     /// ID of the component. Used at runtime to select between
     /// multiple components of the same application.
     pub id: String,
-    /// Description of the component(Optional).
+    /// Description of the component.
     pub description: Option<String>,
     /// Per-component WebAssembly configuration.
     #[serde(flatten)]

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -61,6 +61,8 @@ pub struct RawComponentManifest {
     /// ID of the component. Used at runtime to select between
     /// multiple components of the same application.
     pub id: String,
+    /// Description of the component(Optional).
+    pub description: Option<String>,
     /// Per-component WebAssembly configuration.
     #[serde(flatten)]
     pub wasm: RawWasmConfig,

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -148,6 +148,7 @@ async fn core(
     };
 
     let id = raw.id;
+    let description = raw.description;
     let mounts = match raw.wasm.files {
         Some(f) => assets::prepare_component(&f, src, &base_dst, &id).await?,
         None => vec![],
@@ -159,7 +160,12 @@ async fn core(
         mounts,
         allowed_http_hosts,
     };
-    Ok(CoreComponent { source, id, wasm })
+    Ok(CoreComponent {
+        source,
+        id,
+        description,
+        wasm,
+    })
 }
 
 /// Converts the raw application information from the spin.toml manifest to the standard configuration.

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -65,6 +65,8 @@ pub struct CoreComponent {
     /// ID of the component. Used at runtime to select between
     /// multiple components of the same application.
     pub id: String,
+    /// Description of the component(Optional).
+    pub description: Option<String>,
     /// Per-component WebAssembly configuration.
     pub wasm: WasmConfig,
 }

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -65,7 +65,7 @@ pub struct CoreComponent {
     /// ID of the component. Used at runtime to select between
     /// multiple components of the same application.
     pub id: String,
-    /// Description of the component(Optional).
+    /// Description of the component.
     pub description: Option<String>,
     /// Per-component WebAssembly configuration.
     pub wasm: WasmConfig,

--- a/crates/publish/src/expander.rs
+++ b/crates/publish/src/expander.rs
@@ -113,6 +113,7 @@ fn bindle_component_manifest(
     let asset_group = local.wasm.files.as_ref().map(|_| group_name_for(&local.id));
     Ok(bindle_schema::RawComponentManifest {
         id: local.id.clone(),
+        description: local.description.clone(),
         source: source_digest,
         wasm: bindle_schema::RawWasmConfig {
             environment: local.wasm.environment.clone(),

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -76,6 +76,7 @@ impl TestConfig {
         CoreComponent {
             source: ModuleSource::FileReference(module_path),
             id: "test-component".to_string(),
+            description: None,
             wasm: Default::default(),
         }
     }

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -20,6 +20,7 @@ version = "1.0.0"
 
 [[component]]
 id = "hello"
+description = "A simple component that returns hello world."
 source = "target/wasm32-wasi/release/spinhelloworld.wasm"
 [component.trigger]
 route = "/hello"
@@ -61,6 +62,7 @@ Each `component` object has the following fields:
 
 - `id` (REQUIRED): unique (per application) ID of the component, used at runtime
   to select between multiple components of the same application.
+- `description` (OPTIONAL): Description of the component.
 - `source` (REQUIRED): Source for the WebAssembly module of the component. This
   field can be _one_ the following:
   - a string with the path to a local file containing the WebAssembly module for

--- a/examples/http-rust/spin.toml
+++ b/examples/http-rust/spin.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 [[component]]
 id = "hello"
 source = "target/wasm32-wasi/release/spinhelloworld.wasm"
+description = "A simple component that returns hello."
 [component.trigger]
 route = "/hello"
 [component.build]

--- a/examples/spin-timer/src/main.rs
+++ b/examples/spin-timer/src/main.rs
@@ -86,6 +86,7 @@ pub fn component() -> CoreComponent {
     CoreComponent {
         source: ModuleSource::FileReference("target/test-programs/echo.wasm".into()),
         id: "test".to_string(),
+        description: None,
         wasm: WasmConfig::default(),
     }
 }


### PR DESCRIPTION
The available routes will be printed out in the following format:
`Component Id: URL (wildcard)`

` (wildcard)` will be printed out iff applicable.

Examples:
- hello: http://127.0.0.1:3000/hello
- static: http://127.0.0.1:3000/static (wildcard)

Signed-off-by: Hanzhen Liang <handrenliang@gmail.com>