### PR TITLE
Option to cache files from bindle

### DIFF
--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -22,7 +22,10 @@ use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, CoreComponent, ModuleSource,
     SpinVersion, WasmConfig,
 };
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tracing::log;
 pub(crate) use utils::BindleReader;
 pub use utils::SPIN_MANIFEST_MEDIA_TYPE;
@@ -31,12 +34,17 @@ pub use utils::SPIN_MANIFEST_MEDIA_TYPE;
 /// prepared application configuration consumable by a Spin execution context.
 /// If a directory is provided, use it as the base directory to expand the assets,
 /// otherwise create a new temporary directory.
-pub async fn from_bindle(id: &str, url: &str, base_dst: impl AsRef<Path>) -> Result<Application> {
+pub async fn from_bindle(
+    id: &str,
+    url: &str,
+    cache_dir: &Option<PathBuf>,
+    base_dst: impl AsRef<Path>,
+) -> Result<Application> {
     // TODO
     // Handle Bindle authentication.
     let connection_info = BindleConnectionInfo::new(url, false, None, None);
     let client = connection_info.client()?;
-    let reader = BindleReader::remote(&client, &id.parse()?);
+    let reader = BindleReader::remote(&client, &id.parse()?, cache_dir).await?;
 
     prepare(id, url, &reader, base_dst).await
 }

--- a/crates/loader/src/bindle/utils.rs
+++ b/crates/loader/src/bindle/utils.rs
@@ -4,8 +4,12 @@ use anyhow::{anyhow, bail, Context, Error, Result};
 use bindle::{client::Client, standalone::StandaloneRead, Id, Invoice, Label, Parcel};
 use futures::{Stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
-use std::{fmt::Debug, path::Path, sync::Arc};
-use tokio::fs;
+use std::{
+    fmt::Debug,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tokio::{fs, io::AsyncWriteExt};
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 use super::connection::AnyAuth;
@@ -109,7 +113,7 @@ impl BindleReader {
                 .with_context(|| anyhow!("Error fetching remote parcel {}@{}", bindle_id, id)),
 
             BindleReaderInner::Standalone(s) => {
-                let path = s.parcel_dir.join(format!("{}.dat", id));
+                let path = s.parcel_data_path(id);
                 fs::read(&path).await.with_context(|| {
                     anyhow!(
                         "Error reading standalone parcel {} from {}",
@@ -117,6 +121,23 @@ impl BindleReader {
                         path.display()
                     )
                 })
+            }
+
+            BindleReaderInner::Caching(s, c, bindle_id) => {
+                let path = s.parcel_data_path(id);
+                match fs::read(&path).await {
+                    Ok(contents) => Ok(contents),
+                    Err(_) => {
+                        copy_remote_parcel(c, bindle_id, id, &path).await?;
+                        fs::read(&path).await.with_context(|| {
+                            anyhow!(
+                                "Error reading standalone parcel {} from {}",
+                                id,
+                                path.display()
+                            )
+                        })
+                    }
+                }
             }
         }
     }
@@ -134,7 +155,7 @@ impl BindleReader {
                 .map(|s| s.map_err(Error::from).boxed()),
 
             BindleReaderInner::Standalone(s) => {
-                let path = s.parcel_dir.join(format!("{}.dat", id));
+                let path = s.parcel_data_path(id);
                 let file = fs::File::open(&path).await.with_context(|| {
                     anyhow!(
                         "Error reading standalone parcel {} from {}",
@@ -147,35 +168,61 @@ impl BindleReader {
                     .map_err(Error::from)
                     .boxed())
             }
+
+            BindleReaderInner::Caching(s, c, bindle_id) => {
+                let path = s.parcel_data_path(id);
+                match fs::File::open(&path).await {
+                    Ok(file) => Ok(FramedRead::new(file, BytesCodec::new())
+                        .map_ok(bytes::BytesMut::freeze)
+                        .map_err(Error::from)
+                        .boxed()),
+                    Err(_) => {
+                        copy_remote_parcel(c, bindle_id, id, &path).await?;
+                        let file = fs::File::open(&path).await.with_context(|| {
+                            anyhow!(
+                                "Error reading standalone parcel {} from {}",
+                                id,
+                                path.display()
+                            )
+                        })?;
+                        Ok(FramedRead::new(file, BytesCodec::new())
+                            .map_ok(bytes::BytesMut::freeze)
+                            .map_err(Error::from)
+                            .boxed())
+                    }
+                }
+            }
         }
     }
 
     /// Get the invoice from the bindle source
     pub(crate) async fn get_invoice(&self) -> Result<Invoice> {
         match &self.inner {
-            BindleReaderInner::Remote(c, id) => c
-                .get_invoice(id)
-                .await
-                .with_context(|| anyhow!("Error fetching remote invoice {}", id)),
+            BindleReaderInner::Remote(c, id) => get_invoice_from_remote(c, id).await,
 
-            BindleReaderInner::Standalone(s) => {
-                let bytes = fs::read(&s.invoice_file).await.with_context(|| {
-                    anyhow!(
-                        "Error reading bindle invoice rom '{}'",
-                        s.invoice_file.display()
-                    )
-                })?;
-                toml::from_slice(&bytes).with_context(|| {
-                    anyhow!(
-                        "Error parsing file '{}' as invoice",
-                        s.invoice_file.display()
-                    )
-                })
+            BindleReaderInner::Standalone(s) => get_invoice_from_standalone(&s.invoice_file).await,
+
+            BindleReaderInner::Caching(s, c, id) => {
+                match get_invoice_from_standalone(&s.invoice_file).await {
+                    Ok(inv) => Ok(inv),
+                    Err(_) => backfill_invoice(s, c, id).await,
+                }
             }
         }
     }
 
-    pub(crate) fn remote(c: &Client<AnyAuth>, id: &Id) -> Self {
+    pub(crate) async fn remote(
+        c: &Client<AnyAuth>,
+        id: &Id,
+        cache_dir: &Option<PathBuf>,
+    ) -> Result<Self> {
+        match cache_dir {
+            None => Ok(Self::remote_only(c, id)),
+            Some(path) => Self::caching(c, id, path).await,
+        }
+    }
+
+    pub(crate) fn remote_only(c: &Client<AnyAuth>, id: &Id) -> Self {
         Self {
             inner: BindleReaderInner::Remote(c.clone(), id.clone()),
         }
@@ -188,12 +235,91 @@ impl BindleReader {
             inner: BindleReaderInner::Standalone(Arc::new(s)),
         })
     }
+
+    pub(crate) async fn caching(
+        c: &Client<AnyAuth>,
+        bindle_id: &Id,
+        cache_dir: &Path,
+    ) -> Result<Self> {
+        tokio::fs::create_dir_all(cache_dir)
+            .await
+            .with_context(|| format!("Failed to create cache dir {}", cache_dir.display()))?;
+        let s = StandaloneLayout::new(cache_dir, bindle_id).await?;
+        Ok(Self {
+            inner: BindleReaderInner::Caching(Arc::new(s), c.clone(), bindle_id.clone()),
+        })
+    }
+}
+
+struct StandaloneLayout {
+    invoice_file: PathBuf,
+    parcel_dir: PathBuf,
+}
+
+impl StandaloneLayout {
+    pub async fn new(base_path: &Path, id: &Id) -> anyhow::Result<Self> {
+        let path = base_path.join(id.sha());
+        tokio::fs::create_dir_all(&path).await.with_context(|| {
+            format!(
+                "Failed to create cache directory {} for {}",
+                path.display(),
+                id
+            )
+        })?;
+        let invoice_file = path.join(bindle::standalone::INVOICE_FILE);
+        let parcel_dir = path.join(bindle::standalone::PARCEL_DIR);
+        Ok(Self {
+            invoice_file,
+            parcel_dir,
+        })
+    }
+
+    pub fn parcel_data_path(&self, parcel_id: &str) -> PathBuf {
+        self.parcel_dir.join(format!("{}.dat", parcel_id))
+    }
+}
+
+async fn get_invoice_from_remote(c: &Client<AnyAuth>, id: &Id) -> Result<Invoice, Error> {
+    c.get_invoice(id)
+        .await
+        .with_context(|| anyhow!("Error fetching remote invoice {}", id))
+}
+
+async fn get_invoice_from_standalone(invoice_file: &Path) -> Result<Invoice, Error> {
+    let bytes = fs::read(invoice_file).await.with_context(|| {
+        anyhow!(
+            "Error reading bindle invoice rom '{}'",
+            invoice_file.display()
+        )
+    })?;
+    toml::from_slice(&bytes)
+        .with_context(|| anyhow!("Error parsing file '{}' as invoice", invoice_file.display()))
+}
+
+async fn backfill_invoice(
+    s: &Arc<StandaloneLayout>,
+    c: &Client<AnyAuth>,
+    id: &Id,
+) -> Result<Invoice> {
+    let invoice = get_invoice_from_remote(c, id).await?;
+    write_invoice_file(s, &invoice).await?; // TODO: Should we ignore this?
+    Ok(invoice)
+}
+
+async fn write_invoice_file(s: &Arc<StandaloneLayout>, invoice: &Invoice) -> Result<()> {
+    let invoice_text = toml::to_string_pretty(invoice)?;
+    let invoice_file = &s.invoice_file;
+    tokio::fs::write(invoice_file, &invoice_text)
+        .await
+        .with_context(|| format!("Failed to cache invoice to '{}'", invoice_file.display()))?;
+    Ok(())
 }
 
 #[derive(Clone)]
 enum BindleReaderInner {
     Standalone(Arc<StandaloneRead>),
     Remote(Client<AnyAuth>, Id),
+    Caching(Arc<StandaloneLayout>, Client<AnyAuth>, Id),
 }
 
 impl Debug for BindleReaderInner {
@@ -201,6 +327,46 @@ impl Debug for BindleReaderInner {
         match self {
             Self::Standalone(_) => f.debug_tuple("Standalone").finish(),
             Self::Remote(_, _) => f.debug_tuple("Remote").finish(),
+            Self::Caching(..) => f.debug_tuple("Caching").finish(),
         }
     }
+}
+
+pub(crate) async fn copy_remote_parcel(
+    client: &Client<AnyAuth>,
+    bindle_id: &Id,
+    sha: &str,
+    to: &Path,
+) -> anyhow::Result<()> {
+    let mut stream = client
+        .get_parcel_stream(bindle_id, sha)
+        .await
+        .with_context(|| anyhow!("Failed to fetch asset parcel '{}@{}'", bindle_id, sha))?;
+
+    fs::create_dir_all(to.parent().expect("Cannot copy to file '/'")).await?;
+
+    let mut file = fs::File::create(to).await.with_context(|| {
+        anyhow!(
+            "Failed to create local file for asset parcel '{}@{}'",
+            bindle_id,
+            sha
+        )
+    })?;
+
+    while let Some(chunk) = stream
+        .try_next()
+        .await
+        .with_context(|| anyhow!("Failed to read asset parcel '{}@{}'", bindle_id, sha))?
+    {
+        file.write_all(&chunk).await.with_context(|| {
+            anyhow!(
+                "Failed to write asset parcel '{}@{}' to {}",
+                bindle_id,
+                sha,
+                to.display()
+            )
+        })?;
+    }
+
+    Ok(())
 }

--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -11,7 +11,7 @@ async fn test_from_local_source() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir, &None).await?;
+    let app = from_file(MANIFEST, dir, &None, &None).await?;
 
     assert_eq!(app.info.name, "spin-local-source-test");
     assert_eq!(app.info.version, "1.0.0");
@@ -145,7 +145,7 @@ async fn test_duplicate_component_id_is_rejected() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir, &None).await;
+    let app = from_file(MANIFEST, dir, &None, &None).await;
 
     assert!(
         app.is_err(),

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -105,6 +105,10 @@ pub struct UpOpts {
     )]
     pub cache: Option<PathBuf>,
 
+    /// Directory in which to cache Bindle assets.
+    #[clap(long = "bindle-cache-dir")]
+    pub bindle_cache_dir: Option<PathBuf>,
+
     /// Print output for given component(s) to stdout/stderr
     #[clap(
         name = FOLLOW_LOG_OPT,
@@ -135,10 +139,24 @@ impl UpCommand {
                     .as_deref()
                     .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
                 let bindle_connection = self.bindle_connection();
-                spin_loader::from_file(manifest_file, working_dir, &bindle_connection).await?
+                spin_loader::from_file(
+                    manifest_file,
+                    working_dir,
+                    &bindle_connection,
+                    &self.opts.bindle_cache_dir,
+                )
+                .await?
             }
             (None, Some(bindle)) => match &self.server {
-                Some(server) => spin_loader::from_bindle(bindle, server, working_dir).await?,
+                Some(server) => {
+                    spin_loader::from_bindle(
+                        bindle,
+                        server,
+                        &self.opts.bindle_cache_dir,
+                        working_dir,
+                    )
+                    .await?
+                }
                 _ => bail!("Loading from a bindle requires a Bindle server URL"),
             },
             (Some(_), Some(_)) => bail!("Specify only one of app file or bindle ID"),


### PR DESCRIPTION
Fixes #455.

This feels pretty untidy in places.  If anyone has thoughts on how it could be tidied, I'd really appreciate it!

I did wonder about sticking the cache option into the `BindleConnectionInfo` so it flowed without changing so many things, but I'm not sure that feels quite right...