### PR TITLE
Postgres data types and error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,6 +2474,7 @@ dependencies = [
  "postgres",
  "spin-engine",
  "spin-manifest",
+ "tracing",
  "wit-bindgen-wasmtime",
 ]
 

--- a/crates/outbound-pg/Cargo.toml
+++ b/crates/outbound-pg/Cargo.toml
@@ -11,4 +11,5 @@ anyhow = "1.0"
 postgres = { version = "0.19.3" }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
+tracing = { version = "0.1", features = [ "log" ] }
 wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dde4694aaa6acf9370206527a798ac4ba6a8c5b8" }

--- a/crates/outbound-pg/src/lib.rs
+++ b/crates/outbound-pg/src/lib.rs
@@ -42,10 +42,7 @@ impl outbound_pg::OutboundPg for OutboundPg {
         let mut client = Client::connect(address, NoTls)
             .map_err(|e| PgError::ConnectionFailed(format!("{:?}", e)))?;
 
-        let params: Vec<&(dyn ToSql + Sync)> = params
-            .iter()
-            .map(to_sql_parameter)
-            .collect();
+        let params: Vec<&(dyn ToSql + Sync)> = params.iter().map(to_sql_parameter).collect();
 
         let nrow = client
             .execute(statement, params.as_slice())
@@ -63,10 +60,7 @@ impl outbound_pg::OutboundPg for OutboundPg {
         let mut client = Client::connect(address, NoTls)
             .map_err(|e| PgError::ConnectionFailed(format!("{:?}", e)))?;
 
-        let params: Vec<&(dyn ToSql + Sync)> = params
-            .iter()
-            .map(to_sql_parameter)
-            .collect();
+        let params: Vec<&(dyn ToSql + Sync)> = params.iter().map(to_sql_parameter).collect();
 
         let results = client
             .query(statement, params.as_slice())
@@ -114,11 +108,11 @@ fn infer_column(row: &Row, index: usize) -> Column {
 }
 
 fn convert_data_type(pg_type: &Type) -> DbDataType {
-    match pg_type {
-        &Type::BOOL => DbDataType::Boolean,
-        &Type::INT4 => DbDataType::Int32,
-        &Type::INT8 => DbDataType::Int64,
-        &Type::VARCHAR => DbDataType::DbString,
+    match *pg_type {
+        Type::BOOL => DbDataType::Boolean,
+        Type::INT4 => DbDataType::Int32,
+        Type::INT8 => DbDataType::Int64,
+        Type::VARCHAR => DbDataType::DbString,
         _ => {
             tracing::debug!("Couldn't convert Postgres type {} to WIT", pg_type.name(),);
             DbDataType::Other

--- a/crates/outbound-pg/src/lib.rs
+++ b/crates/outbound-pg/src/lib.rs
@@ -33,8 +33,14 @@ impl HostComponent for OutboundPg {
 }
 
 impl outbound_pg::OutboundPg for OutboundPg {
-    fn execute(&mut self, address: &str, statement: &str, params: Vec<&str>) -> Result<u64, PgError> {
-        let mut client = Client::connect(address, NoTls).map_err(|_| PgError::OtherError("tba".to_owned()))?;
+    fn execute(
+        &mut self,
+        address: &str,
+        statement: &str,
+        params: Vec<&str>,
+    ) -> Result<u64, PgError> {
+        let mut client =
+            Client::connect(address, NoTls).map_err(|_| PgError::OtherError("tba".to_owned()))?;
 
         let params: Vec<&(dyn ToSql + Sync)> = params
             .iter()
@@ -89,31 +95,35 @@ fn convert_entry(row: &Row, index: usize) -> DbValue {
                 Some(v) => DbValue::Boolean(v),
                 None => DbValue::DbNull,
             }
-        },
+        }
         &Type::INT4 => {
             let value: Option<i32> = row.get(index);
             match value {
                 Some(v) => DbValue::Int32(v),
                 None => DbValue::DbNull,
             }
-        },
-        &Type::INT8 =>  {
+        }
+        &Type::INT8 => {
             let value: Option<i64> = row.get(index);
             match value {
                 Some(v) => DbValue::Int64(v),
                 None => DbValue::DbNull,
             }
-        },
-        &Type::VARCHAR =>  {
+        }
+        &Type::VARCHAR => {
             let value: Option<&str> = row.get(index);
             match value {
                 Some(v) => DbValue::DbString(v.to_owned()),
                 None => DbValue::DbNull,
             }
-        },
+        }
         t => {
-            tracing::debug!("Couldn't convert Postgres type {} in column {}", t.name(), column.name());
+            tracing::debug!(
+                "Couldn't convert Postgres type {} in column {}",
+                t.name(),
+                column.name()
+            );
             DbValue::Unsupported
-        },
+        }
     }
 }

--- a/crates/outbound-pg/src/lib.rs
+++ b/crates/outbound-pg/src/lib.rs
@@ -108,7 +108,7 @@ fn to_sql_parameter<'a>(value: &'a ParameterValue) -> anyhow::Result<&'a (dyn To
         ParameterValue::Uint16(_) => Err(anyhow!("Postgres does not support unsigned integers")),
         ParameterValue::Uint32(_) => Err(anyhow!("Postgres does not support unsigned integers")),
         ParameterValue::Uint64(_) => Err(anyhow!("Postgres does not support unsigned integers")),
-        ParameterValue::DbString(v) => Ok(v),
+        ParameterValue::Str(v) => Ok(v),
         ParameterValue::Binary(v) => Ok(v),
         ParameterValue::DbNull => Ok(&DB_NULL),
     }
@@ -138,8 +138,8 @@ fn convert_data_type(pg_type: &Type) -> DbDataType {
         Type::INT2 => DbDataType::Int16,
         Type::INT4 => DbDataType::Int32,
         Type::INT8 => DbDataType::Int64,
-        Type::TEXT => DbDataType::DbString,
-        Type::VARCHAR => DbDataType::DbString,
+        Type::TEXT => DbDataType::Str,
+        Type::VARCHAR => DbDataType::Str,
         _ => {
             tracing::debug!("Couldn't convert Postgres type {} to WIT", pg_type.name(),);
             DbDataType::Other
@@ -210,14 +210,14 @@ fn convert_entry(row: &Row, index: usize) -> Result<DbValue, postgres::Error> {
         &Type::TEXT => {
             let value: Option<&str> = row.try_get(index)?;
             match value {
-                Some(v) => DbValue::DbString(v.to_owned()),
+                Some(v) => DbValue::Str(v.to_owned()),
                 None => DbValue::DbNull,
             }
         }
         &Type::VARCHAR => {
             let value: Option<&str> = row.try_get(index)?;
             match value {
-                Some(v) => DbValue::DbString(v.to_owned()),
+                Some(v) => DbValue::Str(v.to_owned()),
                 None => DbValue::DbNull,
             }
         }

--- a/examples/rust-outbound-pg/db/testdata.sql
+++ b/examples/rust-outbound-pg/db/testdata.sql
@@ -1,0 +1,9 @@
+CREATE TABLE articletest (
+   id integer not null,
+   title varchar(40) not null,
+   content varchar(8000) not null,
+   authorname varchar(40) not null
+);
+
+INSERT INTO articletest VALUES (1, 'My Life as a Goat', 'I went to Nepal to live as a goat, and it was much better than being a butler.', 'E. Blackadder');
+INSERT INTO articletest VALUES (2, 'Magnificent Octopus', 'Once upon a time there was a lovely little sausage.', 'S. Baldrick');

--- a/examples/rust-outbound-pg/src/lib.rs
+++ b/examples/rust-outbound-pg/src/lib.rs
@@ -79,7 +79,7 @@ fn write(_req: Request) -> Result<Response> {
 
 fn as_owned_string(value: &pg::DbValue) -> anyhow::Result<String> {
     match value {
-        pg::DbValue::DbString(s) => Ok(s.to_owned()),
+        pg::DbValue::Str(s) => Ok(s.to_owned()),
         _ => Err(anyhow!("Expected string from database but got {:?}", value)),
     }
 }

--- a/examples/rust-outbound-pg/src/lib.rs
+++ b/examples/rust-outbound-pg/src/lib.rs
@@ -12,7 +12,7 @@ const DB_URL_ENV: &str = "DB_URL";
 #[derive(Debug, Clone)]
 struct Article {
     id: i32,
-    title: String, 
+    title: String,
     content: String,
     authorname: String,
 }
@@ -22,8 +22,15 @@ fn read(_req: Request) -> Result<Response> {
     let address = std::env::var(DB_URL_ENV)?;
 
     let sql = "select id, title, content, authorname from articletest";
-    let rowset = pg::query(&address,sql, &[])
+    let rowset = pg::query(&address, sql, &[])
         .map_err(|e| anyhow!("Error executing Postgres query: {:?}", e))?;
+
+    let column_summary = rowset
+        .columns
+        .iter()
+        .map(format_col)
+        .collect::<Vec<_>>()
+        .join(", ");
 
     let mut response_lines = vec![];
 
@@ -33,20 +40,29 @@ fn read(_req: Request) -> Result<Response> {
         let content = as_owned_string(&row[2])?;
         let authorname = as_owned_string(&row[3])?;
 
-        let article = Article {id, title, content, authorname};
+        let article = Article {
+            id,
+            title,
+            content,
+            authorname,
+        };
 
         println!("article: {:#?}", article);
         response_lines.push(format!("article: {:#?}", article));
     }
-    
+
     // use it in business logic
 
-    let response = format!("Found {} article(s) as follows:\n{}\n",
+    let response = format!(
+        "Found {} article(s) as follows:\n{}\n\n(Column info: {})\n",
         response_lines.len(),
-        response_lines.join("\n")
+        response_lines.join("\n"),
+        column_summary,
     );
 
-    Ok(http::Response::builder().status(200).body(Some(response.into()))?)
+    Ok(http::Response::builder()
+        .status(200)
+        .body(Some(response.into()))?)
 }
 /*
 fn write(_req: Request) -> Result<Response> {
@@ -71,6 +87,13 @@ fn as_owned_string(value: &pg::DbValue) -> anyhow::Result<String> {
 fn as_int(value: &pg::DbValue) -> anyhow::Result<i32> {
     match value {
         pg::DbValue::Int32(n) => Ok(*n),
-        _ => Err(anyhow!("Expected integer from database but got {:?}", value)),
+        _ => Err(anyhow!(
+            "Expected integer from database but got {:?}",
+            value
+        )),
     }
+}
+
+fn format_col(column: &pg::Column) -> String {
+    format!("{}:{:?}", column.name, column.data_type)
 }

--- a/wit/ephemeral/outbound-pg.wit
+++ b/wit/ephemeral/outbound-pg.wit
@@ -1,7 +1,8 @@
 use * from pg-types
+use * from rdbms-types
 
 // query the database: select
-query: func(address: string, statement: string, params: list<string>) -> expected<list<list<payload>>, error>
+query: func(address: string, statement: string, params: list<string>) -> expected<row-set, pg-error>
 
 // execute command to the database: insert, update, delete
-execute: func(address: string, statement: string, params: list<string>) -> expected<u64, error>
+execute: func(address: string, statement: string, params: list<string>) -> expected<u64, pg-error>

--- a/wit/ephemeral/outbound-pg.wit
+++ b/wit/ephemeral/outbound-pg.wit
@@ -2,7 +2,7 @@ use * from pg-types
 use * from rdbms-types
 
 // query the database: select
-query: func(address: string, statement: string, params: list<string>) -> expected<row-set, pg-error>
+query: func(address: string, statement: string, params: list<parameter-value>) -> expected<row-set, pg-error>
 
 // execute command to the database: insert, update, delete
-execute: func(address: string, statement: string, params: list<string>) -> expected<u64, pg-error>
+execute: func(address: string, statement: string, params: list<parameter-value>) -> expected<u64, pg-error>

--- a/wit/ephemeral/pg-types.wit
+++ b/wit/ephemeral/pg-types.wit
@@ -1,8 +1,7 @@
 // General purpose error.
-enum error {
+variant pg-error {
     success,
-    error,
+    connection-failed(string),
+    query-failed(string),
+    other-error(string)
 }
-
-// The field payload
-type payload = list<u8>

--- a/wit/ephemeral/pg-types.wit
+++ b/wit/ephemeral/pg-types.wit
@@ -2,6 +2,8 @@
 variant pg-error {
     success,
     connection-failed(string),
+    bad-parameter(string),
     query-failed(string),
+    value-conversion-failed(string),
     other-error(string)
 }

--- a/wit/ephemeral/rdbms-types.wit
+++ b/wit/ephemeral/rdbms-types.wit
@@ -10,7 +10,7 @@ enum db-data-type {
     uint64,
     floating32,
     floating64,
-    db-string,
+    str,
     binary,
     other,
 }
@@ -27,7 +27,7 @@ variant db-value {
     uint64(u64),
     floating32(float32),
     floating64(float64),
-    db-string(string),
+    str(string),
     binary(list<u8>),
     db-null,
     unsupported,
@@ -45,7 +45,7 @@ variant parameter-value {
     uint64(u64),
     floating32(float32),
     floating64(float64),
-    db-string(string),
+    str(string),
     binary(list<u8>),
     db-null,
 }

--- a/wit/ephemeral/rdbms-types.wit
+++ b/wit/ephemeral/rdbms-types.wit
@@ -1,25 +1,52 @@
 enum db-data-type {
     boolean,
+    int8,
+    int16,
     int32,
     int64,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
+    floating32,
+    floating64,
     db-string,
+    binary,
     other,
 }
 
 variant db-value {
     boolean(bool),
+    int8(s8),
+    int16(s16),
     int32(s32),
     int64(s64),
+    uint8(u8),
+    uint16(u16),
+    uint32(u32),
+    uint64(u64),
+    floating32(float32),
+    floating64(float64),
     db-string(string),
+    binary(list<u8>),
     db-null,
     unsupported,
 }
 
 variant parameter-value {
     boolean(bool),
+    int8(s8),
+    int16(s16),
     int32(s32),
     int64(s64),
+    uint8(u8),
+    uint16(u16),
+    uint32(u32),
+    uint64(u64),
+    floating32(float32),
+    floating64(float64),
     db-string(string),
+    binary(list<u8>),
     db-null,
 }
 

--- a/wit/ephemeral/rdbms-types.wit
+++ b/wit/ephemeral/rdbms-types.wit
@@ -23,6 +23,6 @@ record column {
 type row = list<db-value>
 
 record row-set {
-    // columns: list<column>,
+    columns: list<column>,
     rows: list<row>,
 }

--- a/wit/ephemeral/rdbms-types.wit
+++ b/wit/ephemeral/rdbms-types.wit
@@ -15,6 +15,14 @@ variant db-value {
     unsupported,
 }
 
+variant parameter-value {
+    boolean(bool),
+    int32(s32),
+    int64(s64),
+    db-string(string),
+    db-null,
+}
+
 record column {
     name: string,
     data-type: db-data-type,

--- a/wit/ephemeral/rdbms-types.wit
+++ b/wit/ephemeral/rdbms-types.wit
@@ -1,0 +1,28 @@
+enum db-data-type {
+    boolean,
+    int32,
+    int64,
+    db-string,
+    other,
+}
+
+variant db-value {
+    boolean(bool),
+    int32(s32),
+    int64(s64),
+    db-string(string),
+    db-null,
+    unsupported,
+}
+
+record column {
+    name: string,
+    data-type: db-data-type,
+}
+
+type row = list<db-value>
+
+record row-set {
+    // columns: list<column>,
+    rows: list<row>,
+}


### PR DESCRIPTION
This PR rounds out the initial Postgres implementation in two main ways:

1. Support data types other than strings
2. Categorise errors and provide error messages

As an implementation detail, it also proposes a `rdbms-types.wit` for types that are likely to be the same across multiple relational databases.  This is arguably premature, possibly even undesirable, though it could easily be reversed without a breaking change (bindgen folds includes, so things from this WIT are surfaced as they had been declared in "outbound-pg").

Feedback very much sought!