### PR TITLE
Fix crate unit tests not being run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 
 .PHONY: test-unit
 test-unit:
-	RUST_LOG=$(LOG_LEVEL) cargo test --no-fail-fast -- --skip integration_tests --nocapture --include-ignored
+	RUST_LOG=$(LOG_LEVEL) cargo test --all --no-fail-fast -- --skip integration_tests --nocapture --include-ignored
 
 .PHONY: test-integration
 test-integration:

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -361,7 +361,7 @@ mod tests {
         PathBuf::from(crate_dir).join("..").join("..")
     }
 
-    const TPLS_IN_THIS: usize = 4;
+    const TPLS_IN_THIS: usize = 8;
 
     #[tokio::test]
     async fn can_install_into_new_directory() {


### PR DESCRIPTION
The makefile was reorganised to provide nice clearly separated unit and integration test targets, but in the process the `--all` fell on the cutting room floor.  So we are currently running only the tests for the bin, not the crates.

I assume the `test-integration` target doesn't need the flag.

(Also fixes a test failure that sneaked through when the tests weren't being fully run.)