### PR TITLE
feat: add workdir for component build command

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -91,35 +91,3 @@ fn construct_workdir(src: impl AsRef<Path>, workdir: Option<impl AsRef<Path>>) -
 
     Ok(cwd)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_construct_workdir() {
-        /// Compares paths with `strip_prefix` instead of `==` to avoid handling
-        /// different operating systems separately.
-        fn assert_workdir(
-            src: impl AsRef<Path>,
-            workdir_param: Option<impl AsRef<Path>>,
-            expected: impl AsRef<Path>,
-        ) {
-            let got = construct_workdir(src.as_ref(), workdir_param.as_ref()).unwrap();
-            assert_eq!(
-                got.strip_prefix(expected.as_ref()),
-                Ok(Path::new("")),
-                "{:?} != {:?}",
-                got,
-                expected.as_ref(),
-            )
-        }
-
-        let src = Path::new("/home/alice/app/spin.toml");
-        assert_workdir(src, None::<PathBuf>, "/home/alice/app");
-        assert_workdir(src, Some("foo/bar"), "/home/alice/app/foo/bar");
-        assert_workdir(src, Some("../other-app"), "/home/alice/other-app");
-
-        assert!(construct_workdir(src, Some("/etc")).is_err());
-    }
-}

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -39,7 +39,7 @@ async fn build_component(raw: RawComponentManifest, src: impl AsRef<Path>) -> Re
                 raw.id, b.command
             );
             let workdir = construct_workdir(src.as_ref(), b.workdir.as_ref())?;
-            if !src.as_ref().starts_with(workdir.as_path()) {
+            if b.workdir.is_some() {
                 println!("Working directory: {:?}", workdir);
             }
 

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -82,8 +82,11 @@ fn construct_workdir(src: impl AsRef<Path>, workdir: Option<impl AsRef<Path>>) -
         .to_path_buf();
 
     if let Some(workdir) = workdir {
-        if !workdir.as_ref().is_relative() {
-            bail!("The workdir is not relative.");
+        // Using `Path::has_root` as `is_relative` and `is_absolute` have
+        // surprising behavior on Windows, see:
+        // https://doc.rust-lang.org/std/path/struct.Path.html#method.is_absolute
+        if workdir.as_ref().has_root() {
+            bail!("The workdir specified in the application file must be relative.");
         }
         cwd.push(workdir);
         cwd = cwd.absolutize()?.to_path_buf();

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -80,6 +80,9 @@ pub struct RawComponentManifest {
 pub struct RawBuildConfig {
     /// Build command.
     pub command: String,
+    /// Working directory in which the build command is executed. It must be
+    /// relative to the directory in which `spin.toml` is located.
+    pub workdir: Option<PathBuf>,
 }
 
 /// WebAssembly configuration.


### PR DESCRIPTION
Fixes #406

If `workdir` is not relative an error is returned, assuming it's best to abort
on encountering an invalid value in the configuration. Alternatively, an invalid
`workdir` could be ignored and a warning be logged.

Specifying a `workdir` which is not a subdirectory of `src` is currently
allowed, for example `../other-app`. I'm assuming that's okay since
users should inspect `spin.toml` anyway before running spin (e.g. to check if
they really want to execute the build command).

# Example usage
```
mkdir examples/foo
cp examples/http-rust/spin.toml examples/foo
```

In `examples/foo/spin.toml` updated resp. add the following:
```toml
source = "../http-rust/target/wasm32-wasi/release/spinhelloworld.wasm"

# under [component.build] add
workdir = "../http-rust"
```

After building `spin` with these changes, it is possible to:
```
cd examples/foo && spin build
```


Signed-off-by: Moritz <moritz.zielke@gmail.com>