### PR TITLE
Remove dependency on 'wagi'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.5",
  "once_cell",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -78,27 +78,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,15 +122,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -162,7 +132,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f691e63585950d8c1c43644d11bab9073e40f5060dd2822734ae7c3dc69a3a80"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "blowfish",
  "getrandom 0.2.5",
 ]
@@ -179,60 +149,14 @@ dependencies = [
 [[package]]
 name = "bindle"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aefcdee8421fe9cb679bd5ec175a7d8e0bbaebdb1d950b26eb0118a5abed27cb"
-dependencies = [
- "anyhow",
- "async-compression",
- "async-trait",
- "base64 0.13.0",
- "bcrypt",
- "bytes 1.1.0",
- "dirs 4.0.0",
- "ed25519-dalek",
- "either",
- "futures",
- "hyper",
- "indexmap",
- "jsonwebtoken",
- "lru",
- "mime",
- "mime_guess",
- "oauth2",
- "openid",
- "rand 0.7.3",
- "reqwest",
- "semver 1.0.6",
- "serde",
- "serde_cbor",
- "serde_json",
- "sha2 0.10.2",
- "sled",
- "tempfile",
- "thiserror",
- "time 0.3.7",
- "tokio",
- "tokio-stream",
- "tokio-tar",
- "tokio-util 0.6.9",
- "toml",
- "tracing",
- "tracing-futures",
- "url 2.2.2",
- "warp",
-]
-
-[[package]]
-name = "bindle"
-version = "0.8.0"
 source = "git+https://github.com/fermyon/bindle?tag=v0.8.1#0dd1e7a7747d9f0ea8fda61d5f0f8cc3550f65dd"
 dependencies = [
  "anyhow",
  "async-compression",
  "async-trait",
- "base64 0.13.0",
+ "base64",
  "bcrypt",
- "bytes 1.1.0",
+ "bytes",
  "dirs 4.0.0",
  "ed25519-dalek",
  "either",
@@ -261,22 +185,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-futures",
- "url 2.2.2",
-]
-
-[[package]]
-name = "biscuit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dee631cea28b00e115fd355a1adedc860b155096941dc01259969eabd434a37"
-dependencies = [
- "chrono",
- "data-encoding",
- "num",
- "once_cell",
- "ring",
- "serde",
- "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -348,16 +257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,16 +273,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
 
 [[package]]
 name = "bytes"
@@ -518,13 +407,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -539,7 +424,7 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "lazy_static",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap 0.15.0",
 ]
@@ -583,7 +468,7 @@ version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "memchr",
  "pin-project-lite",
@@ -914,12 +799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
-
-[[package]]
 name = "dialoguer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,17 +917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "docker_credential"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40af8b38f4a4e72f314a29dfe3ce37a530585e85bc9acfd8b01faccaadfc130"
-dependencies = [
- "base64 0.10.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,15 +999,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env-file-reader"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00bb0c3f782b0967b28b4fd608ad3ce331817bdd120bbb193b3958a7a4a87b1"
-dependencies = [
- "regex",
 ]
 
 [[package]]
@@ -1259,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1403,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -1463,7 +1322,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -1478,12 +1337,12 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.6",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1510,31 +1369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "headers"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
-dependencies = [
- "base64 0.13.0",
- "bitflags",
- "bytes 1.1.0",
- "headers-core",
- "http 0.2.6",
- "httpdate",
- "mime",
- "sha-1 0.10.0",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.6",
 ]
 
 [[package]]
@@ -1610,7 +1444,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "url 2.2.2",
+ "url",
  "uuid",
 ]
 
@@ -1625,22 +1459,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa 0.4.8",
-]
-
-[[package]]
-name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "itoa 1.0.1",
 ]
@@ -1651,8 +1474,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
- "bytes 1.1.0",
- "http 0.2.6",
+ "bytes",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1680,12 +1503,12 @@ version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.6",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1704,13 +1527,13 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "http 0.2.6",
+ "http",
  "hyper",
  "log",
- "rustls 0.20.4",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.3",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1719,7 +1542,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "hyper",
  "native-tls",
  "tokio",
