### PR TITLE
chore(rustfmt): standardize the order of Rust imports

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -2,10 +2,11 @@
 
 //! A library for building Spin components.
 
+use std::path::Path;
+
 use anyhow::{bail, Context, Result};
 use path_absolutize::Absolutize;
 use spin_loader::local::config::{RawAppManifest, RawComponentManifest};
-use std::path::Path;
 use subprocess::{Exec, Redirection};
 use tracing::log;
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7,9 +7,8 @@ mod tree;
 use std::fmt::Debug;
 
 pub use provider::Provider;
-pub use tree::{Tree, TreePath};
-
 use template::{Part, Template};
+pub use tree::{Tree, TreePath};
 
 /// A config resolution error.
 #[derive(Debug, thiserror::Error)]

--- a/crates/engine/src/io.rs
+++ b/crates/engine/src/io.rs
@@ -3,6 +3,7 @@ use std::{
     io::{LineWriter, Write},
     sync::{Arc, RwLock, RwLockReadGuard},
 };
+
 use wasi_common::{
     pipe::{ReadPipe, WritePipe},
     WasiFile,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -7,12 +7,13 @@ pub mod host_component;
 /// Input / Output redirects.
 pub mod io;
 
+use std::{collections::HashMap, io::Write, path::PathBuf, sync::Arc};
+
 use anyhow::{bail, Context, Result};
 use host_component::{HostComponent, HostComponents, HostComponentsState};
 use io::{ModuleIoRedirects, OutputBuffers};
 use spin_config::{host_component::ComponentConfig, Resolver};
 use spin_manifest::{Application, CoreComponent, DirectoryMount, ModuleSource};
-use std::{collections::HashMap, io::Write, path::PathBuf, sync::Arc};
 use tokio::{
     task::JoinHandle,
     time::{sleep, Duration},

--- a/crates/http/benches/baseline.rs
+++ b/crates/http/benches/baseline.rs
@@ -1,7 +1,6 @@
 use std::time::Instant;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-
 use futures::future::join_all;
 use http::Request;
 use spin_http_engine::HttpTrigger;

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -2,11 +2,12 @@
 
 #![deny(missing_docs)]
 
+use std::fmt;
+
 use anyhow::{Context, Result};
 use http::Uri;
 use indexmap::IndexMap;
 use spin_manifest::{ComponentMap, HttpConfig};
-use std::fmt;
 
 /// Router for the HTTP trigger.
 #[derive(Clone, Debug)]

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -1,16 +1,18 @@
-use crate::{
-    spin_http::{Method, SpinHttp},
-    ExecutionContext, HttpExecutor, RuntimeContext,
-};
+use std::{net::SocketAddr, str, str::FromStr};
+
 use anyhow::Result;
 use async_trait::async_trait;
 use http::Uri;
 use hyper::{Body, Request, Response};
 use spin_engine::io::capture_io_to_memory;
-use std::{net::SocketAddr, str, str::FromStr};
 use tokio::task::spawn_blocking;
 use tracing::log;
 use wasmtime::{Instance, Store};
+
+use crate::{
+    spin_http::{Method, SpinHttp},
+    ExecutionContext, HttpExecutor, RuntimeContext,
+};
 
 #[derive(Clone)]
 pub struct SpinHttpExecutor;

--- a/crates/http/src/tls.rs
+++ b/crates/http/src/tls.rs
@@ -1,9 +1,10 @@
-use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::{
     fs, io,
     path::{Path, PathBuf},
     sync::Arc,
 };
+
+use rustls_pemfile::{certs, pkcs8_private_keys};
 use tokio_rustls::{rustls, TlsAcceptor};
 
 /// TLS configuration for the server.

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -1,4 +1,9 @@
-use crate::{routes::RoutePattern, ExecutionContext, HttpExecutor};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{Arc, RwLock, RwLockReadGuard},
+};
+
 use anyhow::Result;
 use async_trait::async_trait;
 use hyper::{body, Body, Request, Response};
@@ -6,14 +11,11 @@ use spin_engine::io::{
     redirect_to_mem_buffer, Follow, ModuleIoRedirects, OutputBuffers, WriteDestinations,
 };
 use spin_manifest::WagiConfig;
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    sync::{Arc, RwLock, RwLockReadGuard},
-};
 use tokio::task::spawn_blocking;
 use tracing::log;
 use wasi_common::pipe::{ReadPipe, WritePipe};
