### PR TITLE
feat(cli): add Wasmtime cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "tracing-subscriber 0.3.9",
  "vergen",
  "wasi-outbound-http",
+ "wasmtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 wasi-outbound-http = { path = "crates/outbound-http" }
+wasmtime = "0.34"
 
 [dev-dependencies]
 hyper = { version = "0.14", features = [ "full" ] }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -18,3 +18,5 @@ pub const HIPPO_SERVER_URL_OPT: &str = "HIPPO_SERVER_URL";
 pub const HIPPO_URL_ENV: &str = "HIPPO_URL";
 pub const JSON_MIME_TYPE: &str = "application/json";
 pub const BUILD_UP_OPT: &str = "UP";
+pub const DISABLE_WASMTIME_CACHE: &str = "DISABLE_WASMTIME_CACHE";
+pub const WASMTIME_CACHE_FILE: &str = "WASMTIME_CACHE_FILE";


### PR DESCRIPTION
close #169 
ref #413 

This updates the `spin up` command to always use a Wasmtime cache.
Specifically, if no option is passed, it will attempt to use the default
Wasmtime cache, or create a new `enabled` cache configuration on the first
run.

This behavior can be overridden with the `--disable-cache=true` setting, and the
cache file can be configured with the `--cache <path-to-cache-file>` flag.

See https://github.com/bytecodealliance/wasmtime/blob/main/docs/cli-cache.md
for a reference on the cache file.

Not exactly sure how to (or if we want to) just pass `--disable-cache` instead of `--disable-cache=true`.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>