### PR TITLE
Allow parcel ref in component source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,6 +3449,7 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "sha2 0.10.2",
  "spin-build",
  "spin-config",
  "spin-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ wasmtime = "0.34"
 
 [dev-dependencies]
 hyper = { version = "0.14", features = [ "full" ] }
+sha2 = "0.10.1"
 
 [build-dependencies]
 cargo-target-dep = { git = "https://github.com/fermyon/cargo-target-dep", rev = "b7b1989fe0984c0f7c4966398304c6538e52fe49" }

--- a/crates/loader/src/bindle/connection.rs
+++ b/crates/loader/src/bindle/connection.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use bindle::client::{
+    tokens::{HttpBasic, NoToken, TokenManager},
+    Client, ClientBuilder,
+};
+
+/// BindleConnectionInfo holds the details of a connection to a
+/// Bindle server, including url, insecure configuration and an
+/// auth token manager
+#[derive(Clone)]
+pub struct BindleConnectionInfo {
+    base_url: String,
+    allow_insecure: bool,
+    token_manager: AnyAuth,
+}
+
+impl BindleConnectionInfo {
+    /// Generates a new BindleConnectionInfo instance using the provided
+    /// base_url, allow_insecure setting and optional username and password
+    /// for basic http auth
+    pub fn new<I: Into<String>>(
+        base_url: I,
+        allow_insecure: bool,
+        username: Option<String>,
+        password: Option<String>,
+    ) -> Self {
+        let token_manager: Box<dyn TokenManager + Send + Sync> = match (username, password) {
+            (Some(u), Some(p)) => Box::new(HttpBasic::new(&u, &p)),
+            _ => Box::new(NoToken::default()),
+        };
+
+        Self {
+            base_url: base_url.into(),
+            allow_insecure,
+            token_manager: AnyAuth {
+                token_manager: Arc::new(token_manager),
+            },
+        }
+    }
+
+    /// Returns a client based on this instance's configuration
+    pub fn client(&self) -> bindle::client::Result<Client<AnyAuth>> {
+        let builder = ClientBuilder::default()
+            .http2_prior_knowledge(false)
+            .danger_accept_invalid_certs(self.allow_insecure);
+        builder.build(&self.base_url, self.token_manager.clone())
+    }
+}
+
+/// AnyAuth wraps an authentication token manager which applies
+/// the appropriate auth header per its configuration
+#[derive(Clone)]
+pub struct AnyAuth {
+    token_manager: Arc<Box<dyn TokenManager + Send + Sync>>,
+}
+
+#[async_trait::async_trait]
+impl TokenManager for AnyAuth {
+    async fn apply_auth_header(
+        &self,
+        builder: reqwest::RequestBuilder,
+    ) -> bindle::client::Result<reqwest::RequestBuilder> {
+        self.token_manager.apply_auth_header(builder).await
+    }
+}

--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -11,7 +11,7 @@ async fn test_from_local_source() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir).await?;
+    let app = from_file(MANIFEST, dir, &None).await?;
 
     assert_eq!(app.info.name, "spin-local-source-test");
     assert_eq!(app.info.version, "1.0.0");
@@ -145,7 +145,7 @@ async fn test_duplicate_component_id_is_rejected() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir).await;
+    let app = from_file(MANIFEST, dir, &None).await;
 
     assert!(
         app.is_err(),

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Parser};
+use spin_loader::bindle::BindleConnectionInfo;
 use tempfile::TempDir;
 
 use spin_engine::io::FollowComponents;
@@ -133,7 +134,8 @@ impl UpCommand {
                 let manifest_file = app
                     .as_deref()
                     .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
-                spin_loader::from_file(manifest_file, working_dir).await?
+                let bindle_connection = self.bindle_connection();
+                spin_loader::from_file(manifest_file, working_dir, &bindle_connection).await?
             }
             (None, Some(bindle)) => match &self.server {
                 Some(server) => spin_loader::from_bindle(bindle, server, working_dir).await?,
@@ -221,6 +223,12 @@ impl UpCommand {
             let followed = self.opts.follow_components.clone().into_iter().collect();
             FollowComponents::Named(followed)
         }
+    }
+
+    fn bindle_connection(&self) -> Option<BindleConnectionInfo> {
+        self.server
+            .as_ref()
+            .map(|url| BindleConnectionInfo::new(url, false, None, None))
     }
 }
 

--- a/tests/http/simple-spin-rust/spin-from-parcel.toml
+++ b/tests/http/simple-spin-rust/spin-from-parcel.toml
@@ -1,0 +1,18 @@
+spin_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that returns hello and goodbye."
+name = "spin-hello-from-parcel"
+trigger = {type = "http", base = "/test"}
+version = "1.0.0"
+
+[config]
+object = { default = "teapot" }
+
+[[component]]
+id = "hello"
+source = { reference = "spin-hello-world/1.0.0", parcel = "AWAITING_PARCEL_SHA" }
+files = [ { source = "assets", destination = "/" } ]
+[component.trigger]
+route = "/hello/..."
+[component.config]
+message = "I'm a {{object}}"


### PR DESCRIPTION
Fixes #454.

This duplicates the `BindleConnectioninfo` infrastructure from the Hippo CLI and the `bindle push` command.  It looks like the `publish` crate depends on `loader` so we can probably remove it from `publish`, though it feels a bit weird for `loader` to be the one to export it - it's not the obvious place a consumer would look for it.  We should discuss where we want things like this to live.

It may be that there's a nicer way of threading the connection info through the loader - very much open to suggestions here.

~TO DO~ NOW DONE:
* Write some tests
* Beef up the error handling