### PR TITLE
fix: update rust hello world test to use config interface in Rust SDK

### DIFF
--- a/tests/http/simple-spin-rust/src/lib.rs
+++ b/tests/http/simple-spin-rust/src/lib.rs
@@ -1,27 +1,26 @@
 use anyhow::Result;
-use spin_sdk::{http::{Request, Response}, http_component};
-wit_bindgen_rust::import!("../../../wit/ephemeral/spin-config.wit");
-
+use spin_sdk::{
+    config,
+    http::{Request, Response},
+    http_component,
+};
 
 #[http_component]
 fn hello_world(req: Request) -> Result<Response> {
-
     let path = req.uri().path();
 
     if path.contains("test-placement") {
         match std::fs::read_to_string("/test.txt") {
-            Ok(txt) => 
-                Ok(http::Response::builder()
-                    .status(200)
-                    .body(Some(txt.into()))?),
-            Err(e) => anyhow::bail!("Error, could not access test.txt: {}", e)
+            Ok(txt) => Ok(http::Response::builder()
+                .status(200)
+                .body(Some(txt.into()))?),
+            Err(e) => anyhow::bail!("Error, could not access test.txt: {}", e),
         }
     } else {
-        let msg = spin_config::get_config("message").expect("Failed to acquire message from spin.toml");
+        let msg = config::get("message").expect("Failed to acquire message from spin.toml");
 
         Ok(http::Response::builder()
             .status(200)
             .body(Some(msg.into()))?)
     }
-        
 }


### PR DESCRIPTION
Updates Rust HTTP hello world test to use the config interface added to the Rust SDK in https://github.com/fermyon/spin/pull/651 rather than continuing to use the previous approach of directly importing via wit.

Creates consistency of config usage among tests and examples. 

Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>