### PR TITLE
docs(*): fix links which result in 404: Not Found on GitHub

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -40,7 +40,7 @@ The following are the fields supported by the `spin.toml` manifest file:
 - `trigger` (REQUIRED): Trigger for the application. Currently, the two
 implemented trigger types are:
   - `http`: All components of the application are invoked as a result of
-  incoming HTTP requests. [The HTTP trigger](/http-trigger) configuration has
+  incoming HTTP requests. [The HTTP trigger](./http-trigger.md) configuration has
   the following fields:
     - `type` (REQUIRED): The application trigger type with the value `"http"`.
     - `base` (REQUIRED): The base path for the HTTP application which will be
@@ -48,7 +48,7 @@ implemented trigger types are:
       and a component has `route = "/bar"`, the component will be invoked for
       requests on `/foo/bar`.)
   - `redis`: All components of the application are invoked as a result of messages
-being published on the queues of Redis instance. [The Redis trigger](/redis-trigger)
+being published on the queues of Redis instance. [The Redis trigger](./redis-trigger.md)
 configuration has the following fields:
     - `type` (REQUIRED): The application trigger type with the value `"redis"`.
     - `address` (REQUIRED): The address of the Redis instance the components

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -66,7 +66,7 @@ $ make test
 
 Now you should be ready to start making your contribution. To familiarize
 yourself with the Spin project, please read the
-[document about extending Spin](/extending-and-embedding). Since most of Spin is implemented in
+[document about extending Spin](./extending-and-embedding.md). Since most of Spin is implemented in
 Rust, we try to follow the common Rust coding conventions (keep an eye on the
 recommendations from Clippy!) If applicable, add unit or integration tests to
 ensure your contribution is correct.

--- a/docs/content/distributing-apps.md
+++ b/docs/content/distributing-apps.md
@@ -20,7 +20,7 @@ VS Code extension (through the `Bindle: Start` command):
 $ bindle-server --address 127.0.0.1:8000 --directory .
 ```
 
-Let's push the application from the [quickstart](/quickstart) to the registry:
+Let's push the application from the [quickstart](./quickstart.md) to the registry:
 
 ```bash
 $ export BINDLE_URL=http://localhost:8080/v1

--- a/docs/content/extending-and-embedding.md
+++ b/docs/content/extending-and-embedding.md
@@ -9,9 +9,9 @@ url = "https://github.com/fermyon/spin/blob/main/docs/content/extending-and-embe
 
 Spin currently implements triggers and application models for:
 
-- [HTTP applications](/http-trigger) that are triggered by incoming HTTP
+- [HTTP applications](./http-trigger.md) that are triggered by incoming HTTP
 requests, and that return an HTTP response
