### PR TITLE
Follow logs

### DIFF
--- a/crates/engine/src/io.rs
+++ b/crates/engine/src/io.rs
@@ -20,3 +20,25 @@ pub struct OutRedirect {
     /// Lock for writing.
     pub lock: Arc<RwLock<Vec<u8>>>,
 }
+
+/// Prepares WASI pipes which redirect a component's output to
+/// memory buffers.
+pub fn prepare_io_redirects() -> anyhow::Result<IoStreamRedirects> {
+    let stdin = ReadPipe::from(vec![]);
+
+    let stdout_buf: Vec<u8> = vec![];
+    let lock = Arc::new(RwLock::new(stdout_buf));
+    let stdout = WritePipe::from_shared(lock.clone());
+    let stdout = OutRedirect { out: stdout, lock };
+
+    let stderr_buf: Vec<u8> = vec![];
+    let lock = Arc::new(RwLock::new(stderr_buf));
+    let stderr = WritePipe::from_shared(lock.clone());
+    let stderr = OutRedirect { out: stderr, lock };
+
+    Ok(IoStreamRedirects {
+        stdin,
+        stdout,
+        stderr,
+    })
+}

--- a/crates/engine/src/io.rs
+++ b/crates/engine/src/io.rs
@@ -1,44 +1,215 @@
-use std::sync::{Arc, RwLock};
-use wasi_common::pipe::{ReadPipe, WritePipe};
+use std::{
+    collections::HashSet,
+    io::{LineWriter, Write},
+    sync::{Arc, RwLock, RwLockReadGuard},
+};
+use wasi_common::{
+    pipe::{ReadPipe, WritePipe},
+    WasiFile,
+};
 
-/// Input/Output stream redirects
-#[derive(Clone)]
-pub struct IoStreamRedirects {
-    /// Standard input redirect.
-    pub stdin: ReadPipe<std::io::Cursor<Vec<u8>>>,
-    /// Standard output redirect.
-    pub stdout: OutRedirect,
-    /// Standard error redirect.
-    pub stderr: OutRedirect,
+/// Which components should have their logs followed on stdout/stderr.
+#[derive(Clone, Debug)]
+pub enum FollowComponents {
+    /// No components should have their logs followed.
+    None,
+    /// Only the specified components should have their logs followed.
+    Named(HashSet<String>),
+    /// All components should have their logs followed.
+    All,
 }
 
-/// Output redirect and lock.
-#[derive(Clone)]
-pub struct OutRedirect {
-    /// Output redirect.
-    pub out: WritePipe<Vec<u8>>,
-    /// Lock for writing.
-    pub lock: Arc<RwLock<Vec<u8>>>,
+impl FollowComponents {
+    /// Whether a given component should have its logs followed on stdout/stderr.
+    pub fn should_follow(&self, component_id: &str) -> bool {
+        match self {
+            Self::None => false,
+            Self::All => true,
+            Self::Named(ids) => ids.contains(component_id),
+        }
+    }
+}
+
+/// The buffers in which Wasm module output has been saved.
+pub trait OutputBuffers {
+    /// The buffer in which stdout has been saved.
+    fn stdout(&self) -> &[u8];
+    /// The buffer in which stderr has been saved.
+    fn stderr(&self) -> &[u8];
+}
+
+/// A set of redirected standard I/O streams with which
+/// a Wasm module is to be run.
+pub struct ModuleIoRedirects {
+    pub(crate) stdin: Box<dyn WasiFile>,
+    pub(crate) stdout: Box<dyn WasiFile>,
+    pub(crate) stderr: Box<dyn WasiFile>,
+}
+
+impl ModuleIoRedirects {
+    /// Constructs an instance from a set of WasiFile objects.
+    pub fn new(
+        stdin: Box<dyn WasiFile>,
+        stdout: Box<dyn WasiFile>,
+        stderr: Box<dyn WasiFile>,
+    ) -> Self {
+        Self {
+            stdin,
+            stdout,
+            stderr,
+        }
+    }
+}
+
+/// The destinations to which redirected module output will be written.
+/// Used for subsequently reading back the output.
+pub struct RedirectReadHandles {
+    stdout: Arc<RwLock<WriteDestinations>>,
+    stderr: Arc<RwLock<WriteDestinations>>,
+}
+
+impl RedirectReadHandles {
+    /// Acquires a read lock for the in-memory output buffers.
+    pub fn read(&self) -> impl OutputBuffers + '_ {
+        RedirectReadHandlesLock {
+            stdout: self.stdout.read().unwrap(),
+            stderr: self.stderr.read().unwrap(),
+        }
+    }
+}
+
+struct RedirectReadHandlesLock<'a> {
+    stdout: RwLockReadGuard<'a, WriteDestinations>,
+    stderr: RwLockReadGuard<'a, WriteDestinations>,
+}
+
+impl<'a> OutputBuffers for RedirectReadHandlesLock<'a> {
+    fn stdout(&self) -> &[u8] {
+        self.stdout.buffer()
+    }
+    fn stderr(&self) -> &[u8] {
+        self.stderr.buffer()
+    }
 }
 
 /// Prepares WASI pipes which redirect a component's output to
 /// memory buffers.
