### PR TITLE
Template version affinity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,6 +3783,7 @@ dependencies = [
  "path-absolutize",
  "pathdiff",
  "regex",
+ "semver 1.0.6",
  "serde",
  "sha2 0.10.2",
  "symlink",

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -26,11 +26,12 @@ log = { version = "0.4", default-features = false }
 path-absolutize = "3.0.13"
 pathdiff = "0.2.1"
 regex = "1.5.4"
+semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 sha2 = "0.10.1"
 symlink = "0.1"
 tempfile = "3.3.0"
-tokio = { version = "1.10", features = [ "fs" ] }
+tokio = { version = "1.10", features = [ "fs", "process", "rt", "macros" ] }
 toml = "0.5"
 url = "2.2.2"
 walkdir = "2"

--- a/crates/templates/src/source.rs
+++ b/crates/templates/src/source.rs
@@ -8,6 +8,7 @@ use url::Url;
 use crate::directory::subdirectories;
 
 const TEMPLATE_SOURCE_DIR: &str = "templates";
+const TEMPLATE_VERSION_TAG_PREFIX: &str = "spin/templates/v";
 
 /// A source from which to install templates.
 #[derive(Debug)]
@@ -18,12 +19,7 @@ pub enum TemplateSource {
     ///
     /// Templates much be in a `/templates` directory under the root of the
     /// repository.
-    Git {
-        /// The URL of the Git repository from which to install templates.
-        url: Url,
-        /// The branch or tag from which to install templates; HEAD if omitted.
-        branch: Option<String>,
-    },
+    Git(GitTemplateSource),
     /// Install from a directory in the file system.
     ///
     /// Templates much be in a `/templates` directory under the specified
@@ -31,17 +27,34 @@ pub enum TemplateSource {
     File(PathBuf),
 }
 
+/// Settings for installing templates from a Git repository.
+#[derive(Debug)]
+pub struct GitTemplateSource {
+    /// The URL of the Git repository from which to install templates.
+    url: Url,
+    /// The branch or tag from which to install templates; inferred if omitted.
+    branch: Option<String>,
+    /// The version of the Spin client, used for branch inference.
+    // We have to pass this through because vergen is only on the root bin
+    spin_version: String,
+}
+
 impl TemplateSource {
     /// Creates a `TemplateSource` referring to the specified Git repository
     /// and branch.
-    pub fn try_from_git(git_url: impl AsRef<str>, branch: &Option<String>) -> anyhow::Result<Self> {
+    pub fn try_from_git(
+        git_url: impl AsRef<str>,
+        branch: &Option<String>,
+        spin_version: &str,
+    ) -> anyhow::Result<Self> {
         let url_str = git_url.as_ref();
         let url =
             Url::parse(url_str).with_context(|| format!("Failed to parse {} as URL", url_str))?;
-        Ok(Self::Git {
+        Ok(Self::Git(GitTemplateSource {
             url,
             branch: branch.clone(),
-        })
+            spin_version: spin_version.to_owned(),
+        }))
     }
 }
 
@@ -53,7 +66,7 @@ pub(crate) struct LocalTemplateSource {
 impl TemplateSource {
     pub(crate) async fn get_local(&self) -> anyhow::Result<LocalTemplateSource> {
         match self {
-            Self::Git { url, branch } => clone_local(url, branch).await,
+            Self::Git(git_source) => clone_local(git_source).await,
             Self::File(path) => check_local(path).await,
         }
     }
@@ -86,20 +99,28 @@ impl LocalTemplateSource {
     }
 }
 
-async fn clone_local(url: &Url, branch: &Option<String>) -> anyhow::Result<LocalTemplateSource> {
+async fn clone_local(git_source: &GitTemplateSource) -> anyhow::Result<LocalTemplateSource> {
     let temp_dir = tempdir()?;
     let path = temp_dir.path().to_owned();
 
-    let url_str = url.as_str();
+    let url_str = git_source.url.as_str();
+
+    let actual_branch = match &git_source.branch {
+        Some(b) => Some(b.clone()),
+        None => version_matched_tag(url_str, &git_source.spin_version).await,
+    };
 
     let mut git = Command::new("git");
     git.arg("clone");
+    git.arg("--depth").arg("1");
 
-    if let Some(b) = branch {
+    if let Some(b) = actual_branch {
         git.arg("--branch").arg(b);
     }
 
-    let clone_result = git.arg(&url_str).arg(&path).output().await?;
+    git.arg(&url_str).arg(&path);
+
+    let clone_result = git.output().await?;
     match clone_result.status.success() {
         true => Ok(LocalTemplateSource {
             root: path,
@@ -114,6 +135,32 @@ async fn clone_local(url: &Url, branch: &Option<String>) -> anyhow::Result<Local
     }
 }
 
+async fn version_matched_tag(url: &str, spin_version: &str) -> Option<String> {
+    let preferred_tag = version_preferred_tag(spin_version);
+
+    let mut git = Command::new("git");
+    git.arg("ls-remote");
+    git.arg("--exit-code");
+    git.arg(&url);
+    git.arg(&preferred_tag);
+
+    git.output().await.ok().and_then(|output| {
+        if output.status.success() {
+            Some(preferred_tag)
+        } else {
+            None
+        }
+    })
+}
+
+fn version_preferred_tag(text: &str) -> String {
+    let mm_version = match semver::Version::parse(text) {
+        Ok(version) => format!("{}.{}", version.major, version.minor),
+        Err(_) => text.to_owned(),
+    };
+    format!("{}{}", TEMPLATE_VERSION_TAG_PREFIX, mm_version)
+}
+
 async fn check_local(path: &Path) -> anyhow::Result<LocalTemplateSource> {
     if path.exists() {
         Ok(LocalTemplateSource {
@@ -122,5 +169,38 @@ async fn check_local(path: &Path) -> anyhow::Result<LocalTemplateSource> {
         })
     } else {
         Err(anyhow!("Path not found: {}", path.display()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn preferred_tag_excludes_patch_version() {
+        assert_eq!("spin/templates/v1.2", version_preferred_tag("1.2.3"));
+    }
+
+    #[test]
+    fn preferred_tag_excludes_prerelease_and_build() {
+        assert_eq!(
+            "spin/templates/v1.2",
+            version_preferred_tag("1.2.3-preview.1")
+        );
+        assert_eq!(
+            "spin/templates/v1.2",
+            version_preferred_tag("1.2.3+build.0f74628")
+        );
+        assert_eq!(
+            "spin/templates/v1.2",
+            version_preferred_tag("1.2.3-alpha+0f74628")
+        );
+    }
+
+    #[test]
+    fn preferred_tag_defaults_sensibly_on_bad_semver() {
+        assert_eq!("spin/templates/v1.2", version_preferred_tag("1.2"));
+        assert_eq!("spin/templates/v1.2.3.4", version_preferred_tag("1.2.3.4"));
+        assert_eq!("spin/templates/vgarbage", version_preferred_tag("garbage"));
     }
 }

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -60,7 +60,7 @@ to install a starter set.
 We first need to configure the [templates from the Spin repository](https://github.com/fermyon/spin/tree/main/templates):
 
 ```console
-$ spin templates install --git https://github.com/fermyon/spin --branch v0.2.0
+$ spin templates install --git https://github.com/fermyon/spin
 Copying remote template source
 Installing template redis-rust...
 Installing template http-rust...
@@ -74,9 +74,6 @@ Installing template http-go...
 | ...                                              |
 +--------------------------------------------------+
 ```
-
-> If you downloaded the canary build instead of the release build, leave off the `--branch`
-> flag in `spin templates install`.
 
 > The Spin templates experience is still early — if you are interested in
 > writing your own templates, you can follow the existing

--- a/docs/content/template-authoring.md
+++ b/docs/content/template-authoring.md
@@ -84,3 +84,15 @@ supported:
 | Key           | Value and usage |
 |---------------|-----------------|
 | `pattern`     | A regular expression. The user input must match the regular expression to be accepted. |
+
+## Hosting templates in Git
+
+You can publish templates in a Git repo.  The templates must be in the `/templates`
+directory, with a subdirectory per template.
+
+When a user installs templates from your repo, by default Spin looks for a tag
+to identify a compatible version of the templates.  This tag is of the
+form `spin/templates/vX.Y`, where X is the major version, and Y the minor
+version, of the user's copy of Spin. For example, if the user is on
+Spin 0.3.1, templates will be installed from `spin/templates/v0.3`.  If this
+tag does not exist, Spin installs templates from `HEAD`.

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -79,7 +79,9 @@ impl Install {
         let template_manager =
             TemplateManager::default().context("Failed to construct template directory path")?;
         let source = match (&self.git, &self.dir) {
-            (Some(git), None) => TemplateSource::try_from_git(&git, &self.branch)?,
+            (Some(git), None) => {
+                TemplateSource::try_from_git(&git, &self.branch, env!("VERGEN_BUILD_SEMVER"))?
+            }
             (None, Some(dir)) => TemplateSource::File(dir.clone()),
             _ => anyhow::bail!("Exactly one of `git` and `dir` sources must be specified"),
         };


### PR DESCRIPTION
Fixes #555.

This makes `spin template install --git` attempt to locate compatible templates instead of defaulting to HEAD.  The intended logic is as follows:

* If the user runs `install --git ... --branch ...` then the given branch or tag is used.  No inference occurs.
* If the user runs `install --git ...` without `--branch`:
  * If the repo _contains_ a tag `spin/templates/v1.2.3` (where `1.2.3` is the version of the Spin binary), that tag is used.
  * If _not_, then HEAD is used.

**NOTE:** #555 raises some difficulties and considerations for this logic.  We should not merge this PR without agreeing that this is a reasonable approach to take.

**CONFESSION:** This PR includes an unrelated change to clone the remote repo with depth 1 instead of hauling in all the history.  I can move this to a separate PR if preferred!