### PR TITLE
Update templates to 0.2.0 SDKs

### DIFF
--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.0.0-20220505044303-556ed2698823 // indirect
+require github.com/fermyon/spin/sdk/go v0.2.0

--- a/templates/http-go/content/go.sum
+++ b/templates/http-go/content/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.0.0-20220505044303-556ed2698823 h1:dPblUT12WHpFgO/AvkfjqVIebQmHW81jeakKXcp4x0Y=
-github.com/fermyon/spin/sdk/go v0.0.0-20220505044303-556ed2698823/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.2.0 h1:qIn8NTlOPHIaZow52zm2KznaowZSzhfuf4akpgMLNUw=
+github.com/fermyon/spin/sdk/go v0.2.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/templates/http-rust/content/Cargo.toml
+++ b/templates/http-rust/content/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 # General-purpose crate with common HTTP types.
 http = "0.2"
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "canary" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.2.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e9c7c0a3405845cecd3fe06f3c20ab413302fc73" }
 

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.0.0-20220511213302-98028d235038 // indirect
+require github.com/fermyon/spin/sdk/go v0.2.0

--- a/templates/redis-go/content/go.sum
+++ b/templates/redis-go/content/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.0.0-20220511213302-98028d235038 h1:426G1brfKeAJFvSXHnXbihXfqHgnA71XFNL6dhtsM2o=
-github.com/fermyon/spin/sdk/go v0.0.0-20220511213302-98028d235038/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.2.0 h1:qIn8NTlOPHIaZow52zm2KznaowZSzhfuf4akpgMLNUw=
+github.com/fermyon/spin/sdk/go v0.2.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/templates/redis-rust/content/Cargo.toml
+++ b/templates/redis-rust/content/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 # Logging
 log = { version = "0.4", default-features = false }
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "canary" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.2.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e9c7c0a3405845cecd3fe06f3c20ab413302fc73" }
 


### PR DESCRIPTION
~Go templates need testing after Go package tag applied to Spin repo.~

Now working for me.  If other folks want to double check, checkout and `spin templates install --dir . --update` to ensure you have the latest.