### PR TITLE
Check for successful status code in hippo healthcheck

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -313,15 +313,12 @@ impl DeployCommand {
     async fn check_hippo_healthz(&self) -> Result<()> {
         let hippo_base_url = url::Url::parse(&self.hippo_server_url)?;
         let hippo_healthz_url = hippo_base_url.join("/healthz")?;
-        let result = reqwest::get(hippo_healthz_url.to_string())
-            .await?
-            .error_for_status()?
-            .text()
-            .await?;
-        if result != "Healthy" {
-            return Err(anyhow!("Hippo server {} is unhealthy", hippo_base_url));
+        let status_code = reqwest::get(hippo_healthz_url.to_string()).await?.status();
+
+        if status_code.is_success() {
+            return Ok(());
         }
-        Ok(())
+        Err(anyhow!("Hippo server {} is unhealthy", hippo_base_url))
     }
 }
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Context, Result, bail};
 use bindle::Id;
 use clap::Parser;
 use hippo::{Client, ConnectionInfo};
@@ -318,7 +318,7 @@ impl DeployCommand {
         if status_code.is_success() {
             return Ok(());
         }
-        Err(anyhow!("Hippo server {} is unhealthy", hippo_base_url))
+        bail!("Hippo server {} is unhealthy", hippo_base_url)
     }
 }
 

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Signed-off-by: Thorsten Hans <thorsten.hans@gmail.com>

With this PR hippo healthcheck will rely on on the status code instead of response text

Related issue: #603 