### PR TITLE
chore(*): update templates and examples to use the v0.5.0 sdk

### DIFF
--- a/examples/http-rust-oubound-http/Cargo.lock
+++ b/examples/http-rust-oubound-http/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,4 +1,4 @@
-SDK_VERSION ?= v0.3.0
+SDK_VERSION ?= v0.5.0
 
 bump-versions: bump-go-versions bump-rust-versions
 

--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.4.0
+require github.com/fermyon/spin/sdk/go v0.5.0

--- a/templates/http-go/content/go.sum
+++ b/templates/http-go/content/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
-github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.5.0 h1:rt0I8Vd18jtTXjKkCWsPy2DPBM7zXVbelhrXzNKskxg=
+github.com/fermyon/spin/sdk/go v0.5.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/templates/http-rust/content/Cargo.toml
+++ b/templates/http-rust/content/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 # General-purpose crate with common HTTP types.
 http = "0.2"
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.4.0" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.5.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.4.0
+require github.com/fermyon/spin/sdk/go v0.5.0

--- a/templates/redis-go/content/go.sum
+++ b/templates/redis-go/content/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
-github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.5.0 h1:rt0I8Vd18jtTXjKkCWsPy2DPBM7zXVbelhrXzNKskxg=
+github.com/fermyon/spin/sdk/go v0.5.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/templates/redis-rust/content/Cargo.toml
+++ b/templates/redis-rust/content/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 # Logging
 log = { version = "0.4", default-features = false }
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.4.0" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.5.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
PR to update templates and examples per the recent v0.5.0 sdk bump.

Manually issuing this until we have a solution for https://github.com/fermyon/spin/issues/736