### PR TITLE
fix(vscode): add templates directory to gopls ignore list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
     "gopls": {
         "build.directoryFilters": [
             "-sdk",
-            "-examples"
+            "-examples",
+            "-templates"
         ],
     },
     "rust-analyzer.files.excludeDirs": [


### PR DESCRIPTION
This commit adds the templates directory to the list of directories that should
be ignored by the Go language server.
This is done in order to avoid errors from the templates filling the error pane
every time the root Spin directory is opened in VS Code.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>