### PR TITLE
ci: Archive binary executable artifacts from PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,7 @@ jobs:
         config:
           - {
               os: "ubuntu-latest",
-              arch: "amd64",
               extension: "",
-              extraArgs: "",
-              target: "",
-              targetDir: "target/release",
               bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-linux-amd64.tar.gz",
               bindleBinary: "bindle-server",
               pathInBindleArchive: "bindle-server",
@@ -37,22 +33,14 @@ jobs:
             }
           - {
               os: "macos-latest",
-              arch: "aarch64",
               extension: "",
-              extraArgs: "--target aarch64-apple-darwin",
-              target: "aarch64-apple-darwin",
-              targetDir: "target/aarch64-apple-darwin/release/",
               bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-macos-amd64.tar.gz",
               bindleBinary: "bindle-server",
               pathInBindleArchive: "bindle-server",
             }
           - {
               os: "windows-latest",
-              arch: "amd64",
               extension: ".exe",
-              extraArgs: "",
-              target: "",
-              targetDir: "target/release",
               bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-windows-amd64.tar.gz",
               bindleBinary: "bindle-server.exe",
               pathInBindleArchive: "bindle-server.exe",
@@ -121,6 +109,12 @@ jobs:
       - name: "Test Go SDK"
         if: ${{ matrix.config.platformAgnosticChecks }}
         run: make test-sdk-go
+
+      - name: "Archive executable artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: spin-${{ matrix.config.os }}
+          path: target/debug/spin${{ matrix.config.extension }}
 
   check-docs:
     name: Check Docs


### PR DESCRIPTION
This allows us to test PR executables without local (cross-)compiling.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>

![image](https://user-images.githubusercontent.com/245734/172867768-9302cffd-9324-4598-ab77-616543c8ebe3.png)
