### PR TITLE
feat: feature gate the e2e tests that require dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Cargo Test
         run: |
           make test-unit
-          make test-integration
+          make test-e2e
         env:
           RUST_LOG: spin=trace
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ which = "4.2.5"
 cargo-target-dep = { git = "https://github.com/fermyon/cargo-target-dep", rev = "b7b1989fe0984c0f7c4966398304c6538e52fe49" }
 vergen = { version = "7", default-features = false, features = [ "build", "git" ] }
 
+[features]
+default = []
+e2e-tests = []
+
 [workspace]
 members = [
     "crates/build",

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,12 @@ test-unit:
 
 .PHONY: test-integration
 test-integration:
-	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --no-fail-fast  -- integration_tests::test_dependencies --nocapture
-	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --no-fail-fast -- --skip integration_tests::test_dependencies --nocapture --include-ignored
+	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --no-fail-fast -- --nocapture --include-ignored
+
+.PHONY: test-e2e
+test-e2e:
+	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --features e2e-tests --no-fail-fast  -- integration_tests::test_dependencies --nocapture 
+	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --features e2e-tests --no-fail-fast -- --skip integration_tests::test_dependencies --nocapture --include-ignored
 
 .PHONY: test-sdk-go
 test-sdk-go:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod integration_tests {
     use anyhow::{Context, Result};
-    use hyper::{header::HeaderName, Body, Client, Response};
+    use hyper::{Body, Client, Response};
     use spin_loader::local::{
         config::{RawAppManifestAnyVersion, RawModuleSource},
         raw_manifest_from_file,
@@ -9,50 +9,583 @@ mod integration_tests {
     use std::{
         ffi::OsStr,
         net::{Ipv4Addr, SocketAddrV4, TcpListener},
-        path::{Path, PathBuf},
+        path::Path,
         process::{self, Child, Command},
         time::Duration,
     };
-    use tempfile::TempDir;
     use tokio::{net::TcpStream, time::sleep};
-    use which::which;
 
     const RUST_HTTP_INTEGRATION_TEST: &str = "tests/http/simple-spin-rust";
-    const RUST_HTTP_INTEGRATION_TEST_REF: &str = "spin-hello-world/1.0.0";
-
     const RUST_HTTP_STATIC_ASSETS_TEST: &str = "tests/http/assets-test";
-    const RUST_HTTP_STATIC_ASSETS_REST_REF: &str = "spin-assets-test/1.0.0";
-
-    const RUST_HTTP_HEADERS_ENV_ROUTES_TEST: &str = "tests/http/headers-env-routes-test";
-    const RUST_HTTP_HEADERS_ENV_ROUTES_TEST_REF: &str = "spin-headers-env-routes-test/1.0.0";
 
     const DEFAULT_MANIFEST_LOCATION: &str = "spin.toml";
 
     const SPIN_BINARY: &str = "./target/debug/spin";
-    const BINDLE_SERVER_BINARY: &str = "bindle-server";
-    const NOMAD_BINARY: &str = "nomad";
-    const HIPPO_BINARY: &str = "Hippo.Web";
 
-    const BINDLE_SERVER_PATH_ENV: &str = "SPIN_TEST_BINDLE_SERVER_PATH";
-    const BINDLE_SERVER_BASIC_AUTH_HTPASSWD_FILE: &str = "tests/http/htpasswd";
-    const BINDLE_SERVER_BASIC_AUTH_USER: &str = "bindle-user";
-    const BINDLE_SERVER_BASIC_AUTH_PASSWORD: &str = "topsecret";
+    // This module consist of all integration tests that require dependencies such as bindle-server, nomad, and Hippo.Web to be installed.
+    #[cfg(feature = "e2e-tests")]
+    mod e2e_tests {
+        use super::*;
+        use hyper::header::HeaderName;
+        use std::path::PathBuf;
+        use tempfile::TempDir;
+        use which::which;
 
-    const HIPPO_BASIC_AUTH_USER: &str = "hippo-user";
-    const HIPPO_BASIC_AUTH_PASSWORD: &str = "topsecret";
+        const RUST_HTTP_INTEGRATION_TEST_REF: &str = "spin-hello-world/1.0.0";
 
-    // This assumes all tests have been previously compiled by the top-level build script.
+        const RUST_HTTP_STATIC_ASSETS_REST_REF: &str = "spin-assets-test/1.0.0";
 
-    #[tokio::test]
-    async fn test_dependencies() -> Result<()> {
-        which(get_process(BINDLE_SERVER_BINARY))
-            .with_context(|| format!("Can't find {}", get_process(BINDLE_SERVER_BINARY)))?;
-        which(get_process(NOMAD_BINARY))
-            .with_context(|| format!("Can't find {}", get_process(NOMAD_BINARY)))?;
-        which(get_process(HIPPO_BINARY))
-            .with_context(|| format!("Can't find {}", get_process(HIPPO_BINARY)))?;
+        const RUST_HTTP_HEADERS_ENV_ROUTES_TEST: &str = "tests/http/headers-env-routes-test";
+        const RUST_HTTP_HEADERS_ENV_ROUTES_TEST_REF: &str = "spin-headers-env-routes-test/1.0.0";
 
-        Ok(())
+        const BINDLE_SERVER_BINARY: &str = "bindle-server";
+        const NOMAD_BINARY: &str = "nomad";
+        const HIPPO_BINARY: &str = "Hippo.Web";
+
+        const BINDLE_SERVER_PATH_ENV: &str = "SPIN_TEST_BINDLE_SERVER_PATH";
+        const BINDLE_SERVER_BASIC_AUTH_HTPASSWD_FILE: &str = "tests/http/htpasswd";
+        const BINDLE_SERVER_BASIC_AUTH_USER: &str = "bindle-user";
+        const BINDLE_SERVER_BASIC_AUTH_PASSWORD: &str = "topsecret";
+
+        const HIPPO_BASIC_AUTH_USER: &str = "hippo-user";
+        const HIPPO_BASIC_AUTH_PASSWORD: &str = "topsecret";
+
+        // This assumes all tests have been previously compiled by the top-level build script.
+
+        #[tokio::test]
+        async fn test_dependencies() -> Result<()> {
+            which(get_process(BINDLE_SERVER_BINARY))
+                .with_context(|| format!("Can't find {}", get_process(BINDLE_SERVER_BINARY)))?;
+            which(get_process(NOMAD_BINARY))
+                .with_context(|| format!("Can't find {}", get_process(NOMAD_BINARY)))?;
+            which(get_process(HIPPO_BINARY))
+                .with_context(|| format!("Can't find {}", get_process(HIPPO_BINARY)))?;
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_bindle_roundtrip_no_auth() -> Result<()> {
+            // start the Bindle registry.
+            let config = BindleTestControllerConfig {
+                basic_auth_enabled: false,
+            };
+            let b = BindleTestController::new(config).await?;
+
+            // push the application to the registry using the Spin CLI.
+            run(
+                vec![
+                    SPIN_BINARY,
+                    "bindle",
+                    "push",
+                    "--file",
+                    &format!(
+                        "{}/{}",
+                        RUST_HTTP_INTEGRATION_TEST, DEFAULT_MANIFEST_LOCATION
+                    ),
+                    "--bindle-server",
+                    &b.url,
+                ],
+                None,
+            )?;
+
+            // start Spin using the bindle reference of the application that was just pushed.
+            let s = SpinTestController::with_bindle(RUST_HTTP_INTEGRATION_TEST_REF, &b.url, &[])
+                .await?;
+
+            assert_status(&s, "/test/hello", 200).await?;
+            assert_status(&s, "/test/hello/wildcards/should/be/handled", 200).await?;
+            assert_status(&s, "/thisshouldfail", 404).await?;
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_bindle_roundtrip_basic_auth() -> Result<()> {
+            // start the Bindle registry.
+            let config = BindleTestControllerConfig {
+                basic_auth_enabled: true,
+            };
+            let b = BindleTestController::new(config).await?;
+
+            // push the application to the registry using the Spin CLI.
+            run(
+                vec![
+                    SPIN_BINARY,
+                    "bindle",
+                    "push",
+                    "--file",
+                    &format!(
+                        "{}/{}",
+                        RUST_HTTP_INTEGRATION_TEST, DEFAULT_MANIFEST_LOCATION
+                    ),
+                    "--bindle-server",
+                    &b.url,
+                    "--bindle-username",
+                    BINDLE_SERVER_BASIC_AUTH_USER,
+                    "--bindle-password",
+                    BINDLE_SERVER_BASIC_AUTH_PASSWORD,
+                ],
+                None,
+            )?;
+
+            // start Spin using the bindle reference of the application that was just pushed.
+            let s = SpinTestController::with_bindle(RUST_HTTP_INTEGRATION_TEST_REF, &b.url, &[])
+                .await?;
+
+            assert_status(&s, "/test/hello", 200).await?;
+            assert_status(&s, "/test/hello/wildcards/should/be/handled", 200).await?;
+            assert_status(&s, "/thisshouldfail", 404).await?;
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_bindle_static_assets() -> Result<()> {
+            // start the Bindle registry.
+            let config = BindleTestControllerConfig {
+                basic_auth_enabled: false,
+            };
+            let b = BindleTestController::new(config).await?;
+
+            // push the application to the registry using the Spin CLI.
+            run(
+                vec![
+                    SPIN_BINARY,
+                    "bindle",
+                    "push",
+                    "--file",
+                    &format!(
+                        "{}/{}",
+                        RUST_HTTP_STATIC_ASSETS_TEST, DEFAULT_MANIFEST_LOCATION
+                    ),
+                    "--bindle-server",
+                    &b.url,
+                ],
+                None,
+            )?;
+
+            // start Spin using the bindle reference of the application that was just pushed.
+            let s = SpinTestController::with_bindle(RUST_HTTP_STATIC_ASSETS_REST_REF, &b.url, &[])
+                .await?;
+
+            assert_status(&s, "/static/thisshouldbemounted/1", 200).await?;
+            assert_status(&s, "/static/thisshouldbemounted/2", 200).await?;
+            assert_status(&s, "/static/thisshouldbemounted/3", 200).await?;
+
+            assert_status(&s, "/static/donotmount/a", 404).await?;
+            assert_status(
+                &s,
+                "/static/thisshouldbemounted/thisshouldbeexcluded/4",
+                404,
+            )
+            .await?;
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_headers_env_routes() -> Result<()> {
+            // start the Bindle registry.
+            let config = BindleTestControllerConfig {
+                basic_auth_enabled: false,
+            };
+            let b = BindleTestController::new(config).await?;
+
+            // push the application to the registry using the Spin CLI.
+            run(
+                vec![
+                    SPIN_BINARY,
+                    "bindle",
+                    "push",
+                    "--file",
+                    &format!(
+                        "{}/{}",
+                        RUST_HTTP_HEADERS_ENV_ROUTES_TEST, DEFAULT_MANIFEST_LOCATION
+                    ),
+                    "--bindle-server",
+                    &b.url,
+                ],
+                None,
+            )?;
+
+            // start Spin using the bindle reference of the application that was just pushed.
+            let s = SpinTestController::with_bindle(
+                RUST_HTTP_HEADERS_ENV_ROUTES_TEST_REF,
+                &b.url,
+                &["foo=bar"],
+            )
+            .await?;
+
+            assert_status(&s, "/env", 200).await?;
+
+            verify_headers(
+                &s,
+                "/env/foo",
+                200,
+                &[("env_foo", "bar"), ("env_some_key", "some_value")],
+                "/foo",
+            )
+            .await?;
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_using_parcel_as_module_source() -> Result<()> {
+            let wasm_path = PathBuf::from(RUST_HTTP_INTEGRATION_TEST)
+                .join("target")
+                .join("wasm32-wasi")
+                .join("release")
+                .join("spinhelloworld.wasm");
+            let parcel_sha = file_digest_string(&wasm_path).expect("failed to get sha for parcel");
+
+            // start the Bindle registry.
+            let config = BindleTestControllerConfig {
+                basic_auth_enabled: false,
+            };
+            let b = BindleTestController::new(config).await?;
+
+            // push the application to the registry using the Spin CLI.
+            run(
+                vec![
+                    SPIN_BINARY,
+                    "bindle",
+                    "push",
+                    "--file",
+                    &format!(
+                        "{}/{}",
+                        RUST_HTTP_INTEGRATION_TEST, DEFAULT_MANIFEST_LOCATION
+                    ),
+                    "--bindle-server",
+                    &b.url,
+                ],
+                None,
+            )?;
+
+            let manifest_template =
+                format!("{}/{}", RUST_HTTP_INTEGRATION_TEST, "spin-from-parcel.toml");
+            let manifest = replace_text(&manifest_template, "AWAITING_PARCEL_SHA", &parcel_sha);
+
+            let s = SpinTestController::with_manifest(
+                &format!("{}", manifest.path.display()),
+                &[],
+                Some(&b.url),
+            )
+            .await?;
+
+            assert_status(&s, "/test/hello", 200).await?;
+            assert_status(&s, "/test/hello/wildcards/should/be/handled", 200).await?;
+            assert_status(&s, "/thisshouldfail", 404).await?;
+            assert_status(&s, "/test/hello/test-placement", 200).await?;
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_spin_deploy() -> Result<()> {
+            println!("Testng spin deploy");
+            // start the Bindle registry.
+            let config = BindleTestControllerConfig {
+                basic_auth_enabled: false,
+            };
+            let _nomad = NomadTestController::new().await?;
+            let bindle = BindleTestController::new(config).await?;
+            let hippo = HippoTestController::new(&bindle.url).await?;
+
+            // push the application to the registry using the Spin CLI.
+            run(
+                vec![
+                    SPIN_BINARY,
+                    "deploy",
+                    "--file",
+                    &format!(
+                        "{}/{}",
+                        RUST_HTTP_HEADERS_ENV_ROUTES_TEST, DEFAULT_MANIFEST_LOCATION
+                    ),
+                    "--bindle-server",
+                    &bindle.url,
+                    "--hippo-server",
+                    &hippo.url,
+                    "--hippo-username",
+                    HIPPO_BASIC_AUTH_USER,
+                    "--hippo-password",
+                    HIPPO_BASIC_AUTH_PASSWORD,
+                ],
+                None,
+            )?;
+
+            let apps_vm = hippo.client.list_apps().await?;
+            assert_eq!(apps_vm.apps.len(), 1, "hippo apps: {apps_vm:?}");
+
+            Ok(())
+        }
+
+        async fn verify_headers(
+            s: &SpinTestController,
+            absolute_uri: &str,
+            expected: u16,
+            expected_env_as_headers: &[(&str, &str)],
+            expected_path_info: &str,
+        ) -> Result<()> {
+            let res = req(s, absolute_uri).await?;
+            assert_eq!(res.status(), expected);
+
+            // check the environment variables sent back as headers:
+            for (k, v) in expected_env_as_headers {
+                assert_eq!(
+                    &res.headers()
+                        .get(HeaderName::from_bytes(k.as_bytes())?)
+                        .unwrap_or_else(|| panic!("cannot find header {}", k))
+                        .to_str()?,
+                    v
+                );
+            }
+
+            assert_eq!(
+                res.headers()
+                    .get(HeaderName::from_bytes("spin-path-info".as_bytes())?)
+                    .unwrap_or_else(|| panic!("cannot find spin-path-info header"))
+                    .to_str()?,
+                expected_path_info
+            );
+
+            Ok(())
+        }
+
+        /// Controller for running a Bindle server.
+        /// This assumes `bindle-server` is present in the path.
+        pub struct BindleTestController {
+            pub url: String,
+            pub server_cache: TempDir,
+            server_handle: Child,
+        }
+
+        /// Config for the BindleTestController
+        pub struct BindleTestControllerConfig {
+            pub basic_auth_enabled: bool,
+        }
+
+        impl BindleTestController {
+            pub async fn new(config: BindleTestControllerConfig) -> Result<BindleTestController> {
+                let server_cache = tempfile::tempdir()?;
+
+                let address = format!("127.0.0.1:{}", get_random_port()?);
+                let url = format!("http://{}/v1/", address);
+
+                let bindle_server_binary = std::env::var(BINDLE_SERVER_PATH_ENV)
+                    .unwrap_or_else(|_| BINDLE_SERVER_BINARY.to_owned());
+
+                let auth_args = match config.basic_auth_enabled {
+                    true => vec!["--htpasswd-file", BINDLE_SERVER_BASIC_AUTH_HTPASSWD_FILE],
+                    false => vec!["--unauthenticated"],
+                };
+
+                let server_handle_result = Command::new(&bindle_server_binary)
+                    .args(
+                        [
+                            &[
+                                "-d",
+                                server_cache.path().to_string_lossy().to_string().as_str(),
+                                "-i",
+                                address.as_str(),
+                            ],
+                            auth_args.as_slice(),
+                        ]
+                        .concat(),
+                    )
+                    .spawn();
+
+                let mut server_handle = match server_handle_result {
+                    Ok(h) => Ok(h),
+                    Err(e) => {
+                        let is_path_explicit = std::env::var(BINDLE_SERVER_PATH_ENV).is_ok();
+                        let context = match e.kind() {
+                            std::io::ErrorKind::NotFound => {
+                                if is_path_explicit {
+                                    format!(
+                                        "executing {}: is the path/filename correct?",
+                                        bindle_server_binary
+                                    )
+                                } else {
+                                    format!(
+                                        "executing {}: is binary on PATH?",
+                                        bindle_server_binary
+                                    )
+                                }
+                            }
+                            _ => format!("executing {}", bindle_server_binary),
+                        };
+                        Err(e).context(context)
+                    }
+                }?;
+
+                wait_tcp(&address, &mut server_handle, BINDLE_SERVER_BINARY).await?;
+
+                Ok(Self {
+                    url,
+                    server_handle,
+                    server_cache,
+                })
+            }
+        }
+
+        impl Drop for BindleTestController {
+            fn drop(&mut self) {
+                let _ = self.server_handle.kill();
+            }
+        }
+
+        /// Controller for running Nomad.
+        pub struct NomadTestController {
+            pub url: String,
+            nomad_handle: Child,
+        }
+
+        impl NomadTestController {
+            pub async fn new() -> Result<NomadTestController> {
+                let url = "127.0.0.1:4646".to_string();
+
+                let mut nomad_handle = Command::new(get_process(NOMAD_BINARY))
+                    .args(["agent", "-dev"])
+                    .spawn()
+                    .with_context(|| "executing nomad")?;
+
+                wait_tcp(&url, &mut nomad_handle, NOMAD_BINARY).await?;
+
+                Ok(Self { url, nomad_handle })
+            }
+        }
+
+        impl Drop for NomadTestController {
+            fn drop(&mut self) {
+                let _ = self.nomad_handle.kill();
+            }
+        }
+
+        /// Controller for running Hippo.
+        pub struct HippoTestController {
+            pub url: String,
+            pub client: hippo::Client,
+            hippo_handle: Child,
+        }
+
+        impl HippoTestController {
+            pub async fn new(bindle_url: &str) -> Result<HippoTestController> {
+                let url = format!("http://127.0.0.1:{}", get_random_port()?);
+
+                let mut hippo_handle = Command::new(get_process(HIPPO_BINARY))
+                    .env("ASPNETCORE_URLS", &url)
+                    .env("Nomad__Driver", "raw_exec")
+                    .env("Nomad__Datacenters__0", "dc1")
+                    .env("Database__Driver", "inmemory")
+                    .env("ConnectionStrings__Bindle", format!("Address={bindle_url}"))
+                    .env("Jwt__Key", "ceci n'est pas une jeton")
+                    .env("Jwt__Issuer", "localhost")
+                    .env("Jwt__Audience", "localhost")
+                    .spawn()
+                    .with_context(|| "executing hippo")?;
+
+                wait_hippo(&url, &mut hippo_handle, HIPPO_BINARY).await?;
+
+                let client = hippo::Client::new(hippo::ConnectionInfo {
+                    url: url.clone(),
+                    danger_accept_invalid_certs: true,
+                    api_key: None,
+                });
+                client
+                    .register(
+                        HIPPO_BASIC_AUTH_USER.into(),
+                        HIPPO_BASIC_AUTH_PASSWORD.into(),
+                    )
+                    .await?;
+                let token_info = client
+                    .login(
+                        HIPPO_BASIC_AUTH_USER.into(),
+                        HIPPO_BASIC_AUTH_PASSWORD.into(),
+                    )
+                    .await?;
+                let client = hippo::Client::new(hippo::ConnectionInfo {
+                    url: url.clone(),
+                    danger_accept_invalid_certs: true,
+                    api_key: token_info.token,
+                });
+
+                Ok(Self {
+                    url,
+                    client,
+                    hippo_handle,
+                })
+            }
+        }
+
+        impl Drop for HippoTestController {
+            fn drop(&mut self) {
+                let _ = self.hippo_handle.kill();
+            }
+        }
+
+        async fn wait_hippo(url: &str, process: &mut Child, target: &str) -> Result<()> {
+            println!("hippo url is {} and process is {:?}", url, process);
+            let mut wait_count = 0;
+            loop {
+                if wait_count >= 120 {
+                    panic!(
+                        "Ran out of retries waiting for {} to start on URL {}",
+                        target, url
+                    );
+                }
+
+                if let Ok(Some(_)) = process.try_wait() {
+                    panic!(
+                        "Process exited before starting to serve {} to start on URL {}",
+                        target, url
+                    );
+                }
+
+                if let Ok(rsp) = reqwest::get(format!("{url}/healthz")).await {
+                    if let Ok(result) = rsp.text().await {
+                        if result == "Healthy" {
+                            break;
+                        }
+                    }
+                }
+
+                wait_count += 1;
+                sleep(Duration::from_secs(1)).await;
+            }
+
+            Ok(())
+        }
+
+        fn file_digest_string(path: impl AsRef<Path>) -> Result<String> {
+            use sha2::{Digest, Sha256};
+            let mut file = std::fs::File::open(&path)?;
+            let mut sha = Sha256::new();
+            std::io::copy(&mut file, &mut sha)?;
+            let digest_value = sha.finalize();
+            let digest_string = format!("{:x}", digest_value);
+            Ok(digest_string)
+        }
+
+        struct AutoDeleteFile {
+            pub path: PathBuf,
+        }
+
+        fn replace_text(template_path: impl AsRef<Path>, from: &str, to: &str) -> AutoDeleteFile {
+            let dest = template_path.as_ref().with_extension("temp");
+            let source_text =
+                std::fs::read_to_string(template_path).expect("failed to read manifest template");
+            let result_text = source_text.replace(from, to);
+            std::fs::write(&dest, result_text).expect("failed to write temp manifest");
+            AutoDeleteFile { path: dest }
+        }
+
+        impl Drop for AutoDeleteFile {
+            fn drop(&mut self) {
+                std::fs::remove_file(&self.path).unwrap();
+            }
+        }
     }
 
     #[tokio::test]
@@ -71,126 +604,6 @@ mod integration_tests {
         assert_status(&s, "/test/hello/wildcards/should/be/handled", 200).await?;
         assert_status(&s, "/thisshouldfail", 404).await?;
         assert_status(&s, "/test/hello/test-placement", 200).await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_bindle_roundtrip_no_auth() -> Result<()> {
-        // start the Bindle registry.
-        let config = BindleTestControllerConfig {
-            basic_auth_enabled: false,
-        };
-        let b = BindleTestController::new(config).await?;
-
-        // push the application to the registry using the Spin CLI.
-        run(
-            vec![
-                SPIN_BINARY,
-                "bindle",
-                "push",
-                "--file",
-                &format!(
-                    "{}/{}",
-                    RUST_HTTP_INTEGRATION_TEST, DEFAULT_MANIFEST_LOCATION
-                ),
-                "--bindle-server",
-                &b.url,
-            ],
-            None,
-        )?;
-
-        // start Spin using the bindle reference of the application that was just pushed.
-        let s =
-            SpinTestController::with_bindle(RUST_HTTP_INTEGRATION_TEST_REF, &b.url, &[]).await?;
-
-        assert_status(&s, "/test/hello", 200).await?;
-        assert_status(&s, "/test/hello/wildcards/should/be/handled", 200).await?;
-        assert_status(&s, "/thisshouldfail", 404).await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_bindle_roundtrip_basic_auth() -> Result<()> {
-        // start the Bindle registry.
-        let config = BindleTestControllerConfig {
-            basic_auth_enabled: true,
-        };
-        let b = BindleTestController::new(config).await?;
-
-        // push the application to the registry using the Spin CLI.
-        run(
-            vec![
-                SPIN_BINARY,
-                "bindle",
-                "push",
-                "--file",
-                &format!(
-                    "{}/{}",
-                    RUST_HTTP_INTEGRATION_TEST, DEFAULT_MANIFEST_LOCATION
-                ),
-                "--bindle-server",
-                &b.url,
-                "--bindle-username",
-                BINDLE_SERVER_BASIC_AUTH_USER,
-                "--bindle-password",
-                BINDLE_SERVER_BASIC_AUTH_PASSWORD,
-            ],
-            None,
-        )?;
-
-        // start Spin using the bindle reference of the application that was just pushed.
-        let s =
-            SpinTestController::with_bindle(RUST_HTTP_INTEGRATION_TEST_REF, &b.url, &[]).await?;
-
-        assert_status(&s, "/test/hello", 200).await?;
-        assert_status(&s, "/test/hello/wildcards/should/be/handled", 200).await?;
-        assert_status(&s, "/thisshouldfail", 404).await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_bindle_static_assets() -> Result<()> {
-        // start the Bindle registry.
-        let config = BindleTestControllerConfig {
-            basic_auth_enabled: false,
-        };
-        let b = BindleTestController::new(config).await?;
-
-        // push the application to the registry using the Spin CLI.
-        run(
-            vec![
-                SPIN_BINARY,
-                "bindle",
-                "push",
-                "--file",
-                &format!(
-                    "{}/{}",
-                    RUST_HTTP_STATIC_ASSETS_TEST, DEFAULT_MANIFEST_LOCATION
-                ),
-                "--bindle-server",
-                &b.url,
-            ],
-            None,
-        )?;
-
-        // start Spin using the bindle reference of the application that was just pushed.
-        let s =
-            SpinTestController::with_bindle(RUST_HTTP_STATIC_ASSETS_REST_REF, &b.url, &[]).await?;
-
-        assert_status(&s, "/static/thisshouldbemounted/1", 200).await?;
-        assert_status(&s, "/static/thisshouldbemounted/2", 200).await?;
-        assert_status(&s, "/static/thisshouldbemounted/3", 200).await?;
-
-        assert_status(&s, "/static/donotmount/a", 404).await?;
-        assert_status(
-            &s,
-            "/static/thisshouldbemounted/thisshouldbeexcluded/4",
-            404,
-        )
-        .await?;
 
         Ok(())
     }
@@ -218,174 +631,6 @@ mod integration_tests {
             404,
         )
         .await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_headers_env_routes() -> Result<()> {
-        // start the Bindle registry.
-        let config = BindleTestControllerConfig {
-            basic_auth_enabled: false,
-        };
-        let b = BindleTestController::new(config).await?;
-
-        // push the application to the registry using the Spin CLI.
-        run(
-            vec![
-                SPIN_BINARY,
-                "bindle",
-                "push",
-                "--file",
-                &format!(
-                    "{}/{}",
-                    RUST_HTTP_HEADERS_ENV_ROUTES_TEST, DEFAULT_MANIFEST_LOCATION
-                ),
-                "--bindle-server",
-                &b.url,
-            ],
-            None,
-        )?;
-
-        // start Spin using the bindle reference of the application that was just pushed.
-        let s = SpinTestController::with_bindle(
-            RUST_HTTP_HEADERS_ENV_ROUTES_TEST_REF,
-            &b.url,
-            &["foo=bar"],
-        )
-        .await?;
-
-        assert_status(&s, "/env", 200).await?;
-
-        verify_headers(
-            &s,
-            "/env/foo",
-            200,
-            &[("env_foo", "bar"), ("env_some_key", "some_value")],
-            "/foo",
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_using_parcel_as_module_source() -> Result<()> {
-        let wasm_path = PathBuf::from(RUST_HTTP_INTEGRATION_TEST)
-            .join("target")
-            .join("wasm32-wasi")
-            .join("release")
-            .join("spinhelloworld.wasm");
-        let parcel_sha = file_digest_string(&wasm_path).expect("failed to get sha for parcel");
-
-        // start the Bindle registry.
-        let config = BindleTestControllerConfig {
-            basic_auth_enabled: false,
-        };
-        let b = BindleTestController::new(config).await?;
-
-        // push the application to the registry using the Spin CLI.
-        run(
-            vec![
-                SPIN_BINARY,
-                "bindle",
-                "push",
-                "--file",
-                &format!(
-                    "{}/{}",
-                    RUST_HTTP_INTEGRATION_TEST, DEFAULT_MANIFEST_LOCATION
-                ),
-                "--bindle-server",
-                &b.url,
-            ],
-            None,
-        )?;
-
-        let manifest_template =
-            format!("{}/{}", RUST_HTTP_INTEGRATION_TEST, "spin-from-parcel.toml");
-        let manifest = replace_text(&manifest_template, "AWAITING_PARCEL_SHA", &parcel_sha);
-
-        let s = SpinTestController::with_manifest(
-            &format!("{}", manifest.path.display()),
-            &[],
-            Some(&b.url),
-        )
-        .await?;
-
-        assert_status(&s, "/test/hello", 200).await?;
-        assert_status(&s, "/test/hello/wildcards/should/be/handled", 200).await?;
-        assert_status(&s, "/thisshouldfail", 404).await?;
-        assert_status(&s, "/test/hello/test-placement", 200).await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_spin_deploy() -> Result<()> {
-        // start the Bindle registry.
-        let config = BindleTestControllerConfig {
-            basic_auth_enabled: false,
-        };
-        let _nomad = NomadTestController::new().await?;
-        let bindle = BindleTestController::new(config).await?;
-        let hippo = HippoTestController::new(&bindle.url).await?;
-
-        // push the application to the registry using the Spin CLI.
-        run(
-            vec![
-                SPIN_BINARY,
-                "deploy",
-                "--file",
-                &format!(
-                    "{}/{}",
-                    RUST_HTTP_HEADERS_ENV_ROUTES_TEST, DEFAULT_MANIFEST_LOCATION
-                ),
-                "--bindle-server",
-                &bindle.url,
-                "--hippo-server",
-                &hippo.url,
-                "--hippo-username",
-                HIPPO_BASIC_AUTH_USER,
-                "--hippo-password",
-                HIPPO_BASIC_AUTH_PASSWORD,
-            ],
-            None,
-        )?;
-
-        let apps_vm = hippo.client.list_apps().await?;
-        assert_eq!(apps_vm.apps.len(), 1, "hippo apps: {apps_vm:?}");
-
-        Ok(())
-    }
-
-    async fn verify_headers(
-        s: &SpinTestController,
-        absolute_uri: &str,
-        expected: u16,
-        expected_env_as_headers: &[(&str, &str)],
-        expected_path_info: &str,
-    ) -> Result<()> {
-        let res = req(s, absolute_uri).await?;
-        assert_eq!(res.status(), expected);
-
-        // check the environment variables sent back as headers:
-        for (k, v) in expected_env_as_headers {
-            assert_eq!(
-                &res.headers()
-                    .get(HeaderName::from_bytes(k.as_bytes())?)
-                    .unwrap_or_else(|| panic!("cannot find header {}", k))
-                    .to_str()?,
-                v
-            );
-        }
-
-        assert_eq!(
-            res.headers()
-                .get(HeaderName::from_bytes("spin-path-info".as_bytes())?)
-                .unwrap_or_else(|| panic!("cannot find spin-path-info header"))
-                .to_str()?,
-            expected_path_info
-        );
 
         Ok(())
     }
@@ -449,6 +694,7 @@ mod integration_tests {
         }
 
         // Unfortunately, this is a lot of duplicated code.
+        #[cfg(feature = "e2e-tests")]
         pub async fn with_bindle(
             id: &str,
             bindle_url: &str,
@@ -488,175 +734,6 @@ mod integration_tests {
     impl Drop for SpinTestController {
         fn drop(&mut self) {
             let _ = self.spin_handle.kill();
-        }
-    }
-
-    /// Controller for running a Bindle server.
-    /// This assumes `bindle-server` is present in the path.
-    pub struct BindleTestController {
-        pub url: String,
-        pub server_cache: TempDir,
-        server_handle: Child,
-    }
-
-    /// Config for the BindleTestController
-    pub struct BindleTestControllerConfig {
-        pub basic_auth_enabled: bool,
-    }
-
-    impl BindleTestController {
-        pub async fn new(config: BindleTestControllerConfig) -> Result<BindleTestController> {
-            let server_cache = tempfile::tempdir()?;
-
-            let address = format!("127.0.0.1:{}", get_random_port()?);
-            let url = format!("http://{}/v1/", address);
-
-            let bindle_server_binary = std::env::var(BINDLE_SERVER_PATH_ENV)
-                .unwrap_or_else(|_| BINDLE_SERVER_BINARY.to_owned());
-
-            let auth_args = match config.basic_auth_enabled {
-                true => vec!["--htpasswd-file", BINDLE_SERVER_BASIC_AUTH_HTPASSWD_FILE],
-                false => vec!["--unauthenticated"],
-            };
-
-            let server_handle_result = Command::new(&bindle_server_binary)
-                .args(
-                    [
-                        &[
-                            "-d",
-                            server_cache.path().to_string_lossy().to_string().as_str(),
-                            "-i",
-                            address.as_str(),
-                        ],
-                        auth_args.as_slice(),
-                    ]
-                    .concat(),
-                )
-                .spawn();
-
-            let mut server_handle = match server_handle_result {
-                Ok(h) => Ok(h),
-                Err(e) => {
-                    let is_path_explicit = std::env::var(BINDLE_SERVER_PATH_ENV).is_ok();
-                    let context = match e.kind() {
-                        std::io::ErrorKind::NotFound => {
-                            if is_path_explicit {
-                                format!(
-                                    "executing {}: is the path/filename correct?",
-                                    bindle_server_binary
-                                )
-                            } else {
-                                format!("executing {}: is binary on PATH?", bindle_server_binary)
-                            }
-                        }
-                        _ => format!("executing {}", bindle_server_binary),
-                    };
-                    Err(e).context(context)
-                }
-            }?;
-
-            wait_tcp(&address, &mut server_handle, BINDLE_SERVER_BINARY).await?;
-
-            Ok(Self {
-                url,
-                server_handle,
-                server_cache,
-            })
-        }
-    }
-
-    impl Drop for BindleTestController {
-        fn drop(&mut self) {
-            let _ = self.server_handle.kill();
-        }
-    }
-
-    /// Controller for running Nomad.
-    pub struct NomadTestController {
-        pub url: String,
-        nomad_handle: Child,
-    }
-
-    impl NomadTestController {
-        pub async fn new() -> Result<NomadTestController> {
-            let url = "127.0.0.1:4646".to_string();
-
-            let mut nomad_handle = Command::new(get_process(NOMAD_BINARY))
-                .args(["agent", "-dev"])
-                .spawn()
-                .with_context(|| "executing nomad")?;
-
-            wait_tcp(&url, &mut nomad_handle, NOMAD_BINARY).await?;
-
-            Ok(Self { url, nomad_handle })
-        }
-    }
-
-    impl Drop for NomadTestController {
-        fn drop(&mut self) {
-            let _ = self.nomad_handle.kill();
-        }
-    }
-
-    /// Controller for running Hippo.
-    pub struct HippoTestController {
-        pub url: String,
-        pub client: hippo::Client,
-        hippo_handle: Child,
-    }
-
-    impl HippoTestController {
-        pub async fn new(bindle_url: &str) -> Result<HippoTestController> {
-            let url = format!("http://127.0.0.1:{}", get_random_port()?);
-
-            let mut hippo_handle = Command::new(get_process(HIPPO_BINARY))
-                .env("ASPNETCORE_URLS", &url)
-                .env("Nomad__Driver", "raw_exec")
-                .env("Nomad__Datacenters__0", "dc1")
-                .env("Database__Driver", "inmemory")
-                .env("ConnectionStrings__Bindle", format!("Address={bindle_url}"))
-                .env("Jwt__Key", "ceci n'est pas une jeton")
-                .env("Jwt__Issuer", "localhost")
-                .env("Jwt__Audience", "localhost")
-                .spawn()
-                .with_context(|| "executing hippo")?;
-
-            wait_hippo(&url, &mut hippo_handle, HIPPO_BINARY).await?;
-
-            let client = hippo::Client::new(hippo::ConnectionInfo {
-                url: url.clone(),
-                danger_accept_invalid_certs: true,
-                api_key: None,
-            });
-            client
-                .register(
-                    HIPPO_BASIC_AUTH_USER.into(),
-                    HIPPO_BASIC_AUTH_PASSWORD.into(),
-                )
-                .await?;
-            let token_info = client
-                .login(
-                    HIPPO_BASIC_AUTH_USER.into(),
-                    HIPPO_BASIC_AUTH_PASSWORD.into(),
-                )
-                .await?;
-            let client = hippo::Client::new(hippo::ConnectionInfo {
-                url: url.clone(),
-                danger_accept_invalid_certs: true,
-                api_key: token_info.token,
-            });
-
-            Ok(Self {
-                url,
-                client,
-                hippo_handle,
-            })
-        }
-    }
-
-    impl Drop for HippoTestController {
-        fn drop(&mut self) {
-            let _ = self.hippo_handle.kill();
         }
     }
 
@@ -740,67 +817,6 @@ mod integration_tests {
         }
 
         Ok(())
-    }
-
-    async fn wait_hippo(url: &str, process: &mut Child, target: &str) -> Result<()> {
-        let mut wait_count = 0;
-        loop {
-            if wait_count >= 120 {
-                panic!(
-                    "Ran out of retries waiting for {} to start on URL {}",
-                    target, url
-                );
-            }
-
-            if let Ok(Some(_)) = process.try_wait() {
-                panic!(
-                    "Process exited before starting to serve {} to start on URL {}",
-                    target, url
-                );
-            }
-
-            if let Ok(rsp) = reqwest::get(format!("{url}/healthz")).await {
-                if let Ok(result) = rsp.text().await {
-                    if result == "Healthy" {
-                        break;
-                    }
-                }
-            }
-
-            wait_count += 1;
-            sleep(Duration::from_secs(1)).await;
-        }
-
-        Ok(())
-    }
-
-    fn file_digest_string(path: impl AsRef<Path>) -> Result<String> {
-        use sha2::{Digest, Sha256};
-        let mut file = std::fs::File::open(&path)?;
-        let mut sha = Sha256::new();
-        std::io::copy(&mut file, &mut sha)?;
-        let digest_value = sha.finalize();
-        let digest_string = format!("{:x}", digest_value);
-        Ok(digest_string)
-    }
-
-    struct AutoDeleteFile {
-        pub path: PathBuf,
-    }
-
-    fn replace_text(template_path: impl AsRef<Path>, from: &str, to: &str) -> AutoDeleteFile {
-        let dest = template_path.as_ref().with_extension("temp");
-        let source_text =
-            std::fs::read_to_string(template_path).expect("failed to read manifest template");
-        let result_text = source_text.replace(from, to);
-        std::fs::write(&dest, result_text).expect("failed to write temp manifest");
-        AutoDeleteFile { path: dest }
-    }
-
-    impl Drop for AutoDeleteFile {
-        fn drop(&mut self) {
-            std::fs::remove_file(&self.path).unwrap();
-        }
     }
 
     /// Builds app in `dir` and verifies the build succeeded. Expects manifest


### PR DESCRIPTION
Moves e2e integration tests that require dependencies behind an `e2e-tests` feature, so the dependencies (`bindle-server`, `nomad `and `Hippo.Web`) do not need to be installed to run `make test` or `make test-integration`. 

Running `make test-e2e` will run all tests including ones with dependencies (after checking the dependencies exist).

fixes #626 

Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>