### PR TITLE
fix: Argument or group 'buildinfo' specified in 'conflicts_with*' for  'no-buildinfo' does not exist

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -99,7 +99,7 @@ pub struct DeployCommand {
     /// Disable attaching buildinfo
     #[clap(
         long = "no-buildinfo",
-        conflicts_with = "buildinfo",
+        conflicts_with = BUILDINFO_OPT,
         env = "SPIN_DEPLOY_NO_BUILDINFO"
     )]
     pub no_buildinfo: bool,


### PR DESCRIPTION
Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>