### PR TITLE
ci: support automatically release checksums and binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,12 +124,28 @@ jobs:
           name: spin
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
+      - name: upload binary to Github release
+        if: startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          tag: ${{ github.ref }}
+
       - name: upload binary as GitHub artifact
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v3
         with:
           name: spin
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
+
+      - name: upload binary to Github release
+        if: startsWith(github.ref, 'refs/tags/v') &&  runner.os == 'Windows'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
+          tag: ${{ github.ref }}
 
   checksums:
     name: generate release checksums
@@ -158,6 +174,15 @@ jobs:
         with:
           name: spin
           path: checksums-${{ env.RELEASE_VERSION }}.txt
+
+      - name: upload checksums to Github release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: checksums-${{ env.RELEASE_VERSION }}.txt
+          tag: ${{ github.ref }}
+
 
   update-canary:
     name: update canary release

--- a/docs/content/release-process.md
+++ b/docs/content/release-process.md
@@ -20,10 +20,8 @@ To cut a release of Spin, you will need to do the following:
    - This will trigger a release build
 1. Wait for the `release`
    [action](https://github.com/fermyon/spin/actions/workflows/release.yaml) to
-   complete, and download the binary artifacts and checksums that are generated
-   by that action.
+   complete, binary artifacts and checksums will be automatically uploaded.
 1. Go to the GitHub [tags page](https://github.com/fermyon/spin/releases),
-   create a release, add the release notes, and upload the binaries and
-   checksums you downloaded above.
+   edit a release, add the release notes.
 
 At this point, you can verify in the GitHub UI that the release was successful.


### PR DESCRIPTION
Resolve: https://github.com/fermyon/spin/issues/483

see: https://github.com/Xunzhuo/spin/releases/tag/v0.5.0

Signed-off-by: Xunzhuo <mixdeers@gmail.com>