### PR TITLE
Remove double slash from file URIs

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -141,7 +141,7 @@ where
             .context("SPIN_ALLOW_TRANSIENT_WRITE")?;
 
         // TODO(lann): Find a better home for this; spin_loader?
-        let mut app = if let Some(manifest_file) = manifest_url.strip_prefix("file://") {
+        let mut app = if let Some(manifest_file) = manifest_url.strip_prefix("file:") {
             let bindle_connection = std::env::var("BINDLE_URL")
                 .ok()
                 .map(|url| BindleConnectionInfo::new(url, false, None, None));

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -148,7 +148,7 @@ impl UpCommand {
 
         let manifest_url = match app.info.origin {
             spin_manifest::ApplicationOrigin::File(path) => {
-                format!("file://{}", path.canonicalize()?.to_string_lossy())
+                format!("file:{}", path.canonicalize()?.to_string_lossy())
             }
             spin_manifest::ApplicationOrigin::Bindle { id, server } => {
                 format!("bindle+{}?id={}", server, id)


### PR DESCRIPTION
While valid for absolute URIs, the double slashes cannot work with relative URIs and are usually redundant.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>