### PR TITLE
feat: show when there are not builds to run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,7 @@ dependencies = [
  "spin-loader",
  "subprocess",
  "tokio",
+ "toml",
  "tracing",
 ]
 
@@ -4368,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -12,3 +12,4 @@ tokio = { version = "1.11", features = [ "full" ] }
 spin-loader = { path = "../loader" }
 subprocess = "0.2.8"
 tracing = { version = "0.1", features = [ "log" ] }
+toml = "0.5.9"

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 use path_absolutize::Absolutize;
 use spin_loader::local::config::{RawAppManifest, RawComponentManifest};
 use std::path::{Path, PathBuf};
+use std::{fs, time::Duration};
 use subprocess::{Exec, Redirection};
 use tracing::log;
 
@@ -26,7 +27,22 @@ pub async fn build(app: RawAppManifest, src: &Path) -> Result<()> {
         }
     }
 
-    println!("Successfully ran the build command for the Spin components.");
+    let mut path = src.to_str().unwrap().split('/').collect::<Vec<&str>>();
+    path.pop();
+    path.push("target");
+    path.push("wasm32-wasi");
+    path.push("release");
+    let path = path.join("/");
+
+    let modified = fs::metadata(Path::new(&path)).unwrap().modified();
+    let ten_secs = Duration::from_secs(10);
+
+    if modified.unwrap().elapsed().unwrap() >= ten_secs {
+        println!("nothing to build. Everything up to date");
+    } else {
+        println!("Successfully ran the build command for the Spin components.");
+    }
+
     Ok(())
 }
 

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -5,26 +5,16 @@
 use anyhow::{bail, Context, Result};
 use path_absolutize::Absolutize;
 use spin_loader::local::config::{RawAppManifest, RawComponentManifest};
-use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 use subprocess::{Exec, Redirection};
-use toml::Value;
 use tracing::log;
 
 /// If present, run the build command of each component.
 pub async fn build(app: RawAppManifest, src: &Path) -> Result<()> {
     let src = src.absolutize()?;
-    let mut path = src.to_str().unwrap().split('/').collect::<Vec<&str>>();
-    path.pop();
-    path.push("spin.toml");
-    let path = path.join("/");
 
-    let spin_manifest = read_to_string(&path).unwrap();
-    let manifest_info: Value = toml::from_str(&spin_manifest).unwrap();
-
-    //return early if build command not found
-    if !manifest_info.to_string().contains("component.build") {
-        println!("No build command found");
+    if (app.components.iter().all(|c| c.build.is_none())) {
+        println!("No build command found!");
         return Ok(());
     }
 

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -32,16 +32,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "heck"
@@ -76,19 +80,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "matches"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -97,10 +92,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.9"
+name = "percent-encoding"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "proc-macro2"
@@ -152,9 +147,9 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "form_urlencoded",
  "http",
  "spin-macro",
- "wasi-experimental-http",
  "wit-bindgen-rust",
 ]
 
@@ -181,26 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,39 +189,6 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
-name = "tracing"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
-dependencies = [
- "cfg-if",
- "log",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
-dependencies = [
- "lazy_static",
-]
 
 [[package]]
 name = "unicase"
@@ -283,18 +225,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi-experimental-http"
-version = "0.9.0"
-source = "git+https://github.com/deislabs/wasi-experimental-http?rev=a82ae3d6c85c4251b3663035febeb8100068f51d#a82ae3d6c85c4251b3663035febeb8100068f51d"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "wit-bindgen-gen-core"


### PR DESCRIPTION
For #700 

here's how I implemented this.
 
I check this directory `target/wasm32-wasi/release`. If 10 seconds have elapsed after it was modified, then I assume that there are no builds happening.