### PR TITLE
chore: update to wasmtime v0.35 and wit-bindgen to the newest commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 wasi-outbound-http = { path = "crates/outbound-http" }
-wasmtime = "0.34"
+wasmtime = "0.35"
 
 [dev-dependencies]
 hyper = { version = "0.14", features = [ "full" ] }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 anyhow = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 thiserror = "1"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [dev-dependencies]
 toml = "0.5"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,10 +15,10 @@ tempfile = "3.3.0"
 tokio = { version = "1.10.0", features = [ "fs" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
-wasi-cap-std-sync = "0.34"
-wasi-common = "0.34"
-wasmtime = "0.34"
-wasmtime-wasi = "0.34"
+wasi-cap-std-sync = "0.35"
+wasi-common = "0.35"
+wasmtime = "0.35"
+wasmtime-wasi = "0.35"
 
 [dev-dependencies]
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -37,11 +37,11 @@ tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2"
 wagi = { git = "https://github.com/deislabs/wagi", tag = "v0.8.1" }
-wasi-cap-std-sync = "0.34"
-wasi-common = "0.34"
-wasmtime = "0.34"
-wasmtime-wasi = "0.34"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wasi-cap-std-sync = "0.35"
+wasi-common = "0.35"
+wasmtime = "0.35"
+wasmtime-wasi = "0.35"
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio"] }

--- a/crates/http/benches/spin-http-benchmark/Cargo.toml
+++ b/crates/http/benches/spin-http-benchmark/Cargo.toml
@@ -7,6 +7,6 @@
     crate-type = [ "cdylib" ]
 
 [dependencies]
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/crates/http/tests/rust-http-test/Cargo.toml
+++ b/crates/http/tests/rust-http-test/Cargo.toml
@@ -8,6 +8,6 @@
     crate-type = [ "cdylib" ]
 
 [dependencies]
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/crates/object-store/Cargo.toml
+++ b/crates/object-store/Cargo.toml
@@ -15,5 +15,5 @@ serde = { version = "1.0", features = ["derive"] }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
 tracing = { version = "0.1", features = ["log"] }
-wasmtime = "0.34"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wasmtime = "0.35"
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -20,4 +20,4 @@ tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 url = "2.2.1"
 wasi-experimental-http-wasmtime = { git = "https://github.com/deislabs/wasi-experimental-http", rev = "4ed321d6943f75546e38bba80e14a59797aa29de" }
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -11,4 +11,4 @@ anyhow = "1.0"
 redis = { version = "0.21", features = [ "tokio-comp" ] }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }

--- a/crates/redis/Cargo.toml
+++ b/crates/redis/Cargo.toml
@@ -22,10 +22,10 @@ tokio = { version = "1.14", features = [ "full" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
-wasi-common = "0.34"
-wasmtime = "0.34"
-wasmtime-wasi = "0.34"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wasi-common = "0.35"
+wasmtime = "0.35"
+wasmtime-wasi = "0.35"
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [dev-dependencies]
 spin-testing = { path = "../testing" }

--- a/crates/redis/tests/rust/Cargo.toml
+++ b/crates/redis/tests/rust/Cargo.toml
@@ -8,6 +8,6 @@
     crate-type = [ "cdylib" ]
 
 [dependencies]
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -13,4 +13,4 @@ outbound-redis = { path = "../outbound-redis" }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
 wasi-outbound-http = { path = "../outbound-http" } 
-wasmtime = "0.34"
+wasmtime = "0.35"

--- a/docs/content/extending-and-embedding.md
+++ b/docs/content/extending-and-embedding.md
@@ -32,7 +32,7 @@ defined using
 handle-http-request: function(req: request) -> response
 
 // The entry point for a Redis handler.
-handle-redis-message: function(msg: payload) -> expected<_, error>
+handle-redis-message: function(msg: payload) -> expected<unit, error>
 ```
 
 The entry point we want to execute for our timer trigger takes a string as its

--- a/docs/content/redis-trigger.md
+++ b/docs/content/redis-trigger.md
@@ -48,7 +48,7 @@ format, and is a function that takes the message payload as its only parameter:
 type payload = list<u8>
 
 // The entry point for a Redis handler.
-handle-redis-message: function(msg: payload) -> expected<_, error>
+handle-redis-message: function(msg: payload) -> expected<unit, error>
 ```
 
 > The interface might change in the future to add the Redis instance and

--- a/docs/content/rust-components.md
+++ b/docs/content/rust-components.md
@@ -53,7 +53,7 @@ http = "0.2"
 # The Spin SDK.
 spin-sdk = { git = "https://github.com/fermyon/spin" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 ```
 
 At the time of this writing, `wit-bindgen` must be pinned to a specific `rev`.

--- a/examples/http-rust/Cargo.toml
+++ b/examples/http-rust/Cargo.toml
@@ -16,6 +16,6 @@ http = "0.2"
 # The Spin SDK.
 spin-sdk = { path = "../../sdk/rust", version = "0.1.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/examples/redis-rust/Cargo.toml
+++ b/examples/redis-rust/Cargo.toml
@@ -14,6 +14,6 @@ bytes = "1"
 # The Spin SDK.
 spin-sdk = { path = "../../sdk/rust", version = "0.1.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/examples/rust-outbound-redis/Cargo.toml
+++ b/examples/rust-outbound-redis/Cargo.toml
@@ -16,6 +16,6 @@ http = "0.2"
 # The Spin SDK.
 spin-sdk = { path = "../../sdk/rust" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/examples/spin-timer/Cargo.toml
+++ b/examples/spin-timer/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.14", features = [ "full" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
-wasi-common = "0.34"
-wasmtime = "0.34"
-wasmtime-wasi = "0.34"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wasi-common = "0.35"
+wasmtime = "0.35"
+wasmtime-wasi = "0.35"
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }

--- a/examples/spin-timer/example/Cargo.toml
+++ b/examples/spin-timer/example/Cargo.toml
@@ -7,6 +7,6 @@
     crate-type = [ "cdylib" ]
 
 [dependencies]
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/examples/spin-wagi-http/http-rust/Cargo.toml
+++ b/examples/spin-wagi-http/http-rust/Cargo.toml
@@ -16,6 +16,6 @@ http = "0.2"
 # The Spin SDK.
 spin-sdk = { path = "../../../sdk/rust", version = "0.1.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -12,4 +12,4 @@ bytes = "1"
 http = "0.2"
 spin-macro = {path = "macro"}
 wasi-experimental-http = { git = "https://github.com/deislabs/wasi-experimental-http", rev = "a82ae3d6c85c4251b3663035febeb8100068f51d" }
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }

--- a/sdk/rust/macro/Cargo.toml
+++ b/sdk/rust/macro/Cargo.toml
@@ -14,6 +14,6 @@ http = "0.2"
 proc-macro2 = "1"
 quote = "1.0"
 syn = { version = "1.0", features = [ "full" ]}
-wit-bindgen-gen-rust-wasm = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
-wit-bindgen-gen-core = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-gen-rust-wasm = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
+wit-bindgen-gen-core = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }

--- a/sdk/rust/macro/wit/spin-redis.wit
+++ b/sdk/rust/macro/wit/spin-redis.wit
@@ -1,5 +1,5 @@
 // The entrypoint for a Redis handler.
-handle-redis-message: function(message: payload) -> expected<_, error>
+handle-redis-message: function(message: payload) -> expected<unit, error>
 
 // The message payload.
 type payload = list<u8>

--- a/tests/http/headers-env-routes-test/Cargo.toml
+++ b/tests/http/headers-env-routes-test/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 # The wit-bindgen-rust dependency generates bindings for interfaces.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]
 

--- a/tests/http/simple-spin-rust/Cargo.toml
+++ b/tests/http/simple-spin-rust/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 # The wit-bindgen-rust dependency generates bindings for interfaces.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "458a664bce7b2064d61fbd594efb2673d3130316" }
 
 [workspace]
 

--- a/wit/ephemeral/outbound-redis.wit
+++ b/wit/ephemeral/outbound-redis.wit
@@ -1,10 +1,10 @@
 use * from redis-types
 
 // Publish a Redis message to the specificed channel and return an error, if any.
-publish: function(address: string, channel: string, payload: payload) -> expected<_, error>
+publish: function(address: string, channel: string, payload: payload) -> expected<unit, error>
 
 // Get the value of a key.
 get: function(address: string, key: string) -> expected<payload, error>
 
 // Set key to value. If key alreads holds a value, it is overwritten.
-set: function(address: string, key: string, value: payload) -> expected<_, error>
+set: function(address: string, key: string, value: payload) -> expected<unit, error>

--- a/wit/ephemeral/spin-object-store.wit
+++ b/wit/ephemeral/spin-object-store.wit
@@ -15,11 +15,11 @@ resource object-reader {
 /// And object writer represents a writable object.
 resource object-writer {
     /// Writes data to the given object.
-    write: function(buf: pull-buffer<u8>) -> expected<_, error>
+    write: function(buf: pull-buffer<u8>) -> expected<unit, error>
 
     /// Commits the written data. Until this returns success the state of the
     /// object is unspecified (implementation-specific).
-    commit: function() -> expected<_, error>
+    commit: function() -> expected<unit, error>
 }
 
 /// Prepare an object with the given key to be written. See `object-writer`.
@@ -29,4 +29,4 @@ get-object: function(key: string) -> expected<object-reader, error>
 put-object: function(key: string) -> expected<object-writer, error>
 
 /// Delete the object with the given key.
-delete-object: function(key: string) -> expected<_, error>
+delete-object: function(key: string) -> expected<unit, error>

--- a/wit/ephemeral/spin-redis.wit
+++ b/wit/ephemeral/spin-redis.wit
@@ -1,4 +1,4 @@
 use * from redis-types
 
 // The entrypoint for a Redis handler.
-handle-redis-message: function(message: payload) -> expected<_, error>
+handle-redis-message: function(message: payload) -> expected<unit, error>

--- a/wit/ephemeral/wasi-cache.wit
+++ b/wit/ephemeral/wasi-cache.wit
@@ -5,11 +5,11 @@ use * from types
 // Set the payload for the given key.
 // Implementations may choose to ignore the time-to-live (in seconds) argument.
 // TODO (@radu-matei): perhaps return the number of bytes written?
-set: function(key: string, value: payload, ttl: option<u32>) -> expected<_, error>
+set: function(key: string, value: payload, ttl: option<u32>) -> expected<unit, error>
 
 // Get the payload stored in the cache for the given key.
 // If not found, return a success result with an empty payload.
 get: function(key: string) -> expected<payload, error>
 
 // Delete the cache entry for the given key.
-delete: function(key: string) -> expected<_, error>
+delete: function(key: string) -> expected<unit, error>


### PR DESCRIPTION
This has a dependency on wagi and wasi-experimental-http to update to `wasmtime v0.35`

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>

