### PR TITLE
Spin go sdk error return statement for nil request

### DIFF
--- a/sdk/go/http/internals.go
+++ b/sdk/go/http/internals.go
@@ -23,6 +23,7 @@ func handle_http_request(req *C.spin_http_request_t, res *C.spin_http_response_t
 	r, err := http.NewRequest(sr.Method(), sr.URL(), bytes.NewReader(sr.Body()))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		res.status = C.uint16_t(http.StatusInternalServerError)
 		return
 	}
 

--- a/sdk/go/http/internals.go
+++ b/sdk/go/http/internals.go
@@ -23,6 +23,7 @@ func handle_http_request(req *C.spin_http_request_t, res *C.spin_http_response_t
 	r, err := http.NewRequest(sr.Method(), sr.URL(), bytes.NewReader(sr.Body()))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		return
 	}
 
 	r.Header = fromSpinHeaders(&req.headers)


### PR DESCRIPTION
Currently the spin go sdk is checking for an err when creating a go internal http request. However, the error handling only prints the error message and the code continues on. This change adds a return statement to ensure we do not attempt to access/use a nil request object. That said, this might not be something that needs to be handled due to the pass through with the host env checks. 

I tested this change does not break using the go-spin examples in spin-kitchen sink. If there is advice on how this might be trigger to cause the error capture and access of the nil pointer I am happy implement a more holistic test for it. 