@@ -1727,39 +1550,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperx"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a94cbc2c6f63028e5736ca4e811ae36d3990059c384cbe68298c66728a9776"
-dependencies = [
- "base64 0.10.1",
- "bytes 0.4.12",
- "http 0.1.21",
- "httparse",
- "language-tags",
- "log",
- "mime",
- "percent-encoding 1.0.1",
- "time 0.1.44",
- "unicase 2.6.0",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -1771,12 +1565,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
@@ -1816,15 +1604,6 @@ checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1899,7 +1678,7 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "012bb02250fdd38faa5feee63235f7a459974440b9b57593822414c31f92839e"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "pem",
  "ring",
  "serde",
@@ -1915,12 +1694,6 @@ checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -2023,7 +1796,7 @@ dependencies = [
  "kstring",
  "liquid-core",
  "once_cell",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "regex",
  "unicode-segmentation",
 ]
@@ -2069,15 +1842,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
 
 [[package]]
 name = "matchers"
@@ -2146,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
- "unicase 2.6.0",
+ "unicase",
 ]
 
 [[package]]
@@ -2224,24 +1988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand 0.8.5",
- "safemem",
- "tempfile",
- "twoway",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,31 +2027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint 0.3.3",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,44 +2038,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-bigint 0.3.3",
- "num-integer",
  "num-traits",
 ]
 
@@ -2392,10 +2081,10 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e47cfc4c0a1a519d9a025ebfbac3a2439d1b5cdf397d72dcb79b11d9920dab"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "chrono",
  "getrandom 0.2.5",
- "http 0.2.6",
+ "http",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -2403,7 +2092,7 @@ dependencies = [
  "serde_path_to_error",
  "sha2 0.9.9",
  "thiserror",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -2415,26 +2104,6 @@ dependencies = [
  "crc32fast",
  "indexmap",
  "memchr",
-]
-
-[[package]]
-name = "oci-distribution"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28926bb291150df3e09d0962836b03e9c20fb21d8a172023c5e42650ff16647"
-dependencies = [
- "anyhow",
- "futures-util",
- "hyperx",
- "lazy_static",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tokio",
- "tracing",
- "www-authenticate",
 ]
 
 [[package]]
@@ -2460,24 +2129,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openid"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30a9456b3484c408d9708b6f65b2bd834fdf22b73567775e1ca6de5524dd19"
-dependencies = [
- "base64 0.13.0",
- "biscuit",
- "chrono",
- "lazy_static",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "url 2.2.2",
- "validator",
-]
 
 [[package]]
 name = "openssl"
@@ -2625,14 +2276,8 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -2680,7 +2325,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1 0.8.2",
+ "sha-1",
 ]
 
 [[package]]
@@ -2773,7 +2418,7 @@ version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8bbcd5f6deb39585a0d9f4ef34c4a41c25b7ad26d23c75d837d78c8e7adc85f"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fallible-iterator",
  "futures",
  "log",
@@ -2787,9 +2432,9 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "byteorder",
- "bytes 1.1.0",
+ "bytes",
  "fallible-iterator",
  "hmac",
  "md-5",
@@ -2805,7 +2450,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fallible-iterator",
  "postgres-protocol",
 ]
