### PR TITLE
perf: reduce peak memory usage and open files when loading bindle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "spin-manifest",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-futures",

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -24,6 +24,7 @@ spin-config = { path = "../config" }
 spin-manifest = { path = "../manifest" }
 tempfile = "3.3.0"
 tokio = { version = "1.11", features = [ "full" ] }
+tokio-util = "0.6"
 toml = "0.5"
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"


### PR DESCRIPTION
This patch does two things:

1. Use `bindle::client::Client::get_parcel_stream` instead of `get_parcel`.  The
latter loads the whole asset into memory, while the former allows us to stream
into a local file chunk-by-chunk.

2. Limit parallel I/O in `spin_loader::bindle::assets::Copier` to avoid
hammering the Bindle server and also avoid running out of file descriptors.

This addresses https://github.com/fermyon/spin/issues/413.

Signed-off-by: Joel Dice <joel.dice@gmail.com>