### PR TITLE
fix: Change how `spin up --help` works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "hippo"
 version = "0.13.1"
-source = "git+https://github.com/deislabs/hippo-cli#67f6368fa39d296c3d1b11a93e43bc4c751cba6b"
+source = "git+https://github.com/deislabs/hippo-cli?rev=67f6368fa39d296c3d1b11a93e43bc4c751cba6b#67f6368fa39d296c3d1b11a93e43bc4c751cba6b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -86,16 +86,23 @@ pub struct UpCommand {
     pub allow_transient_write: bool,
 
     /// All other args, to be passed through to the trigger
+    #[clap(hide = true)]
     pub trigger_args: Vec<OsString>,
 }
 
 impl UpCommand {
     pub async fn run(self) -> Result<()> {
         let help = self.help;
+        if help {
+            Self::command()
+                .name("spin-up")
+                .bin_name("spin up")
+                .print_help()?;
+            println!();
+        }
         self.run_inner().await.or_else(|err| {
             if help {
                 tracing::warn!("Error resolving trigger-specific help: {}", err);
-                Self::command().print_help()?;
                 Ok(())
             } else {
                 Err(err)
@@ -154,7 +161,7 @@ impl UpCommand {
         };
 
         let trigger_args = if self.help {
-            vec![OsString::from("--help")]
+            vec![OsString::from("--help-args-only")]
         } else {
             self.trigger_args
         };


### PR DESCRIPTION
Instead of delegating the full help output to the trigger, first print
`spin up`'s own help, then call the trigger with the new
`--help-args-only` flag to output just the arg usage details.

Fixes #664