### PR TITLE
feat(config): support dotenv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e851a83c30366fd01d75b913588e95e74a1705c1ecc5d58b1f8e1a6d556525f"
+dependencies = [
+ "dirs 4.0.0",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3938,6 +3947,7 @@ dependencies = [
  "async-trait",
  "clap 3.1.15",
  "ctrlc",
+ "dotenvy",
  "futures",
  "http 0.2.6",
  "outbound-pg",

--- a/crates/config/src/provider/env.rs
+++ b/crates/config/src/provider/env.rs
@@ -1,20 +1,24 @@
+use std::collections::HashMap;
+
 use anyhow::Context;
 
 use crate::{Key, Provider};
 
-const DEFAULT_PREFIX: &str = "SPIN_APP";
+pub const DEFAULT_PREFIX: &str = "SPIN_APP";
 
 /// A config Provider that uses environment variables.
 #[derive(Debug)]
 pub struct EnvProvider {
     prefix: String,
+    envs: HashMap<String, String>,
 }
 
 impl EnvProvider {
     /// Creates a new EnvProvider.
-    pub fn new(prefix: impl Into<String>) -> Self {
+    pub fn new(prefix: impl Into<String>, envs: HashMap<String, String>) -> Self {
         Self {
             prefix: prefix.into(),
+            envs,
         }
     }
 }
@@ -23,6 +27,7 @@ impl Default for EnvProvider {
     fn default() -> Self {
         Self {
             prefix: DEFAULT_PREFIX.to_string(),
+            envs: HashMap::new(),
         }
     }
 }
@@ -31,7 +36,13 @@ impl Provider for EnvProvider {
     fn get(&self, key: &Key) -> anyhow::Result<Option<String>> {
         let env_key = format!("{}_{}", &self.prefix, key.as_ref().to_ascii_uppercase());
         match std::env::var(&env_key) {
-            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotPresent) => {
+                if let Some(value) = self.envs.get(&env_key) {
+                    return Ok(Some(value.to_string()));
+                }
+
+                Ok(None)
+            }
             other => other
                 .map(Some)
                 .with_context(|| format!("failed to resolve env var {}", &env_key)),
@@ -46,10 +57,29 @@ mod test {
     #[test]
     fn provider_get() {
         std::env::set_var("TESTING_SPIN_ENV_KEY1", "val");
-        let key = Key::new("env_key1").unwrap();
+        let key1 = Key::new("env_key1").unwrap();
+        let mut envs = HashMap::new();
+        envs.insert(
+            "TESTING_SPIN_ENV_KEY1".to_string(),
+            "dotenv_val".to_string(),
+        );
         assert_eq!(
-            EnvProvider::new("TESTING_SPIN").get(&key).unwrap(),
+            EnvProvider::new("TESTING_SPIN", envs.clone())
+                .get(&key1)
+                .unwrap(),
             Some("val".to_string())
+        );
+
+        let key2 = Key::new("env_key2").unwrap();
+        envs.insert(
+            "TESTING_SPIN_ENV_KEY2".to_string(),
+            "dotenv_val".to_string(),
+        );
+        assert_eq!(
+            EnvProvider::new("TESTING_SPIN", envs.clone())
+                .get(&key2)
+                .unwrap(),
+            Some("dotenv_val".to_string())
         );
     }
 

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -21,3 +21,4 @@ spin-manifest = { path = "../manifest" }
 tracing = { version = "0.1", features = [ "log" ] }
 wasi-outbound-http = { path = "../outbound-http" } 
 wasmtime = "0.35.3"
+dotenvy = "0.15.1"

--- a/examples/config-rust/.env
+++ b/examples/config-rust/.env
@@ -1,0 +1,1 @@
+SPIN_APP_DOTENV = "dotenv"

--- a/examples/config-rust/spin.toml
+++ b/examples/config-rust/spin.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [variables]
 object = { default = "teapot" }
+dotenv = { default = "should-be-replaced" }
 
 [[component]]
 id = "spin_config_rust"
@@ -15,5 +16,6 @@ source = "target/wasm32-wasi/release/spin_config_example.wasm"
 route = "/..."
 [component.config]
 message = "I'm a {{object}}"
+dotenv = "{{dotenv}}"
 [component.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/config-rust/src/lib.rs
+++ b/examples/config-rust/src/lib.rs
@@ -7,7 +7,15 @@ use spin_sdk::{
 
 /// This endpoint returns the config value specified by key.
 #[http_component]
-fn get(_req: Request) -> Result<Response> {
+fn get(req: Request) -> Result<Response> {
+    let path = req.uri().path();
+
+    if path.contains("dotenv") {
+        let val = config::get("dotenv").expect("Failed to acquire dotenv from spin.toml");
+        return Ok(http::Response::builder()
+            .status(200)
+            .body(Some(val.into()))?);
+    }
     let val = format!("message: {}", config::get("message")?);
     Ok(http::Response::builder()
         .status(200)

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -32,16 +32,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "heck"
@@ -76,19 +80,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "matches"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -97,10 +92,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.9"
+name = "percent-encoding"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "proc-macro2"
@@ -152,9 +147,9 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "form_urlencoded",
  "http",
  "spin-macro",
- "wasi-experimental-http",
  "wit-bindgen-rust",
 ]
 
@@ -181,26 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,39 +189,6 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
-name = "tracing"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
-dependencies = [
- "cfg-if",
- "log",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
-dependencies = [
- "lazy_static",
-]
 
 [[package]]
 name = "unicase"
@@ -283,18 +225,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi-experimental-http"
-version = "0.9.0"
-source = "git+https://github.com/deislabs/wasi-experimental-http?rev=a82ae3d6c85c4251b3663035febeb8100068f51d#a82ae3d6c85c4251b3663035febeb8100068f51d"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "wit-bindgen-gen-core"


### PR DESCRIPTION
resolve https://github.com/fermyon/spin/issues/660

### Test
In `examples/config-rust`, the default value for `dotenv` is `should-be-replaced`. We put a `.env` file in the same folder and set `dotenv = "dotenv"` in it. We can see the value be replaced.

```console
# build spin
$ cargo build
# run config-rust example
$ cd examples/config-rust
$ ../../target/debug/spin build
$ RUST_LOG=debug ../../target/debug/spin up

# in another terminal, check /dotenv result
$ curl -i http://127.0.0.1:3000/dotenv
```