### PR TITLE
chore(*): address clippy errors

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -123,7 +123,7 @@ impl Resolver {
 }
 
 /// A config key.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Key<'a>(&'a str);
 
 impl<'a> Key<'a> {

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -4,7 +4,7 @@ use crate::{Error, Result};
 
 /// Template represents a simple string template that allows expressions in
 /// double curly braces, similar to Mustache or Liquid.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Template(Vec<Part>);
 
 impl Template {
@@ -54,7 +54,7 @@ impl Display for Template {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Part {
     Lit(Box<str>),
     Expr(Box<str>),

--- a/crates/config/src/tree.rs
+++ b/crates/config/src/tree.rs
@@ -134,7 +134,7 @@ impl TryFrom<String> for TreePath {
     }
 }
 
-#[derive(Clone, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(into = "RawSlot", try_from = "RawSlot")]
 pub(crate) struct Slot {
     pub secret: bool,
@@ -193,10 +193,10 @@ impl std::fmt::Debug for Slot {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Eq, PartialEq)]
 pub struct RawSection(pub HashMap<String, RawSlot>);
 
-#[derive(Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RawSlot {
     pub default: Option<String>,

--- a/crates/engine/src/host_component.rs
+++ b/crates/engine/src/host_component.rs
@@ -30,9 +30,9 @@ pub(crate) struct HostComponents {
 }
 
 impl HostComponents {
-    pub(crate) fn insert<'a, T: 'static, Component: HostComponent + 'static>(
+    pub(crate) fn insert<T: 'static, Component: HostComponent + 'static>(
         &mut self,
-        linker: &'a mut Linker<RuntimeContext<T>>,
+        linker: &mut Linker<RuntimeContext<T>>,
         host_component: Component,
     ) -> Result<()> {
         let handle = HostComponentsStateHandle {

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -103,7 +103,7 @@ pub struct RawWasmConfig {
 
 /// An entry in the `files` list mapping a source path to an absolute
 /// mount path in the guest.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct RawDirectoryPlacement {
     /// The source to mount.
@@ -114,7 +114,7 @@ pub struct RawDirectoryPlacement {
 
 /// A specification for a file or set of files to mount in the
 /// Wasm module.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", untagged)]
 pub enum RawFileMount {
     /// Mount a specified directory at a specified location.
@@ -137,7 +137,7 @@ pub enum RawModuleSource {
 /// TODO
 /// The component and its entrypoint should be pulled from Bindle.
 /// This assumes access to the Bindle server.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct FileComponentBindleSource {
     /// Reference to the bindle (name/version)

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -84,7 +84,7 @@ pub struct CoreComponent {
 }
 
 /// The location from which an application was loaded.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ApplicationOrigin {
     /// The application was loaded from the specified file.
     File(PathBuf),
@@ -98,7 +98,7 @@ pub enum ApplicationOrigin {
 }
 
 /// The trigger type.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase", tag = "type")]
 pub enum ApplicationTrigger {
     /// HTTP trigger type.
@@ -108,7 +108,7 @@ pub enum ApplicationTrigger {
 }
 
 /// HTTP trigger configuration.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct HttpTriggerConfiguration {
     /// Base path for the HTTP application.
     pub base: String,
@@ -132,7 +132,7 @@ impl TryFrom<ApplicationTrigger> for HttpTriggerConfiguration {
 }
 
 /// Redis trigger configuration.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RedisTriggerConfiguration {
     /// Address of Redis server.
     pub address: String,
@@ -217,7 +217,7 @@ impl Default for HttpConfig {
 /// or the Wagi CGI interface.
 ///
 /// If an executor is not specified, the inferred default is `HttpExecutor::Spin`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase", tag = "type")]
 pub enum HttpExecutor {
     /// The component implements the Spin HTTP interface.
@@ -233,7 +233,7 @@ impl Default for HttpExecutor {
 }
 
 /// Wagi specific configuration for the http executor.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields, rename_all = "camelCase")]
 pub struct WagiConfig {
     /// The name of the entrypoint.
@@ -275,7 +275,7 @@ pub struct RedisConfig {
 /// The executor for the Redis component.
 ///
 /// If an executor is not specified, the inferred default is `RedisExecutor::Spin`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase", tag = "type")]
 pub enum RedisExecutor {
     /// The component implements the Spin Redis interface.


### PR DESCRIPTION
* Addresses two clippy errors seen while running `make test` recently

1.  Multiple instances of:
```
error: you are deriving `PartialEq` and can implement `Eq`
   --> crates/manifest/src/lib.rs:278:24
    |
278 | #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
    |                        ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
```

2. One instance of the following.  Please double-check my work here to make sure it is the right fix.
```
error: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
  --> crates/engine/src/host_component.rs:33:5
   |
33 | /     pub(crate) fn insert<'a, T: 'static, Component: HostComponent + 'static>(
34 | |         &mut self,
35 | |         linker: &'a mut Linker<RuntimeContext<T>>,
36 | |         host_component: Component,
37 | |     ) -> Result<()> {
   | |___________________^
   |
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
```