### PR TITLE
Stop using WASI HTTP params in preparation for deprecation

### DIFF
--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use http::Uri;
 use hyper::{Body, Request, Response};
 use spin_engine::io::ModuleIoRedirects;
 use std::{net::SocketAddr, str, str::FromStr};
@@ -85,11 +84,10 @@ impl SpinHttpExecutor {
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect();
 
-            let params = &Self::params(&parts.uri)?;
-            let params: Vec<(&str, &str)> = params
-                .iter()
-                .map(|(k, v)| (k.as_str(), v.as_str()))
-                .collect();
+            // Preparing to remove the params field. We are leaving it in place for now
+            // to avoid breaking the ABI, but no longer pass or accept values in it.
+            // https://github.com/fermyon/spin/issues/663
+            let params = vec![];
 
             let body = Some(&bytes[..]);
             let uri = match parts.uri.path_and_query() {
@@ -186,15 +184,6 @@ impl SpinHttpExecutor {
         };
 
         Ok(())
-    }
-
-    fn params(uri: &Uri) -> Result<Vec<(String, String)>> {
-        match uri.query() {
-            Some(q) => Ok(url::form_urlencoded::parse(q.as_bytes())
-                .into_owned()
-                .collect::<Vec<_>>()),
-            None => Ok(vec![]),
-        }
     }
 }
 

--- a/crates/http/tests/rust-http-test/src/lib.rs
+++ b/crates/http/tests/rust-http-test/src/lib.rs
@@ -6,7 +6,8 @@ struct SpinHttp {}
 
 impl spin_http::SpinHttp for SpinHttp {
     fn handle_http_request(req: Request) -> Response {
-        assert!(req.params.contains(&("abc".to_string(), "def".to_string())));
+        assert!(req.params.is_empty());
+        assert!(req.uri.contains("?abc=def"));
 
         assert!(req
             .headers

--- a/crates/outbound-http/src/lib.rs
+++ b/crates/outbound-http/src/lib.rs
@@ -70,6 +70,10 @@ impl wasi_outbound_http::WasiOutboundHttp for OutboundHttp {
         let headers = request_headers(req.headers)?;
         let body = req.body.unwrap_or_default().to_vec();
 
+        if !req.params.is_empty() {
+            tracing::log::warn!("HTTP params field is deprecated");
+        }
+
         match Handle::try_current() {
             // If running in a Tokio runtime, spawn a new blocking executor
             // that will send the HTTP request, and block on its execution.


### PR DESCRIPTION
Relates to #663.

What this PR does:

* HTTP inbound (trigger):
  * The `params` field is no longer populated when passed to the guest module. (It is set to an empty vector instead.) As far as I can tell, this should have no impact since the Rust and Go SDKs both appear to consume only the `uri`, and any query string APIs operate on that not on the `params` collection.
* HTTP outbound:
  * Spin will log a warning if an outbound request has any parameters set.
  * The Rust SDK no longer splits the `http::Request` URI into WASI `uri` and `params`.  The URI is stringised and preserved intact, and `params` is set to an empty vector.  This should mean the Rust SDK now behaves correctly when the request URI contains a query string but I am not sure where I can test this.
  * I don't believe any changes are required to the Go SDK, as this appears not to refer to `params` anywhere in the code - I assume it already passed through URIs with query strings unaltered.  Again not sure where to put a test for this.

@adamreese can you take a look and confirm that no changes are needed to the Go SDK please?  Thanks!

Signed-off-by: itowlson <ivan.towlson@fermyon.com>