### PR TITLE
chore: update Rust crates to v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "outbound-redis"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "redis",
@@ -3414,7 +3414,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-build"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "spin-engine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http-engine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "spin-object-store"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "spin-publish"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "http 0.2.6",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-outbound-http"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-build"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-config"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-engine"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-http-engine"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/http/benches/spin-http-benchmark/Cargo.toml
+++ b/crates/http/benches/spin-http-benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
     name    = "spin-http-benchmark"
-    version = "0.1.0"
+    version = "0.2.0"
     edition = "2021"
 
 [lib]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-loader"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-manifest"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/object-store/Cargo.toml
+++ b/crates/object-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-object-store"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-outbound-http"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outbound-redis"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-publish"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/redis/Cargo.toml
+++ b/crates/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-redis-engine"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-templates"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-testing"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-trigger"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["mossaka <duibao55328@gmail.com>"]
 

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -76,7 +76,7 @@ successful, you should be ready to commit your changes. We try to follow the
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 guidelines for writing commit messages:
 
-```shell
+```bash
 $ git commit -S -s -m "<your commit message that follows https://www.conventionalcommits.org/en/v1.0.0/>"
 ```
 
@@ -86,7 +86,7 @@ often, please
 before opening a pull request. Once you are happy with your changes you can push
 the branch to your fork:
 
-```shell
+```bash
 # "fork" is the name of the git remote pointing to your fork
 $ git push fork
 ```

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -27,11 +27,11 @@ The following illustrates how to define an HTTP application.
 
 #### HTTP Handler
 
-This `hello_world` function written in Rust defines a component that takes an `http::Request`and returns a `Result<http::Response>`.
+This `hello_world` function written in Rust defines a component that takes a `Request` and returns a `Result<Response>`.
 
 ```rust
 #[http_component]​
-fn hello_world(_req: http::Request) -> Result<http::Response> {​
+fn hello_world(_req: Request) -> Result<Response> {​
     Ok(http::Response::builder()​
         .status(200)​
         .body(Some("Hello, Fermyon!".into()))?)​
@@ -60,7 +60,16 @@ route = "/hello"
 
 Running this application with the `spin` CLI is as simple as using the `spin up` command.
 Because a trigger type of `http` is specified in the `spin.toml`, `spin up` will start
-a web server. Any time a request is made on the `/hello` route, it will invoke the
+a web server:
+
+```console
+$ spin up
+Serving HTTP on address http://127.0.0.1:3000
+Available Routes:
+  hello: http://127.0.0.1:3000/hello
+```
+
+Any time a request is made on the `/hello` route, it will invoke the
 `hello_world` function. Adding another component is as simple as adding another `[[component]]`
 stanza to the `spin.toml` file.
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -3,7 +3,6 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 url = "https://github.com/fermyon/spin/blob/main/docs/content/quickstart.md"
-
 ---
 
 > This is an early preview of the Spin project. It is still experimental code,
@@ -17,8 +16,8 @@ You can download the [latest release](https://github.com/fermyon/spin/releases).
 For example, for an M1 macOS machine:
 
 ```
-$ wget https://github.com/fermyon/spin/releases/download/v0.1.0/spin-v0.1.0-macos-aarch64.tar.gz
-$ tar xfv spin-v0.1.0-macos-aarch64.tar.gz
+$ wget https://github.com/fermyon/spin/releases/download/v0.2.0/spin-v0.2.0-macos-aarch64.tar.gz
+$ tar xfv spin-v0.2.0-macos-aarch64.tar.gz
 $ ./spin --help
 ```
 
@@ -36,50 +35,95 @@ accessed from any directory.
 
 ### Linux: Additional Libraries
 
-On a fresh Linux installation, you will also need the standard build toolchain (`gcc`, `make`, etc.), the SSL library headers, and on some distributions you may need `pkg-config`.
+On a fresh Linux installation, you will also need the standard build toolchain
+(`gcc`, `make`, etc.), the SSL library headers, and on some distributions you
+may need `pkg-config`.
 
-On Debian-like distributions, including Ubuntu, you can install these with a command like this:
+On Debian-like distributions, including Ubuntu, you can install these with a
+command like this:
 
 ```console
 $ sudo apt-get install build-essential libssl-dev pkg-config
 ```
 
-## Building the example applications
+## Creating a new Spin application from a template
 
-To build and run the Spin example applications, clone the Spin repository:
+Spin helps you create a new application based on templates:
 
-```
-$ git clone https://github.com/fermyon/spin
-```
-
-Let's explore [the Rust example from the `examples/http-rust` directory](https://github.com/fermyon/spin/tree/main/examples/http-rust):
-
-```
-$ cd examples/http-rust
+```console
+$ spin templates list
+You have no templates installed. Run
+spin templates install --git https://github.com/fermyon/spin
+to install a starter set.
 ```
 
