### PR TITLE
Use tracing TestWriter in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,6 +3586,7 @@ dependencies = [
  "spin-http-engine",
  "spin-manifest",
  "spin-trigger",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -405,7 +405,7 @@ pub(crate) trait HttpExecutor: Clone + Send + Sync + 'static {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, sync::Once};
+    use std::collections::BTreeMap;
 
     use anyhow::Result;
     use spin_manifest::{HttpConfig, HttpExecutor};
@@ -413,18 +413,6 @@ mod tests {
     use spin_trigger::TriggerExecutorBuilder;
 
     use super::*;
-
-    static LOGGER: Once = Once::new();
-
-    /// We can only initialize the tracing subscriber once per crate.
-    pub(crate) fn init() {
-        LOGGER.call_once(|| {
-            tracing_subscriber::fmt()
-                .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-                .with_ansi(atty::is(atty::Stream::Stderr))
-                .init();
-        });
-    }
 
     #[test]
     fn test_default_headers_with_base_path() -> Result<()> {
@@ -525,8 +513,6 @@ mod tests {
         Ok(())
     }
 
-    // fn _search(key: &str, headers: &[(String, String)]) -> Option<String> {}
-
     fn search<'a>(keys: &'a [&'a str], headers: &[(&[&str], String)]) -> Option<String> {
         let mut res: Option<String> = None;
         for (k, v) in headers {
@@ -540,8 +526,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_spin_http() -> Result<()> {
-        init();
-
         let mut cfg = spin_testing::TestConfig::default();
         cfg.test_program("rust-http-test.wasm")
             .http_trigger(HttpConfig {
@@ -571,8 +555,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_wagi_http() -> Result<()> {
-        init();
-
         let mut cfg = spin_testing::TestConfig::default();
         cfg.test_program("wagi-test.wasm").http_trigger(HttpConfig {
             route: "/test".to_string(),

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -144,12 +144,13 @@ impl fmt::Display for RoutePattern {
 
 #[cfg(test)]
 mod route_tests {
+    use spin_testing::init_tracing;
+
     use super::*;
-    use crate::tests::init;
 
     #[test]
     fn test_exact_route() {
-        init();
+        init_tracing();
 
         let rp = RoutePattern::from("/", "/foo/bar");
         assert!(rp.matches("/foo/bar"));

--- a/crates/redis/src/tests.rs
+++ b/crates/redis/src/tests.rs
@@ -4,18 +4,6 @@ use redis::{Msg, Value};
 use spin_manifest::{RedisConfig, RedisExecutor};
 use spin_testing::TestConfig;
 use spin_trigger::TriggerExecutorBuilder;
-use std::sync::Once;
-
-static LOGGER: Once = Once::new();
-
-/// We can only initialize the tracing subscriber once per crate.
-pub(crate) fn init() {
-    LOGGER.call_once(|| {
-        tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .init();
-    });
-}
 
 fn create_trigger_event(channel: &str, payload: &str) -> redis::Msg {
     Msg::from_value(&redis::Value::Bulk(vec![
@@ -29,8 +17,6 @@ fn create_trigger_event(channel: &str, payload: &str) -> redis::Msg {
 #[ignore]
 #[tokio::test]
 async fn test_pubsub() -> Result<()> {
-    init();
-
     let mut cfg = TestConfig::default();
     cfg.test_program("redis-rust.wasm")
         .redis_trigger(RedisConfig {

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -12,3 +12,4 @@ spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
 spin-http-engine = { path = "../http" }
 spin-trigger = { path = "../trigger" }
+tracing-subscriber = "0.3"


### PR DESCRIPTION
This is designed to interact properly with e.g.
`cargo test -- --nocapture`.

Minor cleanups in the vicinity.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>