### PR TITLE
feat: add accept-defaults to new templates

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -34,6 +34,11 @@ pub struct NewCommand {
     /// file.
     #[clap(long = "values-file")]
     pub values_file: Option<PathBuf>,
+
+    /// An optional argument that allows to skip prompts for the manifest file
+    /// by accepting the defaults if available on the template
+    #[clap(long = "accept-defaults", takes_value = false)]
+    pub accept_defaults: bool,
 }
 
 impl NewCommand {
@@ -59,6 +64,7 @@ impl NewCommand {
             name: self.name.clone(),
             output_path,
             values,
+            accept_defaults: self.accept_defaults,
         };
 
         match template {

--- a/templates/http-c/metadata/spin-template.toml
+++ b/templates/http-c/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-c"
 description = "HTTP request handler using C and the Zig toolchain"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-go/metadata/spin-template.toml
+++ b/templates/http-go/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-go"
 description = "HTTP request handler using (Tiny)Go"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-grain/metadata/spin-template.toml
+++ b/templates/http-grain/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-grain"
 description = "HTTP request handler using Grain"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-rust/metadata/spin-template.toml
+++ b/templates/http-rust/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-rust"
 description = "HTTP request handler using Rust"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-swift/metadata/spin-template.toml
+++ b/templates/http-swift/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-swift"
 description = "HTTP request handler using SwiftWasm"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-zig/metadata/spin-template.toml
+++ b/templates/http-zig/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-zig"
 description = "HTTP request handler using Zig"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/redis-go/metadata/spin-template.toml
+++ b/templates/redis-go/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "redis-go"
 description = "Redis message handler using (Tiny)Go"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 redis-address = { type = "string", prompt = "Redis address", default = "redis://localhost:6379" }
 redis-channel = { type = "string", prompt = "Redis channel" }

--- a/templates/redis-rust/metadata/spin-template.toml
+++ b/templates/redis-rust/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "redis-rust"
 description = "Redis message handler using Rust"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description" }
+project-description = { type = "string",  prompt = "Project description", default = "" }
 redis-address = { type = "string", prompt = "Redis address", default = "redis://localhost:6379" }
 redis-channel = { type = "string", prompt = "Redis channel" }


### PR DESCRIPTION
Add optional argument `--accept-defaults` to `spin new` to accept defaults where available from the template. The values file and value mentioned in the CLI still take precedence.

closes #591.