### PR TITLE
Remove `--all-features` from build scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,11 +77,11 @@ jobs:
           cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Cargo Build
-        run: cargo build --workspace --all-targets --all-features
+        run: cargo build --workspace --all-targets
 
       - name: Cargo Test
         run:
-          cargo test --workspace --all-targets --all-features --no-fail-fast -- --nocapture
+          cargo test --workspace --all-targets --no-fail-fast -- --nocapture
         env:
           RUST_LOG: spin=trace
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,9 @@ jobs:
               os: "ubuntu-latest",
               arch: "amd64",
               extension: "",
-              extraArgs: "",
+              # Ubuntu 22.04 no longer ships libssl1.1, so we statically
+              # link it here to preserve release binary compatibility.
+              extraArgs: "--features vendored-openssl",
               target: "",
               targetDir: "target/release",
             }
@@ -96,7 +98,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: "--all-features --release ${{ matrix.config.extraArgs }}"
+          args: "--release ${{ matrix.config.extraArgs }}"
 
       - name: package release assets
         if: runner.os != 'Windows'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3"
 hippo-openapi = "0.5"
 hippo = { git = "https://github.com/deislabs/hippo-cli"}
 lazy_static = "1.4.0"
+openssl = { version = "0.10", optional = true }
 outbound-redis = { path = "crates/outbound-redis" }
 path-absolutize = "3.0.11"
 regex = "1.5.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ futures = "0.3"
 hippo-openapi = "0.5"
 hippo = { git = "https://github.com/deislabs/hippo-cli"}
 lazy_static = "1.4.0"
-openssl = { version = "0.10", optional = true }
 outbound-redis = { path = "crates/outbound-redis" }
 path-absolutize = "3.0.11"
 regex = "1.5.5"


### PR DESCRIPTION
@dicej I wanted to get the flag out of `make test`, so I figured I'd just clean it up everywhere while I was at it.

@vdice Any good way to test release jobs?