### PR TITLE
doc: fix instructions in distributing-apps.md

### DIFF
--- a/docs/content/distributing-apps.md
+++ b/docs/content/distributing-apps.md
@@ -17,13 +17,13 @@ or use the
 VS Code extension (through the `Bindle: Start` command):
 
 ```bash
-$ bindle-server --address 127.0.0.1:8000 --directory .
+$ bindle-server --address 127.0.0.1:8000 --directory . --unauthenticated
 ```
 
 Let's push the application from the [quickstart](./quickstart.md) to the registry:
 
 ```bash
-$ export BINDLE_URL=http://localhost:8080/v1
+$ export BINDLE_URL=http://localhost:8000/v1
 $ spin bindle push --file spin.toml
 pushed: spin-hello-world/1.0.0
 ```


### PR DESCRIPTION
`bindle-server` v0.8 requires an `--unauthenticated` option in order to run
without authentication.  Also, the port used for `BINDLE_URL` didn't match what
was specified in the `bindle-server` command.

Signed-off-by: Joel Dice <joel.dice@gmail.com>