### PR TITLE
ref(deploy): allows user to re-deploy after changing version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,8 +1520,8 @@ dependencies = [
 
 [[package]]
 name = "hippo"
-version = "0.12.0"
-source = "git+https://github.com/deislabs/hippo-cli#5a7654e6fa9d063d934b078e5216a39ea2f91147"
+version = "0.13.0"
+source = "git+https://github.com/deislabs/hippo-cli#1d4e8254d77bcd843a5c126a5d7b45978d16e973"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "hippo-openapi"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819f70d18f069df5f41af1f8c38d58b685d67084d25071ef2335286ac90f72bf"
+checksum = "7a406e029108ee79482884f716d494f76f321dac8d8bf047abdc36441f077ad7"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ dirs = "4.0"
 dunce = "1.0"
 env_logger = "0.9"
 futures = "0.3"
-hippo-openapi = "0.5"
+hippo-openapi = "0.7"
 hippo = { git = "https://github.com/deislabs/hippo-cli"}
 lazy_static = "1.4.0"
 outbound-redis = { path = "crates/outbound-redis" }


### PR DESCRIPTION
This commit allows users to redeploy their app after changing the version specified in the spin.toml file. It simply deletes the app if it already exists and re-creates it and the relevant channel.

This PR is blocked by a change that needs to be made in the hippo-cli where we need to update the hippo-openapi dep. https://github.com/deislabs/hippo-cli/issues/135

The first route I tried was to simply keep the app and update the channel configuration but was unsuccessful in doing so. I'll need to debug why the hippo channel put api is not working as expected.

Co-authored-by: Ivan Towlson <ivan.towlson@fermyon.com>
Signed-off-by: Michelle Dhanani <michelle@fermyon.com>