### PR TITLE
Update quickstart.md to include `cargo install --path .` installation option

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -21,6 +21,16 @@ $ tar xfv spin-v0.2.0-macos-aarch64.tar.gz
 $ ./spin --help
 ```
 
+If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
+
+```bash
+$ git clone https://github.com/fermyon/spin
+$ cd spin
+$ rustup target add wasm32-wasi
+$ cargo install --path .
+$ spint --help
+```
+
 Alternatively, [follow the contribution document](./contributing.md) for a detailed guide
 on building Spin from source:
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -28,7 +28,7 @@ $ git clone https://github.com/fermyon/spin
 $ cd spin
 $ rustup target add wasm32-wasi
 $ cargo install --path .
-$ spint --help
+$ spin --help
 ```
 
 Alternatively, [follow the contribution document](./contributing.md) for a detailed guide


### PR DESCRIPTION
Installing spin and adding it to path can be a little easier if the user already has `cargo` installed. So I added the steps to the quickstart.

Ideally, users could simply `cargo install spin-cli` but that requires publishing to crates.io #362