-Here is the `spin.toml`, the definition file for a Spin application:
+We first need to configure the [templates from the Spin repository](https://github.com/fermyon/spin/tree/main/templates):
+
+```console
+$ spin templates install --git https://github.com/fermyon/spin
+Copying remote template source
+Installing template redis-rust...
+Installing template http-rust...
+Installing template http-go...
++--------------------------------------------------+
+| Name         Description                         |
++==================================================+
+| http-go      HTTP request handler using (Tiny)Go |
+| http-rust    HTTP request handler using Rust     |
+| redis-rust   Redis message handler using Rust    |
+| ...                                              |
++--------------------------------------------------+
+```
+
+> The Spin templates experience is still early — if you are interested in
+> writing your own templates, you can follow the existing
+> [templates from the Spin repository](https://github.com/fermyon/spin/tree/main/templates)
+> and the [Spin Improvement Proposal (SIP) for templates](https://github.com/fermyon/spin/pull/273).
+
+Let's create a new Spin application based on the Rust HTTP template:
+
+```console
+$ spin new http-rust
+Project description: A simple Spin HTTP component in Rust
+Project name: spin-hello-world
+HTTP base: /
+HTTP path: /hello
+$ tree
+├── .cargo
+│   └── config.toml
+├── .gitignore
+├── Cargo.toml
+├── spin.toml
+└── src
+    └── lib.rs
+```
+
+This command created all the necessary files we need to build and run our first
+Spin application. Here is `spin.toml`, the manifest file for a Spin application:
 
 ```toml
 spin_version = "1"
+description = "A simple Spin HTTP component in Rust"
 name = "spin-hello-world"
-version = "1.0.0"
 trigger = { type = "http", base = "/" }
+version = "0.1.0"
 
 [[component]]
-id = "hello"
-source = "target/wasm32-wasi/release/spinhelloworld.wasm"
+id = "spin-hello-world"
+source = "target/wasm32-wasi/release/spin_hello_world.wasm"
 [component.trigger]
 route = "/hello"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
 ```
 
 This represents a simple Spin HTTP application (triggered by an HTTP request), with
-a single component called `hello`. Spin will execute the `spinhelloworld.wasm`
+a single component called `spin-hello-world`. Spin will execute the `spin_hello_world.wasm`
 WebAssembly module for HTTP requests on the route `/hello`.
 (See the [configuration document](./configuration.md) for a detailed guide on the Spin
 application manifest.)
 
-Now let's have a look at the `hello` component (`examples/http-rust/src/lib.rs`). Below is the complete source
+Now let's have a look at the code. Below is the complete source
 code for a Spin HTTP component written in Rust — a regular Rust function that
 takes an HTTP request as a parameter and returns an HTTP response, and it is
 annotated with the `http_component` macro:
@@ -93,12 +137,12 @@ use spin_sdk::{
 
 /// A simple Spin HTTP component.
 #[http_component]
-fn hello_world(req: Request) -> Result<Response> {
-    println!("{:?}", req);
+fn spin_hello_world(req: Request) -> Result<Response> {
+    println!("{:?}", req.headers());
     Ok(http::Response::builder()
         .status(200)
         .header("foo", "bar")
-        .body(Some("Hello, Fermyon!".into()))?)
+        .body(Some("Hello, Fermyon".into()))?)
 }
 ```
 
@@ -108,14 +152,22 @@ fn hello_world(req: Request) -> Result<Response> {
 We can build this component using the regular Rust toolchain, targeting
 `wasm32-wasi`, which will produce the WebAssembly module and place it at
 `target/wasm32-wasi/release/spinhelloworld.wasm` as referenced in the
-`spin.toml`:
+`spin.toml`. For convenience, we can use the `spin build` command, which will
+execute the command defined above in `spin.toml` and call the Rust toolchain:
 
-```
-$ cargo build --release
+```console
+$ spin build
+Executing the build command for component spin-hello-world: cargo build --target wasm32-wasi --release
+   Compiling spin_hello_world v0.1.0
+    Finished release [optimized] target(s) in 0.10s
+Successfully ran the build command for the Spin components.
 ```
 
-> We are [working on templates](https://github.com/fermyon/spin/pull/186)
-> to streamline the process of creating new applications.
+> `spin build` can be used to build all components defined in the Spin manifest
+> file at the same time, and also has a flag that starts the application after
+> finishing the compilation, `spin build --up`.
+>
+> For more details, see the [page about developing Spin applications](./developing.md).
 
 ## Running the application with `spin up`
 
@@ -128,7 +180,9 @@ $ export RUST_LOG=spin=trace
 # `spin up` in the example/http-rust directory
 # alternatively, use `spin up --file <path/to/spin.toml>`
 $ spin up
-INFO spin_http_engine: Serving HTTP on address 127.0.0.1:3000
+Serving HTTP on address http://127.0.0.1:3000
+Available Routes:
+  spin-hello-world: http://127.0.0.1:3000/hello
 ```
 
 Spin will instantiate all components from the application manifest, and

--- a/docs/templates/content_top.hbs
+++ b/docs/templates/content_top.hbs
@@ -117,6 +117,16 @@
             document.documentElement.classList.toggle('dark-theme', mode === "dark");
         }
     </script>
+    <script>
+        // Automatically pick up file changes and show them in the browser
+        // without manually refreshing, but only when the host is localhost.
+        var script = document.createElement("script");
+        if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
+            script.src = "https://livejs.com/live.js";
+        }
+        document.head.appendChild(script);
+    </script>
+
 </head>
 <body class="documentation">
 

--- a/examples/http-tinygo/readme.md
+++ b/examples/http-tinygo/readme.md
@@ -6,17 +6,20 @@ This example showcases how to build Spin HTTP components using TinyGo.
 package main
 
 import (
- "fmt"
- "net/http"
+	"fmt"
+	"net/http"
 
- spin_http "github.com/fermyon/spin-sdk"
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
 )
 
-func main() {
- spin_http.HandleRequest(func(w http.ResponseWriter, r *http.Request) {
-  fmt.Fprintln(w, "Hello, Fermyon!")
- })
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, "Hello Fermyon!")
+	})
 }
+
+func main() {}
 ```
 
 > For more information and examples for using TinyGo with WebAssembly, check
@@ -47,7 +50,6 @@ id = "hello"
 source = "main.wasm"
 [component.trigger]
 route = "/hello"
-executor = { type = "wagi" }
 ```
 
 At this point, we can execute the application with the `spin` CLI:
@@ -68,9 +70,3 @@ date: Wed, 09 Mar 2022 17:23:08 GMT
 
 Hello, Fermyon!
 ```
-
-## Notes
-
-- components built using TinyGo will be run in Spin using the Wagi executor
-- any time-consuming work taking place in the `main` function will block the
-  handler function

--- a/examples/tinygo-redis/main.go
+++ b/examples/tinygo-redis/main.go
@@ -9,11 +9,11 @@ import (
 func init() {
 	// redis.Handle() must be called in the init() function.
 	redis.Handle(func(payload []byte) error {
-		fmt.Println("Paylod::::")
+		fmt.Println("Payload::::")
 		fmt.Println(string(payload))
 		return nil
 	})
 }
 
-// main functiion must be included for the compiler but is not executed.
+// main function must be included for the compiler but is not executed.
 func main() {}

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "spin-sdk"
-version = "0.1.0"
+version = "0.2.0"
 
 [lib]
 name = "spin_sdk"


### PR DESCRIPTION
depends on #475 
relevant commit https://github.com/fermyon/spin/commit/7141c6363c20a2c91742561d694bb99fc6ded555

This commit updates the intro, quickstart, and language guides in preparation
for the v0.2 release.
Specifically, it adds information about creating new applications based on
templates, and updates the language guides with guides on using Redis.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>