### PR TITLE
ref(deploy): add correct scheme to routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,6 +3539,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber 0.3.9",
+ "url 2.2.2",
  "vergen",
  "wasi-outbound-http",
  "wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ toml = "0.5"
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
+url = "2.2.2"
 wasi-outbound-http = { path = "crates/outbound-http" }
 wasmtime = "0.34"
 


### PR DESCRIPTION
+ At the moment, the default scheme is http so if
you deploy Hippo to AWS for example with ssl enabled
the output would show http as the scheme for the
available routes instead of https.
+ This change makes it so that the routes that get
displayed in the output of spin deploy match the
scheme of the hippo url.
+ In the future, it'd be nice if we could get the routes
with the scheme from the Hippo API.

Co-authored-by: Brian Hardock <brian.hardock@fermyon.com>
Signed-off-by: Michelle Dhanani <michelle@fermyon.com>