+
+use crate::{routes::RoutePattern, ExecutionContext, HttpExecutor};
 
 #[derive(Clone)]
 pub struct WagiHttpExecutor {

--- a/crates/loader/src/assets.rs
+++ b/crates/loader/src/assets.rs
@@ -1,8 +1,9 @@
 #![deny(missing_docs)]
 
+use std::path::{Path, PathBuf};
+
 use anyhow::{anyhow, bail, Context, Result};
 use sha2::Digest;
-use std::path::{Path, PathBuf};
 use tokio::fs;
 
 /// Create the temporary directory for a component.

--- a/crates/loader/src/bindle/assets.rs
+++ b/crates/loader/src/bindle/assets.rs
@@ -1,16 +1,18 @@
 #![deny(missing_docs)]
 
-use crate::{
-    assets::{create_dir, ensure_under},
-    bindle::utils::BindleReader,
-};
+use std::path::Path;
+
 use anyhow::{anyhow, bail, Context, Result};
 use bindle::{Id, Label};
 use futures::{future, stream, StreamExt, TryStreamExt};
 use spin_manifest::DirectoryMount;
-use std::path::Path;
 use tokio::{fs, io::AsyncWriteExt};
 use tracing::log;
+
+use crate::{
+    assets::{create_dir, ensure_under},
+    bindle::utils::BindleReader,
+};
 
 /// Maximum number of assets to download in parallel
 const MAX_PARALLEL_COPIES: usize = 16;

--- a/crates/loader/src/bindle/config.rs
+++ b/crates/loader/src/bindle/config.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 
 /// Application configuration file format.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -9,10 +9,8 @@ pub mod config;
 /// Bindle helper functions.
 mod utils;
 
-use crate::bindle::{
-    config::{RawAppManifest, RawComponentManifest},
-    utils::{find_manifest, parcels_in_group, BindleReader},
-};
+use std::{path::Path, sync::Arc};
+
 use anyhow::{anyhow, Context, Result};
 use bindle::{
     client::{tokens::NoToken, Client},
@@ -23,9 +21,13 @@ use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, CoreComponent, ModuleSource,
     SpinVersion, WasmConfig,
 };
-use std::{path::Path, sync::Arc};
 use tracing::log;
 pub use utils::{BindleTokenManager, SPIN_MANIFEST_MEDIA_TYPE};
+
+use crate::bindle::{
+    config::{RawAppManifest, RawComponentManifest},
+    utils::{find_manifest, parcels_in_group, BindleReader},
+};
 
 /// Given a Bindle server URL and reference, pull it, expand its assets locally, and get a
 /// prepared application configuration consumable by a Spin execution context.

--- a/crates/loader/src/bindle/utils.rs
+++ b/crates/loader/src/bindle/utils.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs)]
 
