### PR TITLE
Enable wasmtime async support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,6 @@ dependencies = [
  "reqwest",
  "spin-engine",
  "spin-manifest",
- "tokio",
  "tracing",
  "tracing-futures",
  "url",
@@ -2211,6 +2210,7 @@ dependencies = [
  "postgres",
  "spin-engine",
  "spin-manifest",
+ "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
 ]
@@ -3353,6 +3353,7 @@ dependencies = [
  "anyhow",
  "serde",
  "thiserror",
+ "tokio",
  "toml",
  "wit-bindgen-wasmtime",
 ]
@@ -4878,6 +4879,7 @@ version = "0.2.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitflags",
  "thiserror",
  "wasmtime",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,12 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 anyhow = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 thiserror = "1"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+tokio = { version = "1", features = [ "rt-multi-thread" ] }
+
+[dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]
 
 [dev-dependencies]
 toml = "0.5"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -17,9 +17,11 @@ tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 wasi-cap-std-sync = "0.39.1"
 wasi-common = "0.39.1"
-wasmtime = "0.39.1"
+wasmtime = { version = "0.39.1", features = [ "async" ] }
 wasmtime-wasi = "0.39.1"
 cap-std = "0.24.1"
 
-[dev-dependencies]
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+[dev-dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = [ "async" ]

--- a/crates/engine/src/host_component.rs
+++ b/crates/engine/src/host_component.rs
@@ -12,7 +12,7 @@ pub trait HostComponent: Send + Sync {
     type State: Any + Send;
 
     /// Add this component to the given Linker, using the given runtime state-getting handle.
-    fn add_to_linker<T>(
+    fn add_to_linker<T: Send>(
         linker: &mut Linker<RuntimeContext<T>>,
         state_handle: HostComponentsStateHandle<Self::State>,
     ) -> Result<()>;
@@ -30,7 +30,7 @@ pub(crate) struct HostComponents {
 }
 
 impl HostComponents {
-    pub(crate) fn insert<T: 'static, Component: HostComponent + 'static>(
+    pub(crate) fn insert<T: Send + 'static, Component: HostComponent + 'static>(
         &mut self,
         linker: &mut Linker<RuntimeContext<T>>,
         host_component: Component,

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -39,9 +39,13 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2"
 wasi-cap-std-sync = "0.39.1"
 wasi-common = "0.39.1"
-wasmtime = "0.39.1"
+wasmtime = { version = "0.39.1", features = ["async"] }
 wasmtime-wasi = "0.39.1"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio"] }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -33,7 +33,7 @@ use crate::{
     wagi::WagiHttpExecutor,
 };
 
-wit_bindgen_wasmtime::import!("../../wit/ephemeral/spin-http.wit");
+wit_bindgen_wasmtime::import!({paths: ["../../wit/ephemeral/spin-http.wit"], async: *});
 
 type ExecutionContext = spin_engine::ExecutionContext<SpinHttpData>;
 type RuntimeContext = spin_engine::RuntimeContext<SpinHttpData>;

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -15,8 +15,11 @@ http = "0.2"
 reqwest = { version = "0.11", default-features = true, features = [ "json", "blocking" ] }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
-tokio = { version = "1.4.0", features = [ "full" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 url = "2.2.1"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]

--- a/crates/outbound-http/src/host_component.rs
+++ b/crates/outbound-http/src/host_component.rs
@@ -14,7 +14,7 @@ pub struct OutboundHttpComponent;
 impl HostComponent for OutboundHttpComponent {
     type State = OutboundHttp;
 
-    fn add_to_linker<T>(
+    fn add_to_linker<T: Send>(
         linker: &mut Linker<RuntimeContext<T>>,
         data_handle: HostComponentsStateHandle<Self::State>,
     ) -> Result<()> {

--- a/crates/outbound-pg/Cargo.toml
+++ b/crates/outbound-pg/Cargo.toml
@@ -11,5 +11,11 @@ anyhow = "1.0"
 postgres = { version = "0.19.3" }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
+tokio = { version = "1", features = [ "rt" ] }
 tracing = { version = "0.1", features = [ "log" ] }
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]
+

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -14,4 +14,8 @@ spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]

--- a/crates/redis/Cargo.toml
+++ b/crates/redis/Cargo.toml
@@ -25,7 +25,11 @@ tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 wasi-common = "0.39.1"
 wasmtime = "0.39.1"
 wasmtime-wasi = "0.39.1"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]
 
 [dev-dependencies]
 spin-testing = { path = "../testing" }

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -12,7 +12,7 @@ use spin_redis::SpinRedisData;
 use spin_trigger::{cli::NoArgs, TriggerExecutor};
 use std::{collections::HashMap, sync::Arc};
 
-wit_bindgen_wasmtime::import!("../../wit/ephemeral/spin-redis.wit");
+wit_bindgen_wasmtime::import!({paths: ["../../wit/ephemeral/spin-redis.wit"], async: *});
 
 type ExecutionContext = spin_engine::ExecutionContext<SpinRedisData>;
 type RuntimeContext = spin_engine::RuntimeContext<SpinRedisData>;

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -98,7 +98,10 @@ impl TestConfig {
         }
     }
 
-    pub async fn prepare_builder<T: Default + 'static>(&self, app: Application) -> Builder<T> {
+    pub async fn prepare_builder<T: Default + Send + 'static>(
+        &self,
+        app: Application,
+    ) -> Builder<T> {
         let config = ExecutionContextConfiguration {
             components: app.components,
             label: app.info.name,

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -19,7 +19,7 @@ pub trait TriggerExecutor: Sized {
     type GlobalConfig;
     type TriggerConfig;
     type RunConfig;
-    type RuntimeContext: Default + 'static;
+    type RuntimeContext: Default + Send + 'static;
 
     /// Create a new trigger executor.
     fn new(
@@ -123,7 +123,9 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
 }
 
 /// Add the default set of host components to the given builder.
-pub fn add_default_host_components<T: Default + 'static>(builder: &mut Builder<T>) -> Result<()> {
+pub fn add_default_host_components<T: Default + Send + 'static>(
+    builder: &mut Builder<T>,
+) -> Result<()> {
     builder.add_host_component(outbound_http::OutboundHttpComponent)?;
     builder.add_host_component(outbound_redis::OutboundRedis {
         connections: Arc::new(RwLock::new(HashMap::new())),

--- a/docs/content/extending-and-embedding.md
+++ b/docs/content/extending-and-embedding.md
@@ -53,7 +53,7 @@ Let's have a look at building the timer trigger:
 
 ```rust
 // examples/spin-timer/src/main.rs
-wit_bindgen_wasmtime::import!("spin-timer.wit");
+wit_bindgen_wasmtime::import!({paths: ["spin-timer.wit"], async: *});
 type ExecutionContext = spin_engine::ExecutionContext<spin_timer::SpinTimerData>;
 
 /// A custom timer trigger that executes a component on every interval.

--- a/examples/spin-timer/Cargo.toml
+++ b/examples/spin-timer/Cargo.toml
@@ -21,4 +21,8 @@ tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 wasi-common = "0.39.1"
 wasmtime = "0.39.1"
 wasmtime-wasi = "0.39.1"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]

--- a/examples/spin-timer/src/main.rs
+++ b/examples/spin-timer/src/main.rs
@@ -6,9 +6,8 @@ use std::{sync::Arc, time::Duration};
 use anyhow::Result;
 use spin_engine::{Builder, ExecutionContextConfiguration};
 use spin_manifest::{CoreComponent, ModuleSource, WasmConfig};
-use tokio::task::spawn_blocking;
 
-wit_bindgen_wasmtime::import!("spin-timer.wit");
+wit_bindgen_wasmtime::import!({paths: ["spin-timer.wit"], async: *});
 
 type ExecutionContext = spin_engine::ExecutionContext<spin_timer::SpinTimerData>;
 
@@ -58,21 +57,14 @@ impl TimerTrigger {
     }
     /// Execute the first component in the application configuration.
     async fn handle(&self, msg: String) -> Result<()> {
-        let (mut store, instance) = self.engine.prepare_component(
-            &self.engine.config.components[0].id,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let (mut store, instance) = self
+            .engine
+            .prepare_component(&self.engine.config.components[0].id, None, None, None, None)
+            .await?;
 
-        let res = spawn_blocking(move || -> Result<String> {
-            let t = spin_timer::SpinTimer::new(&mut store, &instance, |host| {
-                host.data.as_mut().unwrap()
-            })?;
-            Ok(t.handle_timer_request(&mut store, &msg)?)
-        })
-        .await??;
+        let t =
+            spin_timer::SpinTimer::new(&mut store, &instance, |host| host.data.as_mut().unwrap())?;
+        let res = t.handle_timer_request(&mut store, &msg).await?;
         log::info!("{}\n", res);
 
         Ok(())


### PR DESCRIPTION
This is needed to allow for some future features such as cooperative multi-tasking via fuel or epoch interruption.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>