### PR TITLE
Implement CustomLogPipes for Spin Logging/IO: The Return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,6 +3488,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",
+ "cap-std",
  "dirs 4.0.0",
  "sanitize-filename",
  "spin-config",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -19,6 +19,7 @@ wasi-cap-std-sync = "0.34"
 wasi-common = "0.34"
 wasmtime = "0.34"
 wasmtime-wasi = "0.34"
+cap-std = "0.24.1"
 
 [dev-dependencies]
 wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -9,7 +9,7 @@ pub mod io;
 
 use anyhow::{bail, Context, Result};
 use host_component::{HostComponent, HostComponents, HostComponentsState};
-use io::{ModuleIoRedirects, OutputBuffers, CustomLogPipes};
+use io::{CustomLogPipes, ModuleIoRedirects, OutputBuffers};
 use spin_config::{host_component::ComponentConfig, Resolver};
 use spin_manifest::{Application, CoreComponent, DirectoryMount, ModuleSource};
 use std::{collections::HashMap, io::Write, path::PathBuf, sync::Arc};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -9,7 +9,7 @@ pub mod io;
 
 use anyhow::{bail, Context, Result};
 use host_component::{HostComponent, HostComponents, HostComponentsState};
-use io::{RedirectPipes, OutputBuffers, ModuleIoRedirectsTypes};
+use io::{ModuleIoRedirectsTypes, OutputBuffers, RedirectPipes};
 use spin_config::{host_component::ComponentConfig, Resolver};
 use spin_manifest::{Application, CoreComponent, DirectoryMount, ModuleSource};
 use std::{collections::HashMap, io::Write, path::PathBuf, sync::Arc};
