### PR TITLE
fix: Terminate trigger handler on `spin up` termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,6 +2197,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3525,6 +3526,7 @@ dependencies = [
  "cargo-target-dep",
  "clap 3.1.15",
  "comfy-table",
+ "ctrlc",
  "dirs 4.0.0",
  "dunce",
  "env_logger",
@@ -3533,6 +3535,7 @@ dependencies = [
  "hippo-openapi",
  "hyper",
  "lazy_static",
+ "nix",
  "openssl",
  "outbound-redis",
  "path-absolutize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ bindle = { version = "0.8.0", default-features = false, features = ["client"] }
 bytes = "1.1"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 comfy-table = "5.0"
+ctrlc = { version = "3.2", features = ["termination"] }
 dirs = "4.0"
 dunce = "1.0"
 env_logger = "0.9"
@@ -19,6 +20,7 @@ futures = "0.3"
 hippo-openapi = "0.8"
 hippo = { git = "https://github.com/deislabs/hippo-cli"}
 lazy_static = "1.4.0"
+nix = { version = "0.24", features = ["signal"] }
 outbound-redis = { path = "crates/outbound-redis" }
 path-absolutize = "3.0.11"
 regex = "1.5.5"

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["mossaka <duibao55328@gmail.com>"]
 anyhow = "1.0"
 async-trait = "0.1"
 clap = "3"
-ctrlc = "3.2"
+ctrlc = { version = "3.2", features = ["termination"] }
 futures = "0.3"
 http = "0.2"
 outbound-redis = { path = "../outbound-redis" }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -157,7 +157,20 @@ impl UpCommand {
 
         tracing::trace!("Running trigger executor: {:?}", cmd);
 
-        let status = cmd.status().context("Failed to execute trigger")?;
+        let mut child = cmd.spawn().context("Failed to execute trigger")?;
+
+        #[cfg(not(windows))]
+        {
+            // https://github.com/nix-rust/nix/issues/656
+            let pid = nix::unistd::Pid::from_raw(child.id() as i32);
+            ctrlc::set_handler(move || {
+                if let Err(err) = nix::sys::signal::kill(pid, nix::sys::signal::SIGTERM) {
+                    tracing::warn!("Failed to kill trigger handler process: {:?}", err)
+                }
+            })?;
+        }
+
+        let status = child.wait()?;
         if status.success() {
             Ok(())
         } else {


### PR DESCRIPTION
The `Ctrl-C` handler works because it is handled in the trigger handler
child process, but if the parent `spin up` process is terminated
instead - as with e.g. Nomad - the child is left running.

Fix this by adding a signal handler to the parent process which sends
SIGTERM to the child.

I expect this to fix #638