### PR TITLE
Do not install template dirs that are not templates

### DIFF
--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -200,7 +200,7 @@ impl ProgressReporter for ConsoleProgressReporter {
 
 fn reason_text(reason: &SkippedReason) -> String {
     match reason {
-        SkippedReason::AlreadyExists => "Already exists",
+        SkippedReason::AlreadyExists => "Already exists".to_owned(),
+        SkippedReason::InvalidManifest(msg) => format!("Template load error: {}", msg),
     }
-    .to_owned()
 }


### PR DESCRIPTION
Fixes #637.

This doesn't provide a way to clean up invalid directories within the template store; hopefully users can sort that themselves for now.