### PR TITLE
chore: update `outbound-http` crate deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,7 +4504,7 @@ dependencies = [
  "url-escape",
  "wasi-cap-std-sync",
  "wasi-common",
- "wasi-experimental-http-wasmtime 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi-experimental-http-wasmtime",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-wasi",
@@ -4655,25 +4655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi-experimental-http-wasmtime"
-version = "0.9.0"
-source = "git+https://github.com/deislabs/wasi-experimental-http?rev=9a143fa7d8be2a66d6d636c5c1b0c6e2bad68912#9a143fa7d8be2a66d6d636c5c1b0c6e2bad68912"
-dependencies = [
- "anyhow",
- "bytes 1.1.0",
- "futures",
- "http 0.2.6",
- "reqwest",
- "thiserror",
- "tokio",
- "tracing",
- "url 2.2.2",
- "wasi-common",
- "wasmtime",
- "wasmtime-wasi",
-]
-
-[[package]]
 name = "wasi-outbound-http"
 version = "0.2.0"
 dependencies = [
@@ -4688,7 +4669,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url 2.2.2",
- "wasi-experimental-http-wasmtime 0.9.0 (git+https://github.com/deislabs/wasi-experimental-http?rev=9a143fa7d8be2a66d6d636c5c1b0c6e2bad68912)",
+ "wasi-experimental-http-wasmtime",
  "wit-bindgen-wasmtime",
 ]
 

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -19,5 +19,5 @@ tokio = { version = "1.4.0", features = [ "full" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 url = "2.2.1"
-wasi-experimental-http-wasmtime = { git = "https://github.com/deislabs/wasi-experimental-http", rev = "9a143fa7d8be2a66d6d636c5c1b0c6e2bad68912" }
+wasi-experimental-http-wasmtime = "0.9.0"
 wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }


### PR DESCRIPTION
Updates the `outbound-http` crate to use `wasi-experimental-http-wasmtime` release (`0.9.0`) instead of a specific revision.

Context: I'm packaging `spin` on [nixpkgs](https://github.com/nixos/nixpkgs), which relies on [Cargo vendor to succeed](https://github.com/NixOS/nixpkgs/issues/30742#issuecomment-603587399). Running `cargo vendor` currently yields an error:

```
Caused by:
  found duplicate version of package `wasi-experimental-http-wasmtime v0.9.0` vendored from two sources:

      source 1: registry `crates-io`
      source 2: https://github.com/deislabs/wasi-experimental-http?rev=9a143fa7d8be2a66d6d636c5c1b0c6e2bad68912#9a143fa7
```

This PR should fix that!