### PR TITLE
Tweak rust templates

### DIFF
--- a/crates/templates/src/environment.rs
+++ b/crates/templates/src/environment.rs
@@ -25,16 +25,11 @@ pub(crate) async fn get_authors() -> Result<Authors> {
     async fn discover_author() -> Result<(String, Option<String>)> {
         let git_config = find_real_git_config().await;
 
-        let name_variables = [
-            "GIT_AUTHOR_NAME",
-            "GIT_COMMITTER_NAME",
-            "USER",
-            "USERNAME",
-            "NAME",
-        ];
-        let name = get_environment_variable(&name_variables[0..3])
+        let name_variables = ["GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME"];
+        let backup_name_variables = ["USER", "USERNAME", "NAME"];
+        let name = get_environment_variable(&name_variables)
             .or_else(|| git_config.get("user.name").map(|s| s.to_owned()))
-            .or_else(|| get_environment_variable(&name_variables[3..]));
+            .or_else(|| get_environment_variable(&backup_name_variables));
 
         let name = match name {
             Some(name) => name,

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -481,7 +481,7 @@ mod tests {
         let cargo = tokio::fs::read_to_string(content_dir.join("Cargo.toml"))
             .await
             .unwrap();
-        assert!(cargo.contains("name = \"{{project-name | snake_case}}\""));
+        assert!(cargo.contains("name = \"{{project-name | kebab_case}}\""));
     }
 
     #[tokio::test]
@@ -519,6 +519,6 @@ mod tests {
         let cargo = tokio::fs::read_to_string(output_dir.join("Cargo.toml"))
             .await
             .unwrap();
-        assert!(cargo.contains("name = \"my_project\""));
+        assert!(cargo.contains("name = \"my-project\""));
     }
 }

--- a/templates/http-rust/content/Cargo.toml
+++ b/templates/http-rust/content/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{project-name | snake_case}}"
+name = "{{project-name | kebab_case}}"
 authors = ["{{authors}}"]
 description = "{{project-description}}"
 version = "0.1.0"

--- a/templates/redis-rust/content/Cargo.toml
+++ b/templates/redis-rust/content/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{project-name | snake_case}}"
+name = "{{project-name | kebab_case}}"
 authors = ["{{authors}}"]
 description = "{{project-description}}"
 version = "0.1.0"


### PR DESCRIPTION
- Use git `user.name` over `$USER`
- kebab-case crate names
