### PR TITLE
feat(deploy): Output plain text when Hippo login fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "indexmap",
  "itoa 1.0.1",
@@ -3543,6 +3543,7 @@ dependencies = [
  "reqwest",
  "semver 1.0.6",
  "serde",
+ "serde_json",
  "sha2 0.10.2",
  "spin-build",
  "spin-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ url = "2.2.2"
 wasi-outbound-http = { path = "crates/outbound-http" }
 wasmtime = "0.35.3"
 
-
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable
 # '--features openssl/vendored', which is used for Linux releases.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ regex = "1.5.5"
 reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0.82"
 sha2 = "0.10.2"
 spin-build = { path = "crates/build" }
 spin-config = { path = "crates/config" }
@@ -47,6 +48,7 @@ tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 url = "2.2.2"
 wasi-outbound-http = { path = "crates/outbound-http" }
 wasmtime = "0.35.3"
+
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -147,7 +147,8 @@ impl DeployCommand {
             self.hippo_username.clone(),
             self.hippo_password.clone(),
         )
-        .await?
+        .await
+        .context("Problem login Hippo")?
         .token
         {
             Some(t) => t,


### PR DESCRIPTION
Signed-off-by: lidongjies <lidongjies@gmail.com>

With this PR, if it fails to obtain the Hippo token when executing the "spin deploy" command, the following error message will be output

> Error:  Problem login Hippo.
> 
> Caused by:
>           {"type":"https://tools.ietf.org/html/rfc7231#section-6.5.1","title":"Login failed.","status":400,"detail":"Login failed: "}

Related issue #614