### PR TITLE
Retain context of deploy push errors

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -297,7 +297,12 @@ impl DeployCommand {
                     ));
                 }
             } else {
-                return Err(anyhow!("Failed to push bindle to server {}", publish_err));
+                return Err(publish_err).with_context(|| {
+                    format!(
+                        "Failed to push bindle {} to server {}",
+                        bindle_id, self.bindle_server_url
+                    )
+                });
             }
         }
 


### PR DESCRIPTION
If a deployment fails due to a bindle push error (e.g. wrong URL), the error and immediate cause are printed on one line:

```
$ BINDLE_URL=bin spin deploy
Error: Failed to push bindle to server Failed to create a bindle client for server 'bin'
```

This PR proposes to use an `anyhow` context instead, which provides more formatting but also retains additional layers of context:

```
$ BINDLE_URL=bin spin deploy
Error: Failed to push bindle werwrwer/0.1.1+qfef7776 to server bin

Caused by:
    0: Failed to create a bindle client for server 'bin'
    1: Invalid URL given
    2: relative URL without a base

$ BINDLE_URL=http://bin spin deploy
Error: Failed to push bindle werwrwer/0.1.1+qfef7776 to server http://bin

Caused by:
    0: Failed to push bindle from '/tmp/.tmpb3VXG7' to server at 'http://bin'
    1: Error creating request
    2: error sending request for url (http://bin/_i): error trying to connect: dns error: failed to lookup address information: No address associated with hostname
    3: error trying to connect: dns error: failed to lookup address information: No address associated with hostname
    4: dns error: failed to lookup address information: No address associated with hostname
    5: failed to lookup address information: No address associated with hostname
```

I'm not sure if this much context is really right - I do think some measure of diagnostic info is good but this might be too "internal" looking for a user experience.  In which case I'm happy to put it back to how it was before except with a newline _grin_.