### PR TITLE
Update ID of rust-analyzer extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "matklad.rust-analyzer",
+        "rust-lang.rust-analyzer",
         "serayuzgur.crates",
         "fermyon.autobindle",
     ]


### PR DESCRIPTION
Because it changed.