### PR TITLE
fix(ci/release): update capitalization of `README.md` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
     branches: [main]
     paths-ignore:
       - "docs/**"
-      - "readme.md"
+      - "README.md"
 env:
   CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,18 +102,18 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           mkdir _dist
-          cp readme.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
+          cp README.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
           cd _dist
-          tar czf spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz readme.md LICENSE spin${{ matrix.config.extension }}
+          tar czf spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz README.md LICENSE spin${{ matrix.config.extension }}
 
       - name: package release assets
         if: runner.os == 'Windows'
         shell: bash
         run: |
           mkdir _dist
-          cp readme.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
+          cp README.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
           cd _dist
-          7z a -tzip spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip readme.md LICENSE spin${{ matrix.config.extension }}
+          7z a -tzip spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip README.md LICENSE spin${{ matrix.config.extension }}
 
       - name: upload binary as GitHub artifact
         if: runner.os != 'Windows'


### PR DESCRIPTION
ref #487 
cc @michelleN 

A recent commit renamed `readme.md` to `README.md`, which conflicts with the
release job in CI.
This commit updates the CI job to reference the new `README.md` file.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>