### PR TITLE
Install stable templates if using stable build

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -60,7 +60,7 @@ to install a starter set.
 We first need to configure the [templates from the Spin repository](https://github.com/fermyon/spin/tree/main/templates):
 
 ```console
-$ spin templates install --git https://github.com/fermyon/spin
+$ spin templates install --git https://github.com/fermyon/spin --branch v0.2.0
 Copying remote template source
 Installing template redis-rust...
 Installing template http-rust...
@@ -74,6 +74,9 @@ Installing template http-go...
 | ...                                              |
 +--------------------------------------------------+
 ```
+
+> If you downloaded the canary build instead of the release build, leave off the `--branch`
+> flag in `spin templates install`.
 
 > The Spin templates experience is still early — if you are interested in
 > writing your own templates, you can follow the existing


### PR DESCRIPTION
This is a partial fix for #517.

It's partial because we need a longer term strategy for things like this, whether that's keeping `HEAD` on the 'stable' branch or auto inferring the matching tag or what.  Perhaps a topic for the Spin meeting.  It's also partial because it's not sustainable, we don't want to have to rev this as part of every release!

Is it possible to get this fix rolled out to the 0.2.0 docs site, please?