### PR TITLE
Install script for Spin

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -12,36 +12,49 @@ url = "https://github.com/fermyon/spin/blob/main/docs/content/quickstart.md"
 
 ## Getting the `spin` binary
 
-You can download the [latest release](https://github.com/fermyon/spin/releases).
-For example, for an Apple silicon macOS machine:
+You can install the `spin` binary using the `install.sh` script hosted on this site.
 
-```
-$ wget https://github.com/fermyon/spin/releases/download/v0.5.0/spin-v0.5.0-macos-aarch64.tar.gz
-$ tar xfv spin-v0.5.0-macos-aarch64.tar.gz
-$ ./spin --help
+```console
+$ curl https://spin.fermyon.dev/downloads/install.sh | bash
 ```
 
-If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
+To install a specific version (or canary), you can pass arguments to the install script this way:
 
-```bash
-$ git clone https://github.com/fermyon/spin -b v0.5.0
-$ cd spin
-$ rustup target add wasm32-wasi
-$ cargo install --locked --path .
-$ spin --help
+```console
+$ curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v v0.5.0
+
+$ curl https://spin.fermyon.dev/downloads/install.sh | bash -s -- -v canary
+``` 
+
+At this point, move the `spin` binary somewhere in your path, so it can be
+accessed from any directory. For example:
+
+```console
+$ sudo mv ./spin /usr/local/bin/spin
 ```
 
-Alternatively, [follow the contribution document](./contributing.md) for a detailed guide
+### Alternative 1: Building Spin from source
+
+[Follow the contribution document](./contributing.md) for a detailed guide
 on building Spin from source:
 
-```bash
+```console
 $ git clone https://github.com/fermyon/spin
 $ cd spin && make build
 $ ./target/release/spin --help
 ```
 
-At this point, move the `spin` binary somewhere in your path, so it can be
-accessed from any directory.
+### Alternative 2: Using Cargo to install Spin
+
+If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
+
+```console
+$ git clone https://github.com/fermyon/spin -b v0.4.0
+$ cd spin
+$ rustup target add wasm32-wasi
+$ cargo install --locked --path .
+$ spin --help
+```
 
 ### Linux: Additional Libraries
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -49,7 +49,7 @@ $ ./target/release/spin --help
 If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
 
 ```console
-$ git clone https://github.com/fermyon/spin -b v0.4.0
+$ git clone https://github.com/fermyon/spin -b v0.5.0
 $ cd spin
 $ rustup target add wasm32-wasi
 $ cargo install --locked --path .

--- a/docs/downloads/install.sh
+++ b/docs/downloads/install.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fancy colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color aka reset
+
+# Version to install. Defaults to latest or set by --version or -v
+VERSION=""
+
+# Print in colors - 0=green, 1=red, 2=neutral
+# e.g. fancy_print 0 "All is great"
+fancy_print() {
+    if [[ $1 == 0 ]]; then
+        echo -e "${GREEN}${2}${NC}"
+    elif [[ $1 == 1 ]]; then
+        echo -e "${RED}${2}${NC}"
+    else
+        echo -e "${2}"
+    fi
+}
+
+# Function to print the help message
+print_help() {
+    fancy_print 2 ""
+    fancy_print 2 "---- Spin Installer Script ----"
+    fancy_print 2 "This script installs Spin in the current directory."
+    fancy_print 2 ""
+    fancy_print 2 "Comand line arguments"
+    fancy_print 2 "--version or -v  : Provide what version to install e.g. \"v0.5.0\" or \"canary\"."
+    fancy_print 2 "--help    or -h  : Shows this help message"
+}
+
+# Function used to check if utilities are available
+require() {
+    if ! hash "$1" &>/dev/null; then
+        fancy_print 1 "'$1' not found in PATH. This is required for this script to work."
+        exit 1
+    fi
+}
+
+# Parse input arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    '--version' | -v)
+        shift
+        if [[ $# -ne 0 ]]; then
+            VERSION="${1}"
+        else
+            fancy_print 1 "Please provide the desired version. e.g. --version v0.5.0 or -v canary"
+            exit 0
+        fi
+        ;;
+    '--help' | -h)
+        shift
+        print_help
+        ;;
+    *)
+        fancy_print 1 "Unknown argument ${1}."
+        print_help
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Check all required utilities are available
+require wget
+require tar
+require uname
+
+# Check if we're on a suppoerted system and get OS and processor architecture to download the right version
+UNAME_ARC=$(uname -m)
+
+case $UNAME_ARC in
+"x86_64")
+    ARC="amd64"
+    ;;
+"arm64" | "aarch64")
+    ARC="aarch64"
+    ;;
+*)
+    fancy_print 1 "The Processor type: ${UNAME_ARC} is not yet supported by Spin."
+    exit 1
+    ;;
+esac
+
+case $OSTYPE in
+"linux-gnu"*)
+    OS="linux"
+    if [[ $ARC == "aarch64" ]]; then
+        fancy_print 1 "The Processor type: ${ARC}, on ${OSTYPE} is not yet supported by Spin."
+        exit 1
+    fi
+    ;;
+"darwin"*)
+    OS="macos"
+    ;;
+*)
+    fancy_print 1 "The OSTYPE: ${OSTYPE} is not supported by this script."
+    fancy_print 2 "Please refer to this article to install Spin: https://spin.fermyon.dev/quickstart/"
+    exit 1
+    ;;
+esac
+
+# Check desired version. Default to latest if no desired version was requested
+if [[ $VERSION = "" ]]; then
+    VERSION=$(wget -qO- https://github.com/fermyon/spin/releases | grep 'href="/fermyon/spin/releases/tag/v[0-9]*.[0-9]*.[0-9]*\"' | sed -E 's/.*\/fermyon\/spin\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
+fi
+
+# Constructing download FILE and URL
+FILE="spin-${VERSION}-${OS}-${ARC}.tar.gz"
+URL="https://github.com/fermyon/spin/releases/download/${VERSION}/${FILE}"
+
+# Download file, exit if not found - e.g. version does not exist
+fancy_print 0 "Step 1: Downloading: ${URL}"
+wget -q $URL || (fancy_print 1 "The requested file does not exist: ${FILE}"; exit 1)
+fancy_print 0 "Done...\n"
+
+# Decompress the file
+fancy_print 0 "Step 2: Decompressing: ${FILE}"
+tar xfv $FILE
+./spin --version
+fancy_print 0 "Done...\n"
+
+# Remove the compressed file
+fancy_print 0 "Step 3: Removing the downloaded tarball"
+rm $FILE
+fancy_print 0 "Done...\n"
+
+# Direct to quicks-start doc
+fancy_print 0 "You're good to go. Check here for the next steps: https://spin.fermyon.dev/quickstart/"
+fancy_print 0 "Run './spin' to get started"

--- a/docs/spin.toml
+++ b/docs/spin.toml
@@ -14,7 +14,14 @@ route = "/..."
 
 [[component]]
 source = "modules/spin_static_fs.wasm"
-id = "fileserver"
+id = "fileserver_static"
 files = [ { source = "static/", destination = "/" } ]
 [component.trigger]
 route = "/static/..."
+
+[[component]]
+source = "modules/spin_static_fs.wasm"
+id = "fileserver_downloads"
+files = [ { source = "downloads/", destination = "/" } ]
+[component.trigger]
+route = "/downloads/..."


### PR DESCRIPTION
Signed-off-by: Mikkel Mørk Hegnhøj <mikkel@fermyon.com>

This is the first commit for an installer script for Spin, to make the acquisition story easier.

Current progress on testing:

- [x] Tested on MacBook with Apple Silicon
- [ ] Tested on MacBook with Intel
- [x] Tested on Linux with Intel
- [x] Tested on Linus with ARM processor (should fail)
- [x] Tested on WSL
- [x] Get the latest version from GitHub - it's currently hard-coded in the script
- [x] Support installing a specific version (including canary), through an argument (e.g., install.sh -v canary)

A subsequent PR could have the equivalent for PowerShell.

Relates to #641 