-- [Redis applications](/redis-trigger) that are triggered by messages on Redis
+- [Redis applications](./redis-trigger.md) that are triggered by messages on Redis
 channels
 
 The Spin internals and execution context (the part of Spin executing
@@ -25,7 +25,7 @@ timer, executing Spin components at configured time interval.
 
 The current application types that can be implemented with Spin have entry points
 defined using
-[WebAssembly Interface (WIT)]((https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md)):
+[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md):
 
 ```fsharp
 // The entry point for an HTTP handler.
@@ -120,7 +120,7 @@ this is an implementation choice based on the needs of the trigger.
 used — in the case of the HTTP trigger, this is an HTTP response, which is then
 returned to the client.
 
-This is very similar to how the [HTTP](/http-trigger) and [Redis](/redis-trigger)
+This is very similar to how the [HTTP](./http-trigger.md) and [Redis](./redis-trigger.md)
 triggers are implemented, and it is the recommended way to extend Spin with your
 own trigger and application model.
 

--- a/docs/content/go-components.md
+++ b/docs/content/go-components.md
@@ -150,5 +150,5 @@ Any
 [package from the Go standard library](https://tinygo.org/docs/reference/lang-support/stdlib/) that can be imported in TinyGo and that compiles to
 WASI can be used when implementing a Spin component.
 
-> Make sure to read [the page describing the HTTP trigger](/http-trigger) for more
+> Make sure to read [the page describing the HTTP trigger](./http-trigger.md) for more
 > details about building HTTP applications.

--- a/docs/content/http-trigger.md
+++ b/docs/content/http-trigger.md
@@ -12,11 +12,11 @@ some implementation details around the WebAssembly component model and how it
 is used in Spin.
 
 The HTTP trigger in Spin is a web server. It listens for incoming requests and
-based on the [application manifest](/configuration), it routes them to an
+based on the [application manifest](./configuration.md), it routes them to an
 _executor_ which instantiates the appropriate component, executes its
 entry point function, then returns an HTTP response.
 
-Creating an HTTP application is done when [configuring the application](/configuration)
+Creating an HTTP application is done when [configuring the application](./configuration.md)
 by defining the top-level application trigger:
 
 ```toml
@@ -165,7 +165,7 @@ component.
 This interface (`spin-http.wit`) can be directly used together with the
 [Bytecode Alliance `wit-bindgen` project](https://github.com/bytecodealliance/wit-bindgen)
 to build a component that the Spin HTTP executor can invoke.
-This is exactly how [the Rust SDK for Spin](/rust-components) is built, and,
+This is exactly how [the Rust SDK for Spin](./rust-components.md) is built, and,
 as more languages add support for the component model, how we plan to add
 support for them as well.
 
@@ -194,7 +194,7 @@ responses through the module's standard output.
 This means that if a language has support for the WebAssembly System Interface,
 it can be used to build Spin HTTP components.
 The Wagi model is only used to parse the HTTP request and response. Everything
-else — defining the application, running it, or [distributing](/distributing-apps)
+else — defining the application, running it, or [distributing](./distributing-apps.md)
 is done the same way as a component that uses the Spin executor.
 
 Building a Wagi component in a particular programming language that can compile
@@ -215,7 +215,7 @@ print("content-type: text/html; charset=UTF-8\n\n");
 print("hello world\n");
 ```
 
-The [Go SDK for Spin](/go-components) is built on the Wagi executor support.
+The [Go SDK for Spin](./go-components.md) is built on the Wagi executor support.
 Here is another example, written in [Grain](https://grain-lang.org/),
 a new programming language that natively targets WebAssembly:
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -64,4 +64,4 @@ a web server. Any time a request is made on the `/hello` route, it will invoke t
 `hello_world` function. Adding another component is as simple as adding another `[[component]]`
 stanza to the `spin.toml` file.
 
-In the next section, we will [take Spin for a spin](/quickstart).
+In the next section, we will [take Spin for a spin](./quickstart.md).

--- a/docs/content/other-languages.md
+++ b/docs/content/other-languages.md
@@ -8,7 +8,7 @@ url = "https://github.com/fermyon/spin/blob/main/docs/content/other-languages.md
 > This document is continuously evolving as we improve language SDKs and add
 > more examples on how to build Spin components in various programming languages.
 
-> See the document on writing [Rust](/rust-components) and [Go](/go-components)
+> See the document on writing [Rust](./rust-components.md) and [Go](./go-components.md)
 > components for Spin for detailed guides.
 
 WebAssembly is becoming [a popular compilation target for programming languages](https://www.fermyon.com/wasm-languages/webassembly-language-support), and as language toolchains add support for the
@@ -20,11 +20,11 @@ As a general rule:
 - if your language supports the
 [WebAssembly component model](https://github.com/WebAssembly/component-model),
 building Spin components is supported either through an official Spin SDK
-(such as [the Spin SDK for Rust](/rust-components)), or through using
+(such as [the Spin SDK for Rust](./rust-components.md)), or through using
 bindings generators like [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen)
 (for languages such as C and C++)
 - if your language compiles to WASI, but doesn't have support for the component
-model, you can build [Spin HTTP components](/http-trigger) that use the
+model, you can build [Spin HTTP components](./http-trigger.md) that use the
 Wagi executor — for example in languages such as
 [Grain](https://github.com/deislabs/hello-wagi-grain),
 [AssemblyScript](https://github.com/deislabs/hello-wagi-as), or

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -22,7 +22,7 @@ $ tar xfv spin-v0.1.0-macos-aarch64.tar.gz
 $ ./spin --help
 ```
 
-Alternatively, [follow the contribution document](/contributing) for a detailed guide
+Alternatively, [follow the contribution document](./contributing.md) for a detailed guide
 on building Spin from source:
 
 ```bash
@@ -66,7 +66,7 @@ route = "/hello"
 This represents a simple Spin HTTP application (triggered by an HTTP request), with
 a single component called `hello`. Spin will execute the `spinhelloworld.wasm`
 WebAssembly module for HTTP requests on the route `/hello`.
-(See the [configuration document](/configuration) for a detailed guide on the Spin
+(See the [configuration document](./configuration.md) for a detailed guide on the Spin
 application manifest.)
 
 Now let's have a look at the `hello` component (`examples/http-rust/src/lib.rs`). Below is the complete source
@@ -92,7 +92,7 @@ fn hello_world(req: Request) -> Result<Response> {
 }
 ```
 
-> See the document on writing [Rust](/rust-components) and [Go](/go-components)
+> See the document on writing [Rust](./rust-components.md) and [Go](./go-components.md)
 > components for Spin.
 
 We can build this component using the regular Rust toolchain, targeting
@@ -137,12 +137,12 @@ Hello, Fermyon!
 
 You can add as many components as needed in `spin.toml`, mount files and
 directories, allow granular outbound HTTP connections, or set environment variables
-(see the [configuration document](/configuration) for a detailed guide on
+(see the [configuration document](./configuration.md) for a detailed guide on
 the Spin application manifest) and iterate locally with
 `spin up --file spin.toml` until you are ready to distribute the application.
 
 Congratulations! You just completed building and running your first Spin
 application!
-Next, check out the [Rust](/rust-components) or [Go](/go-components) language
+Next, check out the [Rust](./rust-components.md) or [Go](./go-components.md) language
 guides, or have a look at [a more complex Spin application with components built
 in multiple programming languages](https://github.com/fermyon/spin-kitchensink/).

--- a/docs/content/redis-trigger.md
+++ b/docs/content/redis-trigger.md
@@ -9,7 +9,7 @@ Spin applications can be triggered by a new message on a [Redis channel](https:/
 Spin will connect to a configured Redis instance and will invoke components for
 new messages on the configured channels.
 
-> See the [Rust language guide](/rust-components) for details on using Rust to
+> See the [Rust language guide](./rust-components.md) for details on using Rust to
 > build Redis components.
 
 The Redis instance address is specified in the application trigger:
@@ -25,7 +25,7 @@ trigger = { type = "redis", address = "redis://localhost:6379" }
 > messages to channels.
 
 Then, all components in the application are triggered when new messages are
-published to channels in the instance. [Configuring](/configuration) the channel
+published to channels in the instance. [Configuring](./configuration.md) the channel
  is done by setting the `channel` field in the component trigger configuration.
 
 ```toml
@@ -59,7 +59,7 @@ used by the Spin Redis executor when instantiating and invoking the component.
 This interface (`spin-redis.wit`) can be directly used together with the
 [Bytecode Alliance `wit-bindgen` project](https://github.com/bytecodealliance/wit-bindgen)
 to build a component that the Spin HTTP executor can invoke.
-This is exactly how [the Rust SDK for Spin](/rust-components) is built, and,
+This is exactly how [the Rust SDK for Spin](./rust-components.md) is built, and,
 as more languages add support for the component model, how we plan to add
 support for them as well.
 

--- a/docs/content/rust-components.md
+++ b/docs/content/rust-components.md
@@ -141,7 +141,7 @@ Besides the HTTP trigger, Spin has built-in support for a Redis trigger —
 which will connect to a Redis instance and will execute Spin components for
 new messages on the configured channels.
 
-> See the [Redis trigger](/redis-trigger) for details about the Redis trigger.
+> See the [Redis trigger](./redis-trigger.md) for details about the Redis trigger.
 
 Writing a Redis component in Rust also takes advantage of the SDK:
 
@@ -221,7 +221,7 @@ annotated using the `http_component` macro, compiled to the
 This means that any [crate](https://crates.io) that compiles to `wasm32-wasi` can
 be used when implementing the component.
 
-> Make sure to read [the page describing the HTTP trigger](/http-trigger) for more
+> Make sure to read [the page describing the HTTP trigger](./http-trigger.md) for more
 > details about building HTTP applications.
 
 ## Troubleshooting

--- a/docs/content/url-shortener.md
+++ b/docs/content/url-shortener.md
@@ -37,7 +37,7 @@ redirect to `https://github.com/fermyon/spin`. Now that we have a basic
 understanding of how the component should behave, let's see how to implement it
 using Spin.
 
-First, we start with [a new Spin component written in Rust](/rust-components):
+First, we start with [a new Spin component written in Rust](./rust-components.md):
 
 ```rust
 /// A Spin HTTP component that redirects requests 
@@ -91,7 +91,7 @@ pub fn redirect(self, req: Request) -> Result<Response> {
 ```
 
 The `redirect` function is straightforward — it reads the request path from the
-`spin-path-info` header (make sure to read the [document about the HTTP trigger](/http-trigger)
+`spin-path-info` header (make sure to read the [document about the HTTP trigger](./http-trigger.md)
 for an overview of the HTTP headers present in Spin components), selects the
 corresponding destination from the router configuration, then sends the
 HTTP redirect to the new location.
@@ -130,7 +130,7 @@ Not Found
 > Notice that you can use the `--listen` option for `spin up` to start the
 > web server on a specific host and port, which you can then bind to a domain.
 
-We can now [publish the application to the registry](/distributing-apps) (together
+We can now [publish the application to the registry](./distributing-apps.md) (together
 with router configuration file):
 
 ```bash


### PR DESCRIPTION
While perusing the excellent documentation, I noticed that all the links of the
form (/page-name) were broken in both Emacs (file not found) and on GitHub
(404).  Changing them to (./page-name.md) fixed both cases.  Additionally, one
of the HTTPS links had an extra pair of parentheses, which I've removed.

Signed-off-by: Joel Dice <joel.dice@gmail.com>