### PR TITLE
fix(Makefile): fix doc target to use date with suitable value for bart/handlebars templating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ $(CERT_NAME).crt.pem:
 
 .PHONY: doc
 doc:
-	DATE=$(shell date +%Y-%m-%d)
-	echo "title = \"<insert title here>\"\ntemplate = \"main\"\ndate = \"`date +%Y-%m-%d`\"\n" > docs/content/$(SPIN_DOC_NAME)
+	DATE=$(shell date --utc +%Y-%m-%dT%TZ)
+	echo "title = \"<insert title here>\"\ntemplate = \"main\"\ndate = \"`date --utc +%Y-%m-%dT%TZ`\"\n" > docs/content/$(SPIN_DOC_NAME)
 	echo "[extra]\nurl = \"https://github.com/fermyon/spin/blob/main/docs/content/$(SPIN_DOC_NAME)\"\n\n---\n" >> docs/content/$(SPIN_DOC_NAME)


### PR DESCRIPTION
* Updates the `doc` make target to use a suitable datestamp for new docs

See also https://github.com/fermyon/spin/pull/526

Before:

```
$ make doc
DATE=2022-05-26
echo "title = \"<insert title here>\"\ntemplate = \"main\"\ndate = \"`date +%Y-%m-%d`\"\n" > docs/content/new-doc.md
echo "[extra]\nurl = \"https://github.com/fermyon/spin/blob/main/docs/content/new-doc.md\"\n\n---\n" >> docs/content/new-doc.md

$ cd docs && bart check content/*
✅ content/architecture.md
✅ content/configuration.md
✅ content/contributing.md
✅ content/deploying-to-hippo.md
✅ content/developing.md
✅ content/distributing-apps.md
✅ content/extending-and-embedding.md
✅ content/go-components.md
✅ content/http-trigger.md
✅ content/index.md
❌ content/new-doc.md	Could not parse file "content/new-doc.md": TOML parsing error: input is not enough for unique date and time for key `date` at line 3 column 8
✅ content/other-languages.md
✅ content/quickstart.md
✅ content/redis-trigger.md
✅ content/release-process.md
✅ content/rust-components.md
✅ content/template-authoring.md
✅ content/url-shortener.md
Error: One or more pieces of content are invalid
```

After:
```
$ make doc
DATE=2022-05-26T21:15:41Z
echo "title = \"<insert title here>\"\ntemplate = \"main\"\ndate = \"`date --utc +%Y-%m-%dT%TZ`\"\n" > docs/content/new-doc.md
echo "[extra]\nurl = \"https://github.com/fermyon/spin/blob/main/docs/content/new-doc.md\"\n\n---\n" >> docs/content/new-doc.md

$ cd docs && bart check content/*
✅ content/architecture.md
✅ content/configuration.md
✅ content/contributing.md
✅ content/deploying-to-hippo.md
✅ content/developing.md
✅ content/distributing-apps.md
✅ content/extending-and-embedding.md
✅ content/go-components.md
✅ content/http-trigger.md
✅ content/index.md
✅ content/new-doc.md
✅ content/other-languages.md
✅ content/quickstart.md
✅ content/redis-trigger.md
✅ content/release-process.md
✅ content/rust-components.md
✅ content/template-authoring.md
✅ content/url-shortener.md
```