### PR TITLE
Begin replacing wit_bindgen with Rust SDK in integration tests

### DIFF
--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -26,6 +26,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,16 +53,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "proc-macro2"
@@ -76,9 +132,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-macro"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-gen-core",
+ "wit-bindgen-gen-rust-wasm",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "spin-sdk"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "spin-macro",
+ "wasi-experimental-http",
+ "wit-bindgen-rust",
+]
+
+[[package]]
 name = "spinhelloworld"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "spin-sdk",
  "wit-bindgen-rust",
 ]
 
@@ -91,6 +178,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -107,6 +214,39 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tracing"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "unicase"
@@ -143,6 +283,18 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi-experimental-http"
+version = "0.9.0"
+source = "git+https://github.com/deislabs/wasi-experimental-http?rev=a82ae3d6c85c4251b3663035febeb8100068f51d#a82ae3d6c85c4251b3663035febeb8100068f51d"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "thiserror",
+ "tracing",
+]
 
 [[package]]
 name = "wit-bindgen-gen-core"

--- a/tests/http/simple-spin-rust/Cargo.toml
+++ b/tests/http/simple-spin-rust/Cargo.toml
@@ -7,6 +7,13 @@ edition = "2021"
 crate-type = [ "cdylib" ]
 
 [dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# General-purpose crate with common HTTP types.
+http = "0.2"
+spin-sdk = { path = "../../../sdk/rust"}
 # The wit-bindgen-rust dependency generates bindings for interfaces.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2f46ce4cc072107153da0cefe15bdc69aa5b84d0" }
 

--- a/tests/http/simple-spin-rust/src/lib.rs
+++ b/tests/http/simple-spin-rust/src/lib.rs
@@ -1,37 +1,27 @@
-// Generate Rust bindings for interfaces defined in WIT files
-wit_bindgen_rust::export!("../../../wit/ephemeral/spin-http.wit");
+use anyhow::Result;
+use spin_sdk::{http::{Request, Response}, http_component};
 wit_bindgen_rust::import!("../../../wit/ephemeral/spin-config.wit");
 
-// Import the HTTP objects from the generated bindings.
-use spin_http::{Request, Response};
 
-struct SpinHttp {}
-impl spin_http::SpinHttp for SpinHttp {
-    // Implement the `handler` entrypoint for Spin HTTP components.
-    fn handle_http_request(req: Request) -> Response {
-        let path = req.uri;
+#[http_component]
+fn hello_world(req: Request) -> Result<Response> {
 
-        if path.contains("test-placement") {
-            match std::fs::read_to_string("/test.txt") {
-                Ok(text) => Response {
-                    status: 200,
-                    headers: None,
-                    body: Some(text.as_bytes().to_vec()),
-                },
-                Err(e) => Response {
-                    status: 500,
-                    headers: None,
-                    body: Some(format!("ERROR! {:?}", e).as_bytes().to_vec()),
-                },
-            }
-        } else {
-            let message =
-                spin_config::get_config("message").expect("failed to get configured message");
-            Response {
-                status: 200,
-                headers: None,
-                body: Some(message.as_bytes().to_vec()),
-            }
+    let path = req.uri().path();
+
+    if path.contains("test-placement") {
+        match std::fs::read_to_string("/test.txt") {
+            Ok(txt) => 
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(Some(txt.into()))?),
+            Err(e) => anyhow::bail!("Error, could not access test.txt: {}", e)
         }
+    } else {
+        let msg = spin_config::get_config("message").expect("Failed to acquire message from spin.toml");
+
+        Ok(http::Response::builder()
+            .status(200)
+            .body(Some(msg.into()))?)
     }
+        
 }


### PR DESCRIPTION
This PR addresses #216.

I'll need some feedback on the intended behavior for these tests to ensure the integrations are still checking for the desired behavior and functionality.