### PR TITLE
feat(Makefile): add make doc command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 LOG_LEVEL ?= spin=trace
 CERT_NAME ?= local
+SPIN_DOC_NAME ?= new-doc.md
 
 .PHONY: build
 build:
@@ -21,3 +22,9 @@ tls: ${CERT_NAME}.crt.pem
 
 $(CERT_NAME).crt.pem:
 	openssl req -newkey rsa:2048 -nodes -keyout $(CERT_NAME).key.pem -x509 -days 365 -out $(CERT_NAME).crt.pem
+
+.PHONY: doc
+doc:
+	DATE=$(shell date +%Y-%m-%d)
+	echo "title = \"<insert title here>\"\ntemplate = \"main\"\ndate = \"`date +%Y-%m-%d`\"\n" > docs/content/$(SPIN_DOC_NAME)
+	echo "[extra]\nurl = \"https://github.com/fermyon/spin/blob/main/docs/content/$(SPIN_DOC_NAME)\"\n\n---\n" >> docs/content/$(SPIN_DOC_NAME)


### PR DESCRIPTION
+ adds a `doc` make target that generates a new doc
from template
+ can take name of document on command line optionally
+ usage: SPIN_DOC_NAME=mydocument.md make doc

Signed-off-by: Michelle Dhanani <michelle@fermyon.com>