### PR TITLE
doc(quickstart): specify tag in `git clone` command

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -24,7 +24,7 @@ $ ./spin --help
 If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
 
 ```bash
-$ git clone https://github.com/fermyon/spin
+$ git clone https://github.com/fermyon/spin -b v0.3.0
 $ cd spin
 $ rustup target add wasm32-wasi
 $ cargo install --path .


### PR DESCRIPTION
Per #615, the HEAD of the main branch of the repo is not guaranteed to be
compatible with the most recent SDK release, so it's better to have users use
the latest release tag.

We also need better error reporting for SDK compatibility issues; I'll open a
new work item to track that.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>