### PR TITLE
fix(http/router): update router to contain an ordered component map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ name = "spin-manifest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "indexmap",
  "serde",
  "spin-config",
  "thiserror",

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -34,16 +34,13 @@ impl Router {
         Ok(Self { routes })
     }
 
-    // This assumes the order of the components in the app configuration vector
-    // has been preserved, so the routing algorithm, which takes the order into
-    // account, is correct. This seems to be the case with the TOML deserializer,
-    // but might not hold if the application configuration is deserialized in
-    // other ways.
-
+    // This assumes the order of the components in the manifest has been
+    // preserved, so the routing algorithm, which takes the order into account,
+    // is correct.
     /// Returns the component ID that should handle the given path, or an error
     /// if no component matches.
     /// If there are multiple possible components registered for the same route or
-    /// wildcard, this returns the last one in the components vector.
+    /// wildcard, this returns the last entry in the component map.
     pub(crate) fn route(&self, p: &str) -> Result<&str> {
         self.routes
             .iter()

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 
 [dependencies]
+anyhow = "1.0"
+indexmap = "1.6"
 serde = { version = "1.0", features = [ "derive" ] }
 spin-config = { path = "../config" }
-anyhow = "1.0"
 thiserror = "1"

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use spin_config::Resolver;
 use std::{
@@ -19,8 +20,8 @@ pub enum Error {
     InvalidTriggerType,
 }
 
-/// A map of component IDs to some value.
-pub type ComponentMap<T> = HashMap<String, T>;
+/// An ordered map of component IDs to some value.
+pub type ComponentMap<T> = IndexMap<String, T>;
 
 /// Application configuration.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
fix #434 
cc @vdice, @Mossaka 

This commit updates `ComponentMap` to be backed by an `IndexMap` as opposed to
a `HashMap` to preserve the deserialization order from `spin.toml`, which is important
when constructing the HTTP router.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>