-pub fn prepare_io_redirects() -> anyhow::Result<IoStreamRedirects> {
+pub fn capture_io_to_memory(
+    follow_on_stdout: bool,
+    follow_on_stderr: bool,
+) -> (ModuleIoRedirects, RedirectReadHandles) {
+    let stdout_follow = Follow::stdout(follow_on_stdout);
+    let stderr_follow = Follow::stderr(follow_on_stderr);
+
     let stdin = ReadPipe::from(vec![]);
 
-    let stdout_buf: Vec<u8> = vec![];
-    let lock = Arc::new(RwLock::new(stdout_buf));
-    let stdout = WritePipe::from_shared(lock.clone());
-    let stdout = OutRedirect { out: stdout, lock };
+    let (stdout_pipe, stdout_lock) = redirect_to_mem_buffer(stdout_follow);
 
-    let stderr_buf: Vec<u8> = vec![];
-    let lock = Arc::new(RwLock::new(stderr_buf));
-    let stderr = WritePipe::from_shared(lock.clone());
-    let stderr = OutRedirect { out: stderr, lock };
+    let (stderr_pipe, stderr_lock) = redirect_to_mem_buffer(stderr_follow);
 
-    Ok(IoStreamRedirects {
-        stdin,
-        stdout,
-        stderr,
-    })
+    let redirects = ModuleIoRedirects {
+        stdin: Box::new(stdin),
+        stdout: Box::new(stdout_pipe),
+        stderr: Box::new(stderr_pipe),
+    };
+
+    let outputs = RedirectReadHandles {
+        stdout: stdout_lock,
+        stderr: stderr_lock,
+    };
+
+    (redirects, outputs)
+}
+
+/// Indicates whether a memory redirect should also pipe the output to
+/// the console so it can be followed live.
+pub enum Follow {
+    /// Do not pipe to console - only write to memory.
+    None,
+    /// Also pipe to stdout.
+    Stdout,
+    /// Also pipe to stderr.
+    Stderr,
+}
+
+impl Follow {
+    pub(crate) fn writer(&self) -> Box<dyn Write + Send + Sync> {
+        match self {
+            Self::None => Box::new(DiscardingWriter),
+            Self::Stdout => Box::new(LineWriter::new(std::io::stdout())),
+            Self::Stderr => Box::new(LineWriter::new(std::io::stderr())),
+        }
+    }
+
+    /// Follow on stdout if so specified.
+    pub fn stdout(follow_on_stdout: bool) -> Self {
+        if follow_on_stdout {
+            Self::Stdout
+        } else {
+            Self::None
+        }
+    }
+
+    /// Follow on stderr if so specified.
+    pub fn stderr(follow_on_stderr: bool) -> Self {
+        if follow_on_stderr {
+            Self::Stderr
+        } else {
+            Self::None
+        }
+    }
+}
+
+/// Prepares a WASI pipe which writes to a memory buffer, optionally
+/// copying to the specified output stream.
+pub fn redirect_to_mem_buffer(
+    follow: Follow,
+) -> (WritePipe<WriteDestinations>, Arc<RwLock<WriteDestinations>>) {
+    let immediate = follow.writer();
+
+    let buffer: Vec<u8> = vec![];
+    let std_dests = WriteDestinations { buffer, immediate };
+    let lock = Arc::new(RwLock::new(std_dests));
+    let std_pipe = WritePipe::from_shared(lock.clone());
+
+    (std_pipe, lock)
+}
+
+/// The destinations to which a component writes an output stream.
+pub struct WriteDestinations {
+    buffer: Vec<u8>,
+    immediate: Box<dyn Write + Send + Sync>,
+}
+
+impl WriteDestinations {
+    /// The memory buffer to which a component writes an output stream.
+    pub fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+}
+
+impl Write for WriteDestinations {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let written = self.buffer.write(buf)?;
+        self.immediate.write_all(&buf[0..written])?;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.buffer.flush()?;
+        self.immediate.flush()?;
+        Ok(())
+    }
+}
+
+struct DiscardingWriter;
+
+impl Write for DiscardingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -6,16 +6,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 use http::Uri;
 use hyper::{Body, Request, Response};
-use spin_engine::io::{IoStreamRedirects, OutRedirect};
-use std::{
-    net::SocketAddr,
-    str,
-    str::FromStr,
-    sync::{Arc, RwLock},
-};
+use spin_engine::io::prepare_io_redirects;
+use std::{net::SocketAddr, str, str::FromStr};
 use tokio::task::spawn_blocking;
 use tracing::log;
