### PR TITLE
fix spin-cli and http-cpp builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ dunce = "1.0"
 env_logger = "0.9"
 futures = "0.3"
 hippo-openapi = "0.8"
-hippo = { git = "https://github.com/deislabs/hippo-cli"}
+hippo = { git = "https://github.com/deislabs/hippo-cli", rev = "67f6368fa39d296c3d1b11a93e43bc4c751cba6b"}
 lazy_static = "1.4.0"
 nix = { version = "0.24", features = ["signal"] }
 outbound-redis = { path = "crates/outbound-redis" }

--- a/examples/http-cpp/lib.cpp
+++ b/examples/http-cpp/lib.cpp
@@ -23,10 +23,10 @@ extern "C" void spin_http_handle_http_request(spin_http_request_t *request,
   memcpy(body, body_string, body_length);
 
   response->status = 200;
-  response->headers.tag = true;
+  response->headers.is_some = true;
   response->headers.val.ptr = header;
   response->headers.val.len = 1;
-  response->body.tag = true;
+  response->body.is_some = true;
   response->body.val.ptr = body;
   response->body.val.len = body_length;
 }


### PR DESCRIPTION
- The spin-cli build was broken when executed via `cargo install` since [`cargo install` ignores Cargo.lock](https://github.com/rust-lang/cargo/issues/7169) and the main branch of the `hippo-cli` repo is currently incompatible with `spin deploy` due to API changes.  I've fixed this by copying the Cargo.lock revision into Cargo.toml.  Once #621 is merged we'll start using a proper tag instead.
    
- The http-cpp build has been broken since #574 was merged.  My bad for not noticing until now.


Signed-off-by: Joel Dice <joel.dice@fermyon.com>