### PR TITLE
Temporarily use forked bindle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindle"
+version = "0.8.0"
+source = "git+https://github.com/fermyon/bindle?tag=v0.8.1#0dd1e7a7747d9f0ea8fda61d5f0f8cc3550f65dd"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "async-trait",
+ "base64 0.13.0",
+ "bcrypt",
+ "bytes 1.1.0",
+ "dirs 4.0.0",
+ "ed25519-dalek",
+ "either",
+ "futures",
+ "hyper",
+ "jsonwebtoken",
+ "lru",
+ "mime",
+ "mime_guess",
+ "oauth2",
+ "rand 0.7.3",
+ "reqwest",
+ "semver 1.0.6",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.2",
+ "sled",
+ "tempfile",
+ "thiserror",
+ "time 0.3.7",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util 0.6.9",
+ "toml",
+ "tracing",
+ "tracing-futures",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "biscuit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,7 +3662,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "bindle",
+ "bindle 0.8.0 (git+https://github.com/fermyon/bindle?tag=v0.8.1)",
  "bytes 1.1.0",
  "cargo-target-dep",
  "clap 3.1.15",
@@ -3747,7 +3789,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bindle",
+ "bindle 0.8.0 (git+https://github.com/fermyon/bindle?tag=v0.8.1)",
  "bytes 1.1.0",
  "dirs 4.0.0",
  "fs_extra",
@@ -3805,7 +3847,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bindle",
+ "bindle 0.8.0 (git+https://github.com/fermyon/bindle?tag=v0.8.1)",
  "dunce",
  "futures",
  "itertools",
@@ -4730,7 +4772,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "bindle",
+ "bindle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cap-std",
  "chrono",
  "clap 2.34.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 anyhow = "1.0"
 async-trait = "0.1"
 atty = "0.2"
-bindle = { version = "0.8.0", default-features = false, features = ["client"] }
+bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.1", default-features = false, features = ["client"] }
 bytes = "1.1"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 comfy-table = "5.0"

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = "0.3.8"
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.23.0" }
-indexmap = "1.6"
+indexmap = "1"
 serde = { version = "1.0", features = ["derive"] }
 spin-manifest = { path = "../manifest" }
 spin-engine = { path = "../engine" }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.52"
-bindle = { version = "0.8.0", default-features = false, features = ["client"] }
+bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.1", default-features = false, features = ["client"] }
 bytes = "1.1.0"
 dirs = "4.0"
 fs_extra = "1.2.0"

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -6,7 +6,7 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 
 [dependencies]
 anyhow = "1.0"
-indexmap = "1.6"
+indexmap = "1"
 serde = { version = "1.0", features = [ "derive" ] }
 spin-config = { path = "../config" }
 thiserror = "1"

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.52"
-bindle = { version = "0.8.0", default-features = false, features = ["client"] }
+bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.1", default-features = false, features = ["client"] }
 dunce = "1.0"
 futures = "0.3.14"
 itertools = "0.10.3"


### PR DESCRIPTION
We have [backported a fix](https://github.com/fermyon/bindle/commit/0dd1e7a7747d9f0ea8fda61d5f0f8cc3550f65dd) from bindle into a forked 0.8.1 tag. This fixes
a version constraint mismatch on `indexmap` which prevents upgrades to
`wasmtime`.

This should go away with #689 