-use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasmtime::{Instance, Store};
 
 #[derive(Clone)]
@@ -212,26 +206,6 @@ fn contextualise_err(e: anyhow::Error) -> anyhow::Error {
     } else {
         e
     }
-}
-
-pub fn prepare_io_redirects() -> Result<IoStreamRedirects> {
-    let stdin = ReadPipe::from(vec![]);
-
-    let stdout_buf: Vec<u8> = vec![];
-    let lock = Arc::new(RwLock::new(stdout_buf));
-    let stdout = WritePipe::from_shared(lock.clone());
-    let stdout = OutRedirect { out: stdout, lock };
-
-    let stderr_buf: Vec<u8> = vec![];
-    let lock = Arc::new(RwLock::new(stderr_buf));
-    let stderr = WritePipe::from_shared(lock.clone());
-    let stderr = OutRedirect { out: stderr, lock };
-
-    Ok(IoStreamRedirects {
-        stdin,
-        stdout,
-        stderr,
-    })
 }
 
 #[cfg(test)]

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;
 use redis::{Client, ConnectionLike};
+use spin_engine::io::FollowComponents;
 use spin_manifest::{ComponentMap, RedisConfig, RedisTriggerConfiguration};
 use spin_redis::SpinRedisData;
 use spin_trigger::Trigger;
@@ -28,6 +29,8 @@ pub struct RedisTrigger {
     engine: Arc<ExecutionContext>,
     /// Map from channel name to tuple of component name & index.
     subscriptions: HashMap<String, usize>,
+    /// Which components should have their logs followed on stdout/stderr.
+    follow: FollowComponents,
 }
 
 #[async_trait]
@@ -41,6 +44,7 @@ impl Trigger for RedisTrigger {
         execution_context: ExecutionContext,
         trigger_config: Self::Config,
         component_triggers: ComponentMap<Self::ComponentConfig>,
+        follow: FollowComponents,
     ) -> Result<Self> {
         let subscriptions = execution_context
             .config
@@ -59,6 +63,7 @@ impl Trigger for RedisTrigger {
             component_triggers,
             engine: Arc::new(execution_context),
             subscriptions,
+            follow,
         })
     }
 
@@ -112,6 +117,8 @@ impl RedisTrigger {
                 .and_then(|t| t.executor.clone())
                 .unwrap_or_default();
 
+            let follow = self.follow.should_follow(&component.id);
+
             match executor {
                 spin_manifest::RedisExecutor::Spin => {
                     log::trace!("Executing Spin Redis component {}", component.id);
@@ -122,6 +129,7 @@ impl RedisTrigger {
                             &component.id,
                             channel,
                             msg.get_payload_bytes(),
+                            follow,
                         )
                         .await?
                 }
@@ -144,6 +152,7 @@ pub(crate) trait RedisExecutor: Clone + Send + Sync + 'static {
         component: &str,
         channel: &str,
         payload: &[u8],
+        follow: bool,
     ) -> Result<()>;
 }
 

--- a/crates/redis/src/spin.rs
+++ b/crates/redis/src/spin.rs
@@ -1,6 +1,7 @@
 use crate::{spin_redis::SpinRedis, ExecutionContext, RedisExecutor, RuntimeContext};
 use anyhow::Result;
 use async_trait::async_trait;
+use spin_engine::io::prepare_io_redirects;
 use tokio::task::spawn_blocking;
 use wasmtime::{Instance, Store};
 
@@ -20,9 +21,13 @@ impl RedisExecutor for SpinRedisExecutor {
             "Executing request using the Spin executor for component {}",
             component
         );
-        let (store, instance) = engine.prepare_component(component, None, None, None, None)?;
 
-        match Self::execute_impl(store, instance, channel, payload.to_vec()).await {
+        let io_redirects = prepare_io_redirects()?;
+
+        let (store, instance) =
+            engine.prepare_component(component, None, Some(io_redirects.clone()), None, None)?;
+
+        let result = match Self::execute_impl(store, instance, channel, payload.to_vec()).await {
             Ok(()) => {
                 log::trace!("Request finished OK");
                 Ok(())
@@ -31,7 +36,11 @@ impl RedisExecutor for SpinRedisExecutor {
                 log::trace!("Request finished with error {}", e);
                 Err(e)
             }
-        }
+        };
+
+        let log_result = engine.save_output_to_logs(io_redirects, component, true, true);
+
+        result.and(log_result)
     }
 }
 

--- a/crates/redis/src/spin.rs
+++ b/crates/redis/src/spin.rs
@@ -1,7 +1,7 @@
 use crate::{spin_redis::SpinRedis, ExecutionContext, RedisExecutor, RuntimeContext};
 use anyhow::Result;
 use async_trait::async_trait;
