### PR TITLE
ci: Build Linux releases with Ubuntu 18.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-18.04",
               arch: "amd64",
               extension: "",
               extraArgs: "",


### PR DESCRIPTION
This fixes runtime glibc errors on 18.04.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>