### PR TITLE
feat: Add Swift HTTP/Wagi handler for Spin

### DIFF
--- a/templates/http-swift/content/main.swift
+++ b/templates/http-swift/content/main.swift
@@ -1,0 +1,16 @@
+import WASILibc
+
+// Until all of ProcessInfo makes its way into SwiftWasm
+func getEnvVar(key: String) -> Optional<String> {
+    guard let rawValue = getenv(key) else {return Optional.none}
+    return String(validatingUTF8: rawValue)
+}
+
+let server = getEnvVar(key: "SERVER_SOFTWARE") ?? "Unknown Server"
+let message = """
+content-type: text/plain
+
+Hello from \(server)!
+"""
+
+print(message)

--- a/templates/http-swift/content/spin.toml
+++ b/templates/http-swift/content/spin.toml
@@ -1,0 +1,15 @@
+spin_version = "1"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+name = "{{project-name}}"
+trigger = { type = "http", base = "{{http-base}}" }
+version = "0.1.0"
+
+[[component]]
+id = "{{project-name | kebab_case}}"
+source = "main.wasm"
+[component.trigger]
+route = "{{http-path}}"
+executor = { type = "wagi" }
+[component.build]
+command = "swiftc -target wasm32-unknown-wasi main.swift -o main.wasm"

--- a/templates/http-swift/metadata/spin-template.toml
+++ b/templates/http-swift/metadata/spin-template.toml
@@ -1,0 +1,8 @@
+manifest_version = "1"
+id = "http-swift"
+description = "HTTP request handler using SwiftWasm"
+
+[parameters]
+project-description = { type = "string",  prompt = "Project description" }
+http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
+http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }


### PR DESCRIPTION
This adds a `http-swift` template that uses SwiftWasm.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>