+use std::{fmt::Debug, path::Path, sync::Arc};
+
 use anyhow::{anyhow, bail, Context, Error, Result};
 use async_trait::async_trait;
 use bindle::{
@@ -14,7 +16,6 @@ use bindle::{
 use futures::{Stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use reqwest::RequestBuilder;
-use std::{fmt::Debug, path::Path, sync::Arc};
 use tokio::fs;
 use tokio_util::codec::{BytesCodec, FramedRead};
 

--- a/crates/loader/src/local/assets.rs
+++ b/crates/loader/src/local/assets.rs
@@ -1,14 +1,15 @@
 #![deny(missing_docs)]
 
-use crate::assets::{create_dir, ensure_all_under, ensure_under, to_relative};
+use std::path::{Path, PathBuf};
+
 use anyhow::{anyhow, bail, Context, Result};
 use futures::future;
 use spin_manifest::DirectoryMount;
-use std::path::{Path, PathBuf};
 use tracing::log;
 use walkdir::WalkDir;
 
 use super::config::{RawDirectoryPlacement, RawFileMount};
+use crate::assets::{create_dir, ensure_all_under, ensure_under, to_relative};
 
 /// Prepare all local assets given a component ID and its file patterns.
 /// This file will copy all assets into a temporary directory as read-only.

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -4,9 +4,10 @@
 
 #![deny(missing_docs)]
 
+use std::{collections::HashMap, path::PathBuf};
+
 use serde::{Deserialize, Serialize};
 use spin_manifest::{ApplicationTrigger, TriggerConfig};
-use std::{collections::HashMap, path::PathBuf};
 
 /// Container for any version of the manifest.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -10,6 +10,8 @@ pub mod config;
 #[cfg(test)]
 mod tests;
 
+use std::{path::Path, sync::Arc};
+
 use anyhow::{anyhow, bail, Context, Result};
 use config::{RawAppInformation, RawAppManifest, RawAppManifestAnyVersion, RawComponentManifest};
 use futures::future;
@@ -18,7 +20,6 @@ use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, CoreComponent, ModuleSource,
     SpinVersion, WasmConfig,
 };
-use std::{path::Path, sync::Arc};
 use tokio::{fs::File, io::AsyncReadExt};
 
 /// Given the path to a spin.toml manifest file, prepare its assets locally and

--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -1,9 +1,10 @@
-use crate::local::config::{RawDirectoryPlacement, RawFileMount, RawModuleSource};
+use std::path::PathBuf;
 
-use super::*;
 use anyhow::Result;
 use spin_manifest::{HttpConfig, HttpExecutor, HttpTriggerConfiguration};
-use std::path::PathBuf;
+
+use super::*;
+use crate::local::config::{RawDirectoryPlacement, RawFileMount, RawModuleSource};
 
 #[tokio::test]
 async fn test_from_local_source() -> Result<()> {

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -2,15 +2,16 @@
 
 #![deny(missing_docs)]
 
-use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
-use spin_config::Resolver;
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
     path::PathBuf,
     sync::Arc,
 };
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use spin_config::Resolver;
 
 /// A trigger error.
 #[derive(Debug, thiserror::Error)]

--- a/crates/object-store/src/file.rs
+++ b/crates/object-store/src/file.rs
@@ -4,11 +4,12 @@ use std::{
     path::Path,
 };
 
-use crate::wit::spin_object_store;
 use anyhow::Context;
 use cap_std::{ambient_authority, fs::OpenOptions};
 use spin_engine::host_component::{HostComponent, HostComponentsStateHandle};
 use spin_manifest::CoreComponent;
+
+use crate::wit::spin_object_store;
 
 pub struct FileObjectStore {
     root: cap_std::fs::Dir,

--- a/crates/outbound-http/src/lib.rs
+++ b/crates/outbound-http/src/lib.rs
@@ -1,14 +1,14 @@
 mod host_component;
 
+use std::str::FromStr;
+
 use futures::executor::block_on;
+pub use host_component::OutboundHttpComponent;
 use http::HeaderMap;
 use reqwest::{Client, Url};
-use std::str::FromStr;
 use tokio::runtime::Handle;
-use wasi_outbound_http::*;
-
-pub use host_component::OutboundHttpComponent;
 pub use wasi_outbound_http::add_to_linker;
+use wasi_outbound_http::*;
 
 wit_bindgen_wasmtime::export!("../../wit/ephemeral/wasi-outbound-http.wit");
 

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -1,7 +1,6 @@
+pub use outbound_redis::add_to_linker;
 use outbound_redis::*;
 use redis::Commands;
-
-pub use outbound_redis::add_to_linker;
 use spin_engine::{
     host_component::{HostComponent, HostComponentsStateHandle},
     RuntimeContext,

--- a/crates/publish/src/bindle_pusher.rs
+++ b/crates/publish/src/bindle_pusher.rs
@@ -1,8 +1,9 @@
 #![deny(missing_docs)]
 
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use bindle::{standalone::StandaloneRead, Id};
-use std::path::Path;
 
 /// Pushes a standalone bindle to a Bindle server.
 pub async fn push_all(

--- a/crates/publish/src/bindle_writer.rs
+++ b/crates/publish/src/bindle_writer.rs
@@ -1,11 +1,12 @@
 #![deny(missing_docs)]
 
-use anyhow::{Context, Result};
-use bindle::{Invoice, Parcel};
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
 };
+
+use anyhow::{Context, Result};
+use bindle::{Invoice, Parcel};
 
 struct BindleWriter {
     source_dir: PathBuf,

--- a/crates/publish/src/expander.rs
+++ b/crates/publish/src/expander.rs
@@ -1,13 +1,15 @@
 #![deny(missing_docs)]
 
-use crate::bindle_writer::{self, ParcelSources};
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result};
 use bindle::{BindleSpec, Condition, Group, Invoice, Label, Parcel};
 use path_absolutize::Absolutize;
 use semver::BuildMetadata;
 use sha2::{Digest, Sha256};
 use spin_loader::{bindle::config as bindle_schema, local::config as local_schema};
-use std::path::{Path, PathBuf};
+
+use crate::bindle_writer::{self, ParcelSources};
 
 /// Expands a file-based application manifest to a Bindle invoice.
 pub async fn expand_manifest(

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -6,15 +6,15 @@ mod bindle_pusher;
 mod bindle_writer;
 mod expander;
 
-pub use bindle_pusher::push_all;
-pub use bindle_writer::write;
-pub use expander::expand_manifest;
+use std::sync::Arc;
 
 use bindle::client::{
     tokens::{HttpBasic, NoToken, TokenManager},
     Client, ClientBuilder,
 };
-use std::sync::Arc;
+pub use bindle_pusher::push_all;
+pub use bindle_writer::write;
+pub use expander::expand_manifest;
 
 /// BindleConnectionInfo holds the details of a connection to a
 /// Bindle server, including url, insecure configuration and an

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -2,7 +2,8 @@
 
 mod spin;
 
-use crate::spin::SpinRedisExecutor;
+use std::{collections::HashMap, sync::Arc};
+
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -11,7 +12,8 @@ use spin_engine::io::FollowComponents;
 use spin_manifest::{ComponentMap, RedisConfig, RedisTriggerConfiguration};
 use spin_redis::SpinRedisData;
 use spin_trigger::Trigger;
-use std::{collections::HashMap, sync::Arc};
+
+use crate::spin::SpinRedisExecutor;
 
 wit_bindgen_wasmtime::import!("../../wit/ephemeral/spin-redis.wit");
 

--- a/crates/redis/src/spin.rs
+++ b/crates/redis/src/spin.rs
@@ -1,9 +1,10 @@
-use crate::{spin_redis::SpinRedis, ExecutionContext, RedisExecutor, RuntimeContext};
 use anyhow::Result;
 use async_trait::async_trait;
 use spin_engine::io::capture_io_to_memory;
 use tokio::task::spawn_blocking;
 use wasmtime::{Instance, Store};
+
+use crate::{spin_redis::SpinRedis, ExecutionContext, RedisExecutor, RuntimeContext};
 
 #[derive(Clone)]
 pub struct SpinRedisExecutor;

--- a/crates/redis/src/tests.rs
+++ b/crates/redis/src/tests.rs
@@ -1,9 +1,11 @@
-use super::*;
+use std::sync::Once;
+
 use anyhow::Result;
 use spin_manifest::{RedisConfig, RedisExecutor};
 use spin_testing::TestConfig;
 use spin_trigger::build_trigger_from_app;
-use std::sync::Once;
+
+use super::*;
 
 static LOGGER: Once = Once::new();
 

--- a/crates/templates/src/interaction.rs
+++ b/crates/templates/src/interaction.rs
@@ -1,7 +1,7 @@
-use crate::template::{TemplateParameter, TemplateParameterDataType};
-
 // use console::style;
 use dialoguer::Input;
+
+use crate::template::{TemplateParameter, TemplateParameterDataType};
 
 pub(crate) fn prompt_parameter(parameter: &TemplateParameter) -> Option<String> {
     let prompt = parameter.prompt();

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -320,9 +320,8 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use crate::RunOptions;
-
     use super::*;
+    use crate::RunOptions;
 
     struct DiscardingReporter;
 

--- a/examples/spin-timer/src/main.rs
+++ b/examples/spin-timer/src/main.rs
@@ -1,13 +1,14 @@
 // The wit_bindgen_wasmtime::import below is triggering this lint.
 #![allow(clippy::needless_question_mark)]
 
+use std::{sync::Arc, time::Duration};
+
 use anyhow::Result;
 use async_trait::async_trait;
 use spin_engine::{io::FollowComponents, Builder, ExecutionContextConfiguration};
 use spin_manifest::{ComponentMap, CoreComponent, ModuleSource, WasmConfig};
 use spin_timer::SpinTimerData;
 use spin_trigger::Trigger;
-use std::{sync::Arc, time::Duration};
 use tokio::task::spawn_blocking;
 
 wit_bindgen_wasmtime::import!("spin-timer.wit");

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -4,7 +4,6 @@
 
 /// Exports the procedural macros for writing handlers for Spin components.
 pub use spin_macro::*;
-
 /// Exports the experimental outbound HTTP crate.
 pub use wasi_experimental_http as outbound_http;
 

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use clap::Parser;
 use lazy_static::lazy_static;
-
 use spin_cli::commands::{
     bindle::BindleCommands, build::BuildCommand, deploy::DeployCommand, new::NewCommand,
     templates::TemplateCommands, up::UpCommand,

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-
 use spin_loader::local::{config::RawAppManifestAnyVersion, raw_manifest_from_file};
 
 use crate::{

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
-
 use spin_templates::{RunOptions, TemplateManager};
 
 /// Scaffold a new application or component based on a template.

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use comfy_table::Table;
-
 use spin_templates::{
     InstallOptions, InstallationResults, ProgressReporter, SkippedReason, Template,
     TemplateManager, TemplateSource,

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -3,13 +3,12 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Parser};
-use tempfile::TempDir;
-
 use spin_engine::io::FollowComponents;
 use spin_http_engine::{HttpTrigger, HttpTriggerExecutionConfig, TlsConfig};
 use spin_manifest::ApplicationTrigger;
 use spin_redis_engine::RedisTrigger;
 use spin_trigger::{run_trigger, ExecutionOptions};
+use tempfile::TempDir;
 
 use crate::opts::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 pub mod commands;
 pub(crate) mod opts;
 
+use std::path::{Path, PathBuf};
+
 use anyhow::{anyhow, bail, Result};
 use semver::BuildMetadata;
 use spin_manifest::Application;
-use std::path::{Path, PathBuf};
 
 pub(crate) fn app_dir(app_file: impl AsRef<Path>) -> Result<PathBuf> {
     let path_buf = app_file

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,13 +1,14 @@
 #[cfg(test)]
 mod integration_tests {
-    use anyhow::{Context, Result};
-    use hyper::{header::HeaderName, Body, Client, Response};
     use std::{
         ffi::OsStr,
         net::{Ipv4Addr, SocketAddrV4, TcpListener},
         process::{self, Child, Command},
         time::Duration,
     };
+
+    use anyhow::{Context, Result};
+    use hyper::{header::HeaderName, Body, Client, Response};
     use tempfile::TempDir;
     use tokio::{net::TcpStream, time::sleep};
 


### PR DESCRIPTION
This commit updates the order of the Rust imports throughtout the project to be
consistent with — specifically, standard library, external, and crate imports.

The `group_imports=StdExternalCrate` rustfmt setting only works for the nightly
toolchain, so this commit does not enforce it in CI (which would also require
all contributors to run the nightly toolchain to format).

To run the formatter using this setting:

`cargo +nightly fmt --all -- --emit files --config group_imports=StdExternalCrate`

Signed-off-by: Radu Matei <radu.matei@fermyon.com>