@@ -238,7 +238,7 @@ impl<T: Default> ExecutionContext<T> {
         &self,
         component: &str,
         data: Option<T>,
-        io: Option<Arc<RedirectPipes>>,
+        io: Option<RedirectPipes>,
         env: Option<HashMap<String, String>>,
         args: Option<Vec<String>>,
     ) -> Result<(Store<RuntimeContext<T>>, Instance)> {
@@ -257,7 +257,7 @@ impl<T: Default> ExecutionContext<T> {
     /// Save logs for a given component in the log directory on the host
     pub fn save_output_to_logs(
         &self,
-        io_redirects: impl OutputBuffers,
+        ior: impl OutputBuffers,
         component: &str,
         save_stdout: bool,
         save_stderr: bool,
@@ -293,7 +293,7 @@ impl<T: Default> ExecutionContext<T> {
                 .append(true)
                 .create(true)
                 .open(stdout_filename)?;
-            let contents = io_redirects.stdout();
+            let contents = ior.stdout();
             file.write_all(contents)?;
         }
 
@@ -303,7 +303,7 @@ impl<T: Default> ExecutionContext<T> {
                 .append(true)
                 .create(true)
                 .open(stderr_filename)?;
-            let contents = io_redirects.stderr();
+            let contents = ior.stderr();
             file.write_all(contents)?;
         }
 
@@ -314,7 +314,7 @@ impl<T: Default> ExecutionContext<T> {
         &self,
         component: &Component<T>,
         data: Option<T>,
-        io: Option<Arc<RedirectPipes>>,
+        io: Option<RedirectPipes>,
         env: Option<HashMap<String, String>>,
         args: Option<Vec<String>>,
     ) -> Result<Store<RuntimeContext<T>>> {
@@ -326,8 +326,7 @@ impl<T: Default> ExecutionContext<T> {
             .envs(&env)?;
         match io {
             Some(r) => {
-                let rp = Arc::try_unwrap(r).unwrap();
-                wasi_ctx = wasi_ctx.stderr(rp.stderr).stdout(rp.stdout).stdin(rp.stdin);
+                wasi_ctx = wasi_ctx.stderr(r.stderr).stdout(r.stdout).stdin(r.stdin);
             }
             None => wasi_ctx = wasi_ctx.inherit_stdio(),
         };

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -9,7 +9,7 @@ pub mod io;
 
 use anyhow::{bail, Context, Result};
 use host_component::{HostComponent, HostComponents, HostComponentsState};
-use io::{ModuleIoRedirects, OutputBuffers};
+use io::{ModuleIoRedirects, OutputBuffers, CustomLogPipes};
 use spin_config::{host_component::ComponentConfig, Resolver};
 use spin_manifest::{Application, CoreComponent, DirectoryMount, ModuleSource};
 use std::{collections::HashMap, io::Write, path::PathBuf, sync::Arc};
@@ -35,6 +35,8 @@ pub struct ExecutionContextConfiguration {
     pub log_dir: Option<PathBuf>,
     /// Application configuration resolver.
     pub config_resolver: Option<Arc<Resolver>>,
+    /// Custom log pipes on host.
+    pub custom_log_pipes: Option<CustomLogPipes>,
 }
 
 impl From<Application> for ExecutionContextConfiguration {

--- a/crates/http/benches/spin-http-benchmark/Cargo.lock
+++ b/crates/http/benches/spin-http-benchmark/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http-benchmark"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "wit-bindgen-rust",
 ]

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -32,7 +32,8 @@ impl HttpExecutor for SpinHttpExecutor {
             component
         );
 
-        let (redirects, outputs) = capture_io_to_memory(follow, follow, engine.config.custom_log_pipes.clone());
+        let (redirects, outputs) =
+            capture_io_to_memory(follow, follow, engine.config.custom_log_pipes.clone());
 
         let (store, instance) =
             engine.prepare_component(component, None, Some(redirects), None, None)?;

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -32,7 +32,7 @@ impl HttpExecutor for SpinHttpExecutor {
             component
         );
 
-        let (redirects, outputs) = capture_io_to_memory(follow, follow);
+        let (redirects, outputs) = capture_io_to_memory(follow, follow, engine.config.custom_log_pipes.clone());
 
         let (store, instance) =
             engine.prepare_component(component, None, Some(redirects), None, None)?;

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -131,13 +131,10 @@ impl WagiHttpExecutor {
         let stdout_lock = Arc::new(RwLock::new(stdout_buf));
         let stdout_pipe = WritePipe::from_shared(stdout_lock.clone());
 
-        let (stderr_pipe, stderr_lock) = redirect_to_mem_buffer(Follow::stderr(follow_on_stderr), None);
+        let (stderr_pipe, stderr_lock) =
+            redirect_to_mem_buffer(Follow::stderr(follow_on_stderr), None);
 
-        let rd = ModuleIoRedirects::new(
-            Box::new(stdin),
-            Box::new(stdout_pipe),
-            stderr_pipe,
-        );
+        let rd = ModuleIoRedirects::new(Box::new(stdin), Box::new(stdout_pipe), stderr_pipe);
 
         let h = WagiRedirectReadHandles {
             stdout: stdout_lock,

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -89,7 +89,7 @@ impl HttpExecutor for WagiHttpExecutor {
         let (mut store, instance) = engine.prepare_component(
             component,
             None,
-            Some(Arc::new(redirects)),
+            Some(redirects),
             Some(headers),
             Some(argv.split(' ').map(|s| s.to_owned()).collect()),
         )?;

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -131,12 +131,12 @@ impl WagiHttpExecutor {
         let stdout_lock = Arc::new(RwLock::new(stdout_buf));
         let stdout_pipe = WritePipe::from_shared(stdout_lock.clone());
 
-        let (stderr_pipe, stderr_lock) = redirect_to_mem_buffer(Follow::stderr(follow_on_stderr));
+        let (stderr_pipe, stderr_lock) = redirect_to_mem_buffer(Follow::stderr(follow_on_stderr), None);
 
         let rd = ModuleIoRedirects::new(
             Box::new(stdin),
             Box::new(stdout_pipe),
-            Box::new(stderr_pipe),
+            stderr_pipe,
         );
 
         let h = WagiRedirectReadHandles {

--- a/crates/redis/src/spin.rs
+++ b/crates/redis/src/spin.rs
@@ -23,7 +23,7 @@ impl RedisExecutor for SpinRedisExecutor {
             component
         );
 
-        let (redirects, outputs) = capture_io_to_memory(follow, follow);
+        let (redirects, outputs) = capture_io_to_memory(follow, follow, engine.config.custom_log_pipes.clone());
 
         let (store, instance) =
             engine.prepare_component(component, None, Some(redirects), None, None)?;

--- a/crates/redis/src/spin.rs
+++ b/crates/redis/src/spin.rs
@@ -23,7 +23,8 @@ impl RedisExecutor for SpinRedisExecutor {
             component
         );
 
-        let (redirects, outputs) = capture_io_to_memory(follow, follow, engine.config.custom_log_pipes.clone());
+        let (redirects, outputs) =
+            capture_io_to_memory(follow, follow, engine.config.custom_log_pipes.clone());
 
         let (store, instance) =
             engine.prepare_component(component, None, Some(redirects), None, None)?;

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -3,7 +3,8 @@ use std::{error::Error, path::PathBuf};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use spin_engine::{
-    io::FollowComponents, Builder, Engine, ExecutionContext, ExecutionContextConfiguration,
+    io::{FollowComponents, ModuleIoRedirectsTypes},
+    Builder, Engine, ExecutionContext, ExecutionContextConfiguration,
 };
 use spin_manifest::{Application, ApplicationTrigger, ComponentMap, TriggerConfig};
 
@@ -73,7 +74,7 @@ where
         label: app.info.name,
         log_dir,
         config_resolver: app.config_resolver,
-        ..Default::default()
+        module_io_redirects: ModuleIoRedirectsTypes::default(),
     };
     let mut builder = match wasmtime_config {
         Some(wasmtime_config) => {

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -73,6 +73,7 @@ where
         label: app.info.name,
         log_dir,
         config_resolver: app.config_resolver,
+        ..Default::default()
     };
     let mut builder = match wasmtime_config {
         Some(wasmtime_config) => {


### PR DESCRIPTION
> That's exactly right. If you have your WasiFiles already, you can call `ModuleIoRedirects::new` directly, and pass that to `prepare_component`. (At least, you'll be able to if that PR is accepted.)
> 
> WAGI does this in a very simple form because it needs different behaviour for stdin, and a slightly different interaction with the buffer for stdout. It's really valuable to know that this is more broadly useful as a public customisation point though!

To provide an update on this from #438 (and maybe close that issue soon), it turns out that I couldn't really make the current architecture use our own pipes — As previously implied, the meat and potatoes of logging is done in `execute`:
https://github.com/fermyon/spin/blob/c3ff7d90fe115daa3fa85ce3e626c738e7baef76/crates/http/src/spin.rs#L19-L59

It's there that `capture_io_to_memory`, `prepare_component` (that receives redirects), and, subsequently, `redirect_to_mem_buffer` are called.

Considering our builder is set w/ `with_engine()`, as per:
https://github.com/fermyon/spin/blob/1fbfb23b4e96a580d6d4f4b6d617e916974493f1/crates/engine/src/lib.rs#L103-L119

I tried emulating the work done in `execute` in the `build` stage similar to how the `store` does it:
https://github.com/fermyon/spin/blob/0f51ad0b86b798ae18cb4f211f0c3fcfbbe9a156/crates/engine/src/lib.rs#L304-L316

... but, nothing came of it as `execute` would eventually run and override/never access my `RuntimeContext` WASI context data.

All and all, this PR allows users to set `CustomLogPipes` when creating their `ExecutionContextConfiguration` — these `CustomLogPipes` are later accessed by `execute` and passed in to `capture_io_to_memory` (which has a side-effect on `prepare_component`) providing a good and needed override of Spin's default settings.

_EDIT: For ease of review, I remade this PR ~ my rebases to fix sign-off issues made the previous one (i.e., #471) kind of messy_