-use spin_engine::io::prepare_io_redirects;
+use spin_engine::io::capture_io_to_memory;
 use tokio::task::spawn_blocking;
 use wasmtime::{Instance, Store};
 
@@ -16,16 +16,17 @@ impl RedisExecutor for SpinRedisExecutor {
         component: &str,
         channel: &str,
         payload: &[u8],
+        follow: bool,
     ) -> Result<()> {
         log::trace!(
             "Executing request using the Spin executor for component {}",
             component
         );
 
-        let io_redirects = prepare_io_redirects()?;
+        let (redirects, outputs) = capture_io_to_memory(follow, follow);
 
         let (store, instance) =
-            engine.prepare_component(component, None, Some(io_redirects.clone()), None, None)?;
+            engine.prepare_component(component, None, Some(redirects), None, None)?;
 
         let result = match Self::execute_impl(store, instance, channel, payload.to_vec()).await {
             Ok(()) => {
@@ -38,7 +39,7 @@ impl RedisExecutor for SpinRedisExecutor {
             }
         };
 
-        let log_result = engine.save_output_to_logs(io_redirects, component, true, true);
+        let log_result = engine.save_output_to_logs(outputs.read(), component, true, true);
 
         result.and(log_result)
     }

--- a/crates/redis/src/tests.rs
+++ b/crates/redis/src/tests.rs
@@ -29,7 +29,8 @@ async fn test_pubsub() -> Result<()> {
         });
     let app = cfg.build_application();
 
-    let trigger: RedisTrigger = build_trigger_from_app(app, None, None).await?;
+    let trigger: RedisTrigger =
+        build_trigger_from_app(app, None, FollowComponents::None, None).await?;
 
     // TODO
     // use redis::{FromRedisValue, Msg, Value};

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 
 use http::{Request, Response};
 use hyper::Body;
-use spin_engine::Builder;
+use spin_engine::{io::FollowComponents, Builder};
 use spin_http_engine::HttpTrigger;
 use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, ApplicationTrigger, CoreComponent,
@@ -105,7 +105,7 @@ impl TestConfig {
 
     pub async fn build_http_trigger(&self) -> HttpTrigger {
         let app = self.build_application();
-        spin_trigger::build_trigger_from_app(app, None, None)
+        spin_trigger::build_trigger_from_app(app, None, FollowComponents::None, None)
             .await
             .unwrap()
     }

--- a/examples/spin-timer/src/main.rs
+++ b/examples/spin-timer/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use spin_engine::{Builder, ExecutionContextConfiguration};
+use spin_engine::{io::FollowComponents, Builder, ExecutionContextConfiguration};
 use spin_manifest::{ComponentMap, CoreComponent, ModuleSource, WasmConfig};
 use spin_timer::SpinTimerData;
 use spin_trigger::Trigger;
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
         ..Default::default()
     })
     .await?;
-    let trigger = TimerTrigger::new(builder, (), Default::default())?;
+    let trigger = TimerTrigger::new(builder, (), Default::default(), FollowComponents::None)?;
     trigger
         .run(TimerExecutionConfig {
             interval: Duration::from_secs(1),
@@ -61,6 +61,7 @@ impl Trigger for TimerTrigger {
         execution_context: ExecutionContext,
         _: Self::Config,
         _: ComponentMap<Self::ComponentConfig>,
+        _: FollowComponents,
     ) -> Result<Self> {
         Ok(Self {
             engine: Arc::new(execution_context),

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -20,3 +20,4 @@ pub const JSON_MIME_TYPE: &str = "application/json";
 pub const BUILD_UP_OPT: &str = "UP";
 pub const DISABLE_WASMTIME_CACHE: &str = "DISABLE_WASMTIME_CACHE";
 pub const WASMTIME_CACHE_FILE: &str = "WASMTIME_CACHE_FILE";
+pub const FOLLOW_LOG_OPT: &str = "FOLLOW_ID";


### PR DESCRIPTION
Fixes #380.

For discussion and feedback.

The current UI is:

* `spin up ... --follow comp1 --follow comp2` to follow specifically those components
* `spin up ... --follow-all` to follow all components

The current behaviour is the followed component stdout gets redirected to Spin stdout and component stderr to Spin stderr, _unless_ the executor chooses to do things differently.  (WAGI, for example, follows only stderr.)

I feel like there should be scope for simplification, and I'm not quite sure whether I'm passing the follow selection around in an appropriate way.  Also there is a clippy lint that I'm not sure how to address.  Input eagerly requested.

Note: This needs a rebase but I was thinking I'd hold off on that until I've had feedback on whether this is along the right lines - no point ploughing through a rebase if we decide to redesign it!