@@ -2826,7 +2471,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -2837,7 +2482,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -2896,14 +2541,8 @@ checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
 dependencies = [
  "bitflags",
  "memchr",
- "unicase 2.6.0",
+ "unicase",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quickcheck"
@@ -3026,17 +2665,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
 dependencies = [
  "async-trait",
- "bytes 1.1.0",
+ "bytes",
  "combine",
  "dtoa",
  "futures-util",
  "itoa 0.4.8",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite",
  "sha1",
  "tokio",
  "tokio-util 0.6.9",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -3123,13 +2762,13 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
+ "base64",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.6",
+ "http",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -3141,18 +2780,18 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.4",
+ "rustls",
  "rustls-pemfile 0.3.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.3",
+ "tokio-rustls",
  "tokio-util 0.6.9",
- "url 2.2.2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3214,27 +2853,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.0",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -3255,7 +2881,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -3264,7 +2890,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -3278,12 +2904,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -3315,26 +2935,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sct"
@@ -3433,7 +3037,6 @@ version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
- "indexmap",
  "itoa 1.0.1",
  "ryu",
  "serde",
@@ -3470,30 +3073,6 @@ dependencies = [
  "digest 0.8.1",
  "fake-simd",
  "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.3",
 ]
 
 [[package]]
@@ -3595,7 +3174,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
 dependencies = [
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-traits",
  "thiserror",
  "time 0.3.7",
@@ -3671,8 +3250,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "bindle 0.8.0 (git+https://github.com/fermyon/bindle?tag=v0.8.1)",
- "bytes 1.1.0",
+ "bindle",
+ "bytes",
  "cargo-target-dep",
  "clap 3.1.15",
  "comfy-table",
@@ -3710,8 +3289,8 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.3.9",
- "url 2.2.2",
+ "tracing-subscriber",
+ "url",
  "uuid",
  "vergen",
  "wasi-outbound-http",
@@ -3735,7 +3314,7 @@ name = "spin-engine"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "bytes 1.1.0",
+ "bytes",
  "cap-std",
  "dirs 4.0.0",
  "sanitize-filename",
@@ -3759,18 +3338,19 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "bytes 1.1.0",
+ "bytes",
  "cap-std",
  "clap 3.1.15",
  "criterion",
  "futures",
  "futures-util",
- "http 0.2.6",
+ "http",
  "hyper",
  "hyper-rustls",
  "indexmap",
  "miniserde",
  "num_cpus",
+ "percent-encoding",
  "rustls-pemfile 0.3.0",
  "serde",
  "spin-engine",
@@ -3779,12 +3359,11 @@ dependencies = [
  "spin-trigger",
  "tls-listener",
  "tokio",
- "tokio-rustls 0.23.3",
+ "tokio-rustls",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.3.9",
- "url 2.2.2",
- "wagi",
+ "tracing-subscriber",
+ "url",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
@@ -3798,8 +3377,8 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bindle 0.8.0 (git+https://github.com/fermyon/bindle?tag=v0.8.1)",
- "bytes 1.1.0",
+ "bindle",
+ "bytes",
  "dirs 4.0.0",
  "fs_extra",
  "futures",
@@ -3819,7 +3398,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
  "walkdir",
  "wasi-outbound-http",
 ]
@@ -3829,8 +3408,8 @@ name = "spin-macro"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes 1.1.0",
- "http 0.2.6",
+ "bytes",
+ "http",
  "proc-macro2",
  "quote",
  "syn",
@@ -3856,7 +3435,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bindle 0.8.0 (git+https://github.com/fermyon/bindle?tag=v0.8.1)",
+ "bindle",
  "dunce",
  "futures",
  "itertools",
@@ -3890,7 +3469,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
@@ -3902,9 +3481,9 @@ name = "spin-sdk"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "bytes 1.1.0",
+ "bytes",
  "form_urlencoded",
- "http 0.2.6",
+ "http",
  "spin-macro",
  "wit-bindgen-rust",
 ]
@@ -3915,7 +3494,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.1.0",
+ "bytes",
  "console",
  "dialoguer 0.10.0",
  "dirs 3.0.2",
@@ -3941,7 +3520,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
- "url 2.2.2",
+ "url",
  "walkdir",
 ]
 
@@ -3950,7 +3529,7 @@ name = "spin-testing"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "http 0.2.6",
+ "http",
  "hyper",
  "spin-engine",
  "spin-http-engine",
@@ -3974,7 +3553,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
@@ -3991,7 +3570,7 @@ dependencies = [
  "ctrlc",
  "dotenvy",
  "futures",
- "http 0.2.6",
+ "http",
  "outbound-pg",
  "outbound-redis",
  "serde",
@@ -4019,12 +3598,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -4262,7 +3835,7 @@ dependencies = [
  "pin-project-lite",
  "thiserror",
  "tokio",
- "tokio-rustls 0.23.3",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -4271,7 +3844,7 @@ version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "libc",
  "memchr",
  "mio 0.8.2",
@@ -4314,12 +3887,12 @@ checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes 1.1.0",
+ "bytes",
  "fallible-iterator",
  "futures",
  "log",
  "parking_lot 0.12.0",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "phf",
  "pin-project-lite",
  "postgres-protocol",
@@ -4331,24 +3904,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
- "rustls 0.20.4",
+ "rustls",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -4378,25 +3940,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
-dependencies = [
- "futures-util",
- "log",
- "pin-project",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -4410,7 +3959,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -4489,38 +4038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,7 +4045,7 @@ checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",
- "matchers 0.1.0",
+ "matchers",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -4545,34 +4062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "tungstenite"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
-dependencies = [
- "base64 0.13.0",
- "byteorder",
- "bytes 1.1.0",
- "http 0.2.6",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha-1 0.9.8",
- "thiserror",
- "url 2.2.2",
- "utf-8",
-]
-
-[[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4586,20 +4075,11 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -4643,42 +4123,16 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "url-escape"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e0ce4d1246d075ca5abec4b41d33e87a6054d08e2366b63205665e950db218"
-dependencies = [
- "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -4688,45 +4142,6 @@ checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "validator"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d6937c33ec6039d8071bcf72933146b5bbe378d645d8fa59bdadabfc2a249"
-dependencies = [
- "idna 0.2.3",
- "lazy_static",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url 2.2.2",
- "validator_derive",
- "validator_types",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286b4497f270f59276a89ae0ad109d5f8f18c69b613e3fb22b61201aadb0c4d"
-dependencies = [
- "if_chain",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "regex",
- "syn",
- "validator_types",
-]
-
-[[package]]
-name = "validator_types"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
 name = "valuable"
@@ -4739,12 +4154,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
@@ -4764,54 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
-[[package]]
-name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wagi"
-version = "0.8.1"
-source = "git+https://github.com/deislabs/wagi?rev=479fae0e375679865be47a2bc2f1cc183531ab52#479fae0e375679865be47a2bc2f1cc183531ab52"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "bindle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cap-std",
- "chrono",
- "clap 2.34.0",
- "docker_credential",
- "env-file-reader",
- "futures",
- "hyper",
- "indexmap",
- "oci-distribution",
- "reqwest",
- "serde",
- "sha2 0.9.9",
- "tempfile",
- "tokio",
- "tokio-rustls 0.22.0",
- "toml",
- "tracing",
- "tracing-futures",
- "tracing-subscriber 0.2.25",
- "url 2.2.2",
- "url-escape",
- "wasi-cap-std-sync",
- "wasi-common",
- "wasi-experimental-http-wasmtime",
- "wasmtime",
- "wasmtime-cache",
- "wasmtime-wasi",
- "wat",
-]
 
 [[package]]
 name = "walkdir"
@@ -4832,37 +4196,6 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
-dependencies = [
- "bytes 1.1.0",
- "futures-channel",
- "futures-util",
- "headers",
- "http 0.2.6",
- "hyper",
- "log",
- "mime",
- "mime_guess",
- "multipart",
- "percent-encoding 2.1.0",
- "pin-project",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-rustls 0.22.0",
- "tokio-stream",
- "tokio-tungstenite",
- "tokio-util 0.6.9",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4925,40 +4258,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi-experimental-http-wasmtime"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b3c3d331fffcd3725016d16f289e165fbdd9a9cc53da7266a4cd61b7dbf104"
-dependencies = [
- "anyhow",
- "bytes 1.1.0",
- "futures",
- "http 0.2.6",
- "reqwest",
- "thiserror",
- "tokio",
- "tracing",
- "url 2.2.2",
- "wasi-common",
- "wasmtime",
- "wasmtime-wasi",
-]
-
-[[package]]
 name = "wasi-outbound-http"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "bytes 1.1.0",
+ "bytes",
  "futures",
- "http 0.2.6",
+ "http",
  "reqwest",
  "spin-engine",
  "spin-manifest",
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.2",
+ "url",
  "wit-bindgen-wasmtime",
 ]
 
@@ -5075,7 +4388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c6ab24291fa7cb3a181f5669f6c72599b7ef781669759b45c7828c5999d0c0"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
+ "base64",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
@@ -5272,16 +4585,6 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -5296,7 +4599,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -5550,17 +4853,6 @@ dependencies = [
  "log",
  "thiserror",
  "wast 35.0.2",
-]
-
-[[package]]
-name = "www-authenticate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62efb8259cda4e4c732287397701237b78daa4c43edcf3e613c8503a6c07dd"
-dependencies = [
- "hyperx",
- "unicase 1.4.2",
- "url 1.7.2",
 ]
 
 [[package]]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -20,6 +20,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.23.0" }
 indexmap = "1"
+percent-encoding = "2"
 serde = { version = "1.0", features = ["derive"] }
 spin-manifest = { path = "../manifest" }
 spin-engine = { path = "../engine" }
@@ -36,7 +37,6 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2"
-wagi = { git = "https://github.com/deislabs/wagi", rev = "479fae0e375679865be47a2bc2f1cc183531ab52" }
 wasi-cap-std-sync = "0.35.3"
 wasi-common = "0.35.3"
 wasmtime = "0.35.3"

--- a/crates/http/src/wagi/LICENSE.wagi
+++ b/crates/http/src/wagi/LICENSE.wagi
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright (c) Microsoft Corporation. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/http/src/wagi/util.rs
+++ b/crates/http/src/wagi/util.rs
@@ -1,0 +1,325 @@
+// This file contains code copied from https://github.com/deislabs/wagi
+// The copied code's license is in this directory under LICENSE.wagi
+
+use std::{collections::HashMap, net::SocketAddr};
+
+use anyhow::Error;
+use http::{
+    header::{HeaderName, HOST},
+    request::Parts,
+    HeaderMap, HeaderValue, Response, StatusCode,
+};
+use hyper::Body;
+
+use crate::routes::RoutePattern;
+
+/// This sets the version of CGI that WAGI adheres to.
+///
+/// At the point at which WAGI diverges from CGI, this value will be replaced with
+/// WAGI/1.0
+pub const WAGI_VERSION: &str = "CGI/1.1";
+
+/// The CGI-defined "server software version".
+pub const SERVER_SOFTWARE_VERSION: &str = "WAGI/1";
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_headers(
+    route: &RoutePattern,
+    req: &Parts,
+    content_length: usize,
+    client_addr: SocketAddr,
+    default_host: &str,
+    use_tls: bool,
+) -> HashMap<String, String> {
+    let (host, port) = parse_host_header_uri(&req.headers, &req.uri, default_host);
+    let path_info = req
+        .uri
+        .path()
+        .strip_prefix(route.path_or_prefix())
+        .unwrap_or_default()
+        .to_owned();
+
+    let mut headers = HashMap::new();
+
+    // CGI headers from RFC
+    headers.insert("AUTH_TYPE".to_owned(), "".to_owned()); // Not currently supported
+
+    // CONTENT_LENGTH (from the spec)
+    // The server MUST set this meta-variable if and only if the request is
+    // accompanied by a message-body entity.  The CONTENT_LENGTH value must
+    // reflect the length of the message-body after the server has removed
+    // any transfer-codings or content-codings.
+    headers.insert("CONTENT_LENGTH".to_owned(), format!("{}", content_length));
+
+    // CONTENT_TYPE (from the spec)
+    // The server MUST set this meta-variable if an HTTP Content-Type field is present
+    // in the client request header.  If the server receives a request with an
+    // attached entity but no Content-Type header field, it MAY attempt to determine
+    // the correct content type, otherwise it should omit this meta-variable.
+    //
+    // Right now, we don't attempt to determine a media type if none is presented.
+    //
+    // The spec seems to indicate that if CONTENT_LENGTH > 0, this may be set
+    // to "application/octet-stream" if no type is otherwise set. Not sure that is
+    // a good idea.
+    headers.insert(
+        "CONTENT_TYPE".to_owned(),
+        req.headers
+            .get("CONTENT_TYPE")
+            .map(|c| c.to_str().unwrap_or(""))
+            .unwrap_or("")
+            .to_owned(),
+    );
+
+    let protocol = if use_tls { "https" } else { "http" };
+
+    // Since this is not in the specification, an X_ is prepended, per spec.
+    // NB: It is strange that there is not a way to do this already. The Display impl
+    // seems to only provide the path.
+    let uri = req.uri.clone();
+    headers.insert(
+        "X_FULL_URL".to_owned(),
+        format!(
+            "{}://{}:{}{}",
+            protocol,
+            host,
+            port,
+            uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("")
+        ),
+    );
+
+    headers.insert("GATEWAY_INTERFACE".to_owned(), WAGI_VERSION.to_owned());
+
+    // This is the Wagi route. This is different from PATH_INFO in that it may
+    // have a trailing '/...'
+    headers.insert(
+        "X_MATCHED_ROUTE".to_owned(),
+        route.full_pattern().into_owned(),
+    );
+
+    headers.insert(
+        "QUERY_STRING".to_owned(),
+        req.uri.query().unwrap_or("").to_owned(),
+    );
+
+    headers.insert("REMOTE_ADDR".to_owned(), client_addr.ip().to_string());
+    headers.insert("REMOTE_HOST".to_owned(), client_addr.ip().to_string()); // The server MAY substitute it with REMOTE_ADDR
+    headers.insert("REMOTE_USER".to_owned(), "".to_owned()); // TODO: Parse this out of uri.authority?
+    headers.insert("REQUEST_METHOD".to_owned(), req.method.to_string());
+
+    // The Path component is /$SCRIPT_NAME/$PATH_INFO
+    // SCRIPT_NAME is the route that matched.
+    // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.13
+    headers.insert("SCRIPT_NAME".to_owned(), route.path_or_prefix().to_owned());
+    // PATH_INFO is any path information after SCRIPT_NAME
+    //
+    // I am intentionally ignoring the PATH_INFO rule that says that a PATH_INFO
+    // cannot have a path seperator in it. If it becomes important to distinguish
+    // between what was decoded out of the path and what is encoded in the path,
+    // the X_RAW_PATH_INFO can be used.
+    //
+    // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.5
+    let pathsegment = path_info;
+    let pathinfo = percent_encoding::percent_decode_str(&pathsegment).decode_utf8_lossy();
+    headers.insert("X_RAW_PATH_INFO".to_owned(), pathsegment.clone());
+    headers.insert("PATH_INFO".to_owned(), pathinfo.to_string());
+    // PATH_TRANSLATED is the url-decoded version of PATH_INFO
+    // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.6
+    headers.insert("PATH_TRANSLATED".to_owned(), pathinfo.to_string());
+
+    // From the spec: "the server would use the contents of the request's Host header
+    // field to select the correct virtual host."
+    headers.insert("SERVER_NAME".to_owned(), host);
+    headers.insert("SERVER_PORT".to_owned(), port);
+    headers.insert("SERVER_PROTOCOL".to_owned(), format!("{:?}", req.version));
+
+    headers.insert(
+        "SERVER_SOFTWARE".to_owned(),
+        SERVER_SOFTWARE_VERSION.to_owned(),
+    );
+
+    // Normalize incoming HTTP headers. The spec says:
+    // "The HTTP header field name is converted to upper case, has all
+    // occurrences of "-" replaced with "_" and has "HTTP_" prepended to
+    // give the meta-variable name."
+    req.headers.iter().for_each(|header| {
+        let key = format!(
+            "HTTP_{}",
+            header.0.as_str().to_uppercase().replace('-', "_")
+        );
+        // Per spec 4.1.18, skip some headers
+        if key == "HTTP_AUTHORIZATION" || key == "HTTP_CONNECTION" {
+            return;
+        }
+        let val = header.1.to_str().unwrap_or("CORRUPT VALUE").to_owned();
+        headers.insert(key, val);
+    });
+
+    headers
+}
+
+/// Internal utility function for parsing a host header.
+///
+/// This attempts to use three sources to construct a definitive host/port pair, ordering
+/// by precedent.
+///
+/// - The content of the host header is considered most authoritative.
+/// - Next most authoritative is self.host, which is set at the CLI or in the config
+/// - As a last resort, we use the host/port that Hyper gives us.
+/// - If none of these provide sufficient data, which is definitely a possiblity,
+///   we go with `localhost` as host and `80` as port. This, of course, is problematic,
+///   but should only manifest if both the server and the client are behaving badly.
+fn parse_host_header_uri(
+    headers: &HeaderMap,
+    uri: &hyper::Uri,
+    default_host: &str,
+) -> (String, String) {
+    let host_header = headers.get(HOST).and_then(|v| match v.to_str() {
+        Err(_) => None,
+        Ok(s) => Some(s.to_owned()),
+    });
+
+    let mut host = uri
+        .host()
+        .map(|h| h.to_string())
+        .unwrap_or_else(|| "localhost".to_owned());
+    let mut port = uri.port_u16().unwrap_or(80).to_string();
+
+    let mut parse_host = |hdr: String| {
+        let mut parts = hdr.splitn(2, ':');
+        match parts.next() {
+            Some(h) if !h.is_empty() => host = h.to_owned(),
+            _ => {}
+        }
+        match parts.next() {
+            Some(p) if !p.is_empty() => {
+                tracing::debug!(port = p, "Overriding port");
+                port = p.to_owned()
+            }
+            _ => {}
+        }
+    };
+
+    // Override with local host field if set.
+    if !default_host.is_empty() {
+        parse_host(default_host.to_owned());
+    }
+
+    // Finally, the value of the HOST header is considered authoritative.
+    // When it comes to port number, the HOST header isn't necessarily 100% trustworthy.
+    // But it appears that this is still the best behavior for the CGI spec.
+    if let Some(hdr) = host_header {
+        parse_host(hdr);
+    }
+
+    (host, port)
+}
+
+pub fn compose_response(stdout: &[u8]) -> Result<Response<Body>, Error> {
+    // Okay, once we get here, all the information we need to send back in the response
+    // should be written to the STDOUT buffer. We fetch that, format it, and send
+    // it back. In the process, we might need to alter the status code of the result.
+    //
+    // This is a little janky, but basically we are looping through the output once,
+    // looking for the double-newline that distinguishes the headers from the body.
+    // The headers can then be parsed separately, while the body can be sent back
+    // to the client.
+    let mut last = 0;
+    let mut scan_headers = true;
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut out_headers: Vec<u8> = Vec::new();
+    stdout.iter().for_each(|i| {
+        // Ignore CR in headers
+        if scan_headers && *i == 13 {
+            return;
+        } else if scan_headers && *i == 10 && last == 10 {
+            out_headers.append(&mut buffer);
+            buffer = Vec::new();
+            scan_headers = false;
+            return; // Consume the linefeed
+        }
+        last = *i;
+        buffer.push(*i)
+    });
+    let mut res = Response::new(Body::from(buffer));
+    let mut sufficient_response = false;
+    parse_cgi_headers(String::from_utf8(out_headers)?)
+        .iter()
+        .for_each(|h| {
+            use hyper::header::{CONTENT_TYPE, LOCATION};
+            match h.0.to_lowercase().as_str() {
+                "content-type" => {
+                    sufficient_response = true;
+                    res.headers_mut().insert(CONTENT_TYPE, h.1.parse().unwrap());
+                }
+                "status" => {
+                    // The spec does not say that status is a sufficient response.
+                    // (It says that it may be added along with Content-Type, because
+                    // a status has a content type). However, CGI libraries in the wild
+                    // do not set content type correctly if a status is an error.
+                    // See https://datatracker.ietf.org/doc/html/rfc3875#section-6.2
+                    sufficient_response = true;
+                    // Status can be `Status CODE [STRING]`, and we just want the CODE.
+                    let status_code = h.1.split_once(' ').map(|(code, _)| code).unwrap_or(h.1);
+                    tracing::debug!(status_code, "Raw status code");
+                    match status_code.parse::<StatusCode>() {
+                        Ok(code) => *res.status_mut() = code,
+                        Err(e) => {
+                            tracing::log::warn!("Failed to parse code: {}", e);
+                            *res.status_mut() = StatusCode::BAD_GATEWAY;
+                        }
+                    }
+                }
+                "location" => {
+                    sufficient_response = true;
+                    res.headers_mut()
+                        .insert(LOCATION, HeaderValue::from_str(h.1).unwrap());
+                    *res.status_mut() = StatusCode::from_u16(302).unwrap();
+                }
+                _ => {
+                    // If the header can be parsed into a valid HTTP header, it is
+                    // added to the headers. Otherwise it is ignored.
+                    match HeaderName::from_lowercase(h.0.as_str().to_lowercase().as_bytes()) {
+                        Ok(hdr) => {
+                            res.headers_mut()
+                                .insert(hdr, HeaderValue::from_str(h.1).unwrap());
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, header_name = %h.0, "Invalid header name")
+                        }
+                    }
+                }
+            }
+        });
+    if !sufficient_response {
+        tracing::debug!("{:?}", res.body());
+        return Ok(internal_error(
+            // Technically, we let `status` be sufficient, but this is more lenient
+            // than the specification.
+            "Exactly one of 'location' or 'content-type' must be specified",
+        ));
+    }
+    Ok(res)
+}
+
+fn parse_cgi_headers(headers: String) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    headers.trim().split('\n').for_each(|h| {
+        let parts: Vec<&str> = h.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            tracing::warn!(header = h, "corrupt header");
+            return;
+        }
+        map.insert(parts[0].trim().to_owned(), parts[1].trim().to_owned());
+    });
+    map
+}
+
+/// Create an HTTP 500 response
+fn internal_error(msg: impl std::string::ToString) -> Response<Body> {
+    let message = msg.to_string();
+    tracing::error!(error = %message, "HTTP 500 error");
+    let mut res = Response::new(Body::from(message));
+    *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+    res
+}


### PR DESCRIPTION
Spin's Wagi implementation depended on only a few functions from the
'wagi' crate. Remove the crate dependency by copying those functions into
Spin, with some small adaptations.

This removes some transitive dependencies including `wasi-experimental-http`.