### PR TITLE
do not add revision twice

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -181,7 +181,6 @@ impl DeployCommand {
         .await
         .context("Problem creating a channel in Hippo")?;
 
-        Client::add_revision(&hippo_client, name.clone(), bindle_id.version_string()).await?;
         println!(
             "Deployed {} version {}",
             name.clone(),


### PR DESCRIPTION
When the app is created, Hippo imports all available revisions from the
bindle-server. Therefore, the call to create_and_push_bindle() is all
that is necessary to upload the revision.

https://github.com/deislabs/hippo/blob/v0.14.1/src/Application/Apps/EventHandlers/InitialRevisionImport.cs

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>