### PR TITLE
ci(*): add docs site content check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,3 +121,18 @@ jobs:
       - name: "Test Go SDK"
         if: ${{ matrix.config.platformAgnosticChecks }}
         run: make test-sdk-go
+
+  check-docs:
+    name: Check Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install bart
+        run: |
+          curl -LOs https://github.com/fermyon/bartholomew/releases/download/v0.3.0/bart
+          chmod +x bart
+          mv bart /usr/local/bin
+
+      - name: Check docs site content
+        run: make check-content

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ doc:
 	DATE=$(shell date --utc +%Y-%m-%dT%TZ)
 	echo "title = \"<insert title here>\"\ntemplate = \"main\"\ndate = \"`date --utc +%Y-%m-%dT%TZ`\"\n" > docs/content/$(SPIN_DOC_NAME)
 	echo "[extra]\nurl = \"https://github.com/fermyon/spin/blob/main/docs/content/$(SPIN_DOC_NAME)\"\n\n---\n" >> docs/content/$(SPIN_DOC_NAME)
+
+.PHONY: check-content
+check-content:
+	cd docs && bart check content/* && bart check content/**/*


### PR DESCRIPTION
* adds a `check-content` make target (and corresponding step in the GH build.yml workflow) using [bart](https://github.com/fermyon/bartholomew#the-bartholomew-cli) to check the markdown content/templating for the spin docs