### PR TITLE
fix: Rename top-level config section to variables

### DIFF
--- a/crates/loader/src/bindle/config.rs
+++ b/crates/loader/src/bindle/config.rs
@@ -9,6 +9,7 @@ pub struct RawAppManifest {
     pub trigger: spin_manifest::ApplicationTrigger,
 
     /// Application-specific configuration schema.
+    #[serde(rename = "variables")]
     pub config: Option<spin_config::Tree>,
 
     /// Configuration for the application components.

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -27,6 +27,7 @@ pub struct RawAppManifest {
     pub info: RawAppInformation,
 
     /// Application-specific configuration schema.
+    #[serde(rename = "variables")]
     pub config: Option<spin_config::Tree>,
 
     /// Configuration for the application components.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -54,7 +54,7 @@ configuration has the following fields:
     - `type` (REQUIRED): The application trigger type with the value `"redis"`.
     - `address` (REQUIRED): The address of the Redis instance the components
 are using for message subscriptions.
-- `config` (OPTIONAL): [Custom configuration](#custom-configuration) "slots".
+- `variables` (OPTIONAL): [Custom configuration](#custom-configuration) "slots".
 - A list of `component` objects (REQUIRED) defining the application components.
 
 ### Component configuration
@@ -123,7 +123,7 @@ component code via the [spin-config interface](https://github.com/fermyon/spin/b
 
 ### Custom Config Slots
 
-Application-global custom config "slots" are defined in the top-level `[config]`
+Application-global custom config "slots" are defined in the top-level `[variables]`
 section. These entries aren't accessed directly by components, but are referenced
 by [component config](#component-custom-config) value templates. Each entry must
 either have a `default` value or be marked as `required = true`. "Required" entries
@@ -132,7 +132,7 @@ must be [provided](#custom-config-providers) with a value.
 Configuration keys may only contain lowercase letters and underscores between letters.
 
 ```toml
-[config]
+[variables]
 api_host = { default = "api.example.com" }
 api_key = { required = true }
 ```

--- a/docs/content/sips/002-app-config.md
+++ b/docs/content/sips/002-app-config.md
@@ -9,7 +9,7 @@ Owner: lann.martin@fermyon.com
 
 Created: March 22, 2022
 
-Updated: April 4, 2022
+Updated: July 19, 2022
 
 ## Background
 
@@ -33,7 +33,7 @@ Configuration within a "parent" (component or application) consists of a number 
 - A slot may be marked as "secret", in which case any associated value should be handled with care (e.g. not logged)
 
 ```toml
-[config]
+[variables]
 required_key = { required = true }
 optional_key = { default = "default_value" }
 secret_key = { required = true, secret = true }
@@ -41,14 +41,14 @@ secret_key = { required = true, secret = true }
 
 Default values can use template strings to reference other slots.
 ```toml
-[config]
+[variables]
 key1 = { required = true }
 key2 = { default = "prefix-{{ key1 }}-suffix" }
 ```
 
 ### Components and applications set configuration values of their dependencies
 
-In dependency configuration, templates strings can reference top-level config keys (those in `[config]`), "sibling" keys within the same dependency, and "ancestor" dependant configs.
+In dependency configuration, templates strings can reference top-level config keys (those in `[variables]`), "sibling" keys within the same dependency, and "ancestor" dependant configs.
 
 - Top-level references use just the key name: `{{ top_level_key }}`
 - "Sibling" references use a single `.` prefix: `{{ .sibling_key }}`
@@ -57,7 +57,7 @@ In dependency configuration, templates strings can reference top-level config ke
 
 `spin.toml`:
 ```toml
-[config]
+[variables]
 app_root = { default = "/app" }
 log_file = { default = "{{ app_root }}/log.txt" }
 ...

--- a/examples/config-rust/spin.toml
+++ b/examples/config-rust/spin.toml
@@ -5,7 +5,7 @@ name = "spin-config-rust"
 trigger = { type = "http", base = "/" }
 version = "0.1.0"
 
-[config]
+[variables]
 object = { default = "teapot" }
 
 [[component]]

--- a/examples/config-tinygo/spin.toml
+++ b/examples/config-tinygo/spin.toml
@@ -5,7 +5,7 @@ name = "spin-config-tinygo"
 trigger = { type = "http", base = "/" }
 version = "1.0.0"
 
-[config]
+[variables]
 object = { default = "teapot" }
 
 [[component]]

--- a/tests/http/simple-spin-rust/spin-from-parcel.toml
+++ b/tests/http/simple-spin-rust/spin-from-parcel.toml
@@ -5,7 +5,7 @@ name = "spin-hello-from-parcel"
 trigger = {type = "http", base = "/test"}
 version = "1.0.0"
 
-[config]
+[variables]
 object = { default = "teapot" }
 
 [[component]]

--- a/tests/http/simple-spin-rust/spin.toml
+++ b/tests/http/simple-spin-rust/spin.toml
@@ -5,7 +5,7 @@ name = "spin-hello-world"
 trigger = {type = "http", base = "/test"}
 version = "1.0.0"
 
-[config]
+[variables]
 object = { default = "teapot" }
 
 [[component]]


### PR DESCRIPTION
This PR renames the top-level config section in the spin.toml to variables.
Updates the examples and documentation.

NOTE: This is a breaking change.

Signed-off-by: Brian H <brian.hardock@fermyon.com>