### PR TITLE
fix: Use correct features for spin-trigger clap dependency

### DIFF
--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["mossaka <duibao55328@gmail.com>"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-clap = "3"
+clap = { version = "3.1.15", features = ["derive", "env"] }
 ctrlc = { version = "3.2", features = ["termination"] }
 futures = "0.3"
 http = "0.2"


### PR DESCRIPTION
This normally works because the root Cargo.toml specifies the required features and unification makes those apply to spin-trigger as a dependency.