### PR TITLE
Add `spin-conformance` crate (#724)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,6 +3263,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin-abi-conformance"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "cap-std 0.25.2",
+ "clap 3.2.19",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml",
+ "wasi-common",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wit-bindgen-wasmtime",
+]
+
+[[package]]
 name = "spin-build"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ e2e-tests = []
 
 [workspace]
 members = [
+    "crates/abi-conformance",
     "crates/build",
     "crates/config",
     "crates/engine",

--- a/crates/abi-conformance/Cargo.toml
+++ b/crates/abi-conformance/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "spin-abi-conformance"
+version = "0.5.0"
+edition = "2021"
+authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+
+[dependencies]
+anyhow = "1.0.44"
+clap = { version = "3.1.15", features = ["derive", "env"] }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0.82"
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+wasmtime = "0.39.1"
+wasmtime-wasi = "0.39.1"
+wasi-common = "0.39.1"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
+rand_core = "0.6.3"
+tempfile = "3.3.0"
+cap-std = "0.25.2"
+toml = "0.5.9"

--- a/crates/abi-conformance/src/bin/spin-abi-conformance.rs
+++ b/crates/abi-conformance/src/bin/spin-abi-conformance.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use clap::Parser;
+use std::{
+    fs::{self, File},
+    io::{self, Read, Write},
+    path::PathBuf,
+};
+use wasmtime::{Config, Engine, Module};
+
+#[derive(Parser)]
+#[clap(author, version, about)]
+pub struct Options {
+    /// Name of Wasm file to test (or stdin if not specified)
+    #[clap(short, long)]
+    pub input: Option<PathBuf>,
+
+    /// Name of JSON file to write report to (or stdout if not specified)
+    #[clap(short, long)]
+    pub output: Option<PathBuf>,
+
+    /// Name of TOML configuration file to use
+    #[clap(short, long)]
+    pub config: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let options = &Options::parse();
+
+    let engine = &Engine::new(&Config::new())?;
+
+    let module = &if let Some(input) = &options.input {
+        Module::from_file(engine, input)
+    } else {
+        Module::new(engine, &{
+            let mut buffer = Vec::new();
+            io::stdin().read_to_end(&mut buffer)?;
+            buffer
+        })
+    }?;
+
+    let config = if let Some(config) = &options.config {
+        toml::from_str(&fs::read_to_string(config)?)?
+    } else {
+        spin_abi_conformance::Config::default()
+    };
+
+    let report = &spin_abi_conformance::test(module, config)?;
+
+    let writer = if let Some(output) = &options.output {
+        Box::new(File::create(output)?) as Box<dyn Write>
+    } else {
+        Box::new(io::stdout().lock())
+    };
+
+    serde_json::to_writer_pretty(writer, report)?;
+
+    Ok(())
+}

--- a/crates/abi-conformance/src/lib.rs
+++ b/crates/abi-conformance/src/lib.rs
@@ -1,0 +1,239 @@
+//! Spin ABI Conformance Test Suite
+//!
+//! This crate provides a suite of tests to check a given SDK or language integration's implementation of Spin
+//! functions.  It is intended for use by language integrators and SDK authors to verify that their integrations
+//! and SDKs work correctly with the Spin ABIs.  It is not intended for Spin _application_ development, since it
+//! requires a module written specifically to behave as expected by this suite, whereas a given application will
+//! have its own expected behaviors which can only be verified by tests specific to that application.
+//!
+//! The suite may be run via the [`test()`] function, which accepts a [`wasmtime::Module`] and a [`Config`] and
+//! returns a [`Report`] which details which tests succeeded and which failed.  The definition of success in this
+//! context depends on whether the test is for a function implemented by the guest (e.g. triggers) or by the host
+//! (e.g. outbound requests).
+//!
+//! - For a guest-implemented function, the host will call the function and assert the result matches what is
+//! expected (see [`Report::http_trigger`] for an example).
+//!
+//! - For a host-implemented function, the host will call a guest-implemented function according to the specified
+//! [`InvocationStyle`] with a set of arguments indicating which host function to call and with what arguments.
+//! The host then asserts that host function was indeed called with the expected arguments (see
+//! [`Report::outbound_http`] for an example).
+
+use anyhow::{Context as _, Result};
+use outbound_http::OutboundHttp;
+use outbound_pg::OutboundPg;
+use outbound_redis::OutboundRedis;
+use serde::{Deserialize, Serialize};
+use spin_config::SpinConfig;
+use spin_http::{Method, Request, SpinHttp, SpinHttpData};
+use spin_redis::SpinRedisData;
+use std::str;
+use wasi_common::{pipe::WritePipe, WasiCtx};
+use wasmtime::{InstancePre, Linker, Module, Store};
+use wasmtime_wasi::WasiCtxBuilder;
+
+pub use outbound_pg::PgReport;
+pub use outbound_redis::RedisReport;
+pub use wasi::WasiReport;
+
+mod outbound_http;
+mod outbound_pg;
+mod outbound_redis;
+mod spin_config;
+mod spin_http;
+mod spin_redis;
+mod wasi;
+
+/// The invocation style to use when the host asks the guest to call a host-implemented function
+#[derive(Copy, Clone, Default, Deserialize)]
+pub enum InvocationStyle {
+    /// The host should call into the guest using WASI's `_start` function, passing arguments as CLI parameters.
+    ///
+    /// This is the default if no value is specified.
+    #[default]
+    Command,
+
+    /// The host should call into the guest using spin-http.wit's `handle-http-request` function, passing arguments
+    /// via the request body as a JSON array of strings.
+    HttpTrigger,
+}
+
+/// Configuration options for the [`test()`] function
+#[derive(Default, Deserialize)]
+pub struct Config {
+    /// The invocation style to use when the host asks the guest to call a host-implemented function
+    #[serde(default)]
+    pub invocation_style: InvocationStyle,
+}
+
+/// Report of which tests succeeded or failed
+///
+/// These results fall into either of two categories:
+///
+/// - Guest-implemented exports which behave as prescribed by the test (e.g. `http_trigger` and `redis_trigger`)
+///
+/// - Host-implemented imports which are called by the guest with the arguments specified by the host
+/// (e.g. `outbound_http`)
+#[derive(Serialize)]
+pub struct Report {
+    /// Result of the Spin HTTP trigger test
+    ///
+    /// The guest module should expect a call to `handle-http-request` with a POST request to "/foo" containing a
+    /// single header "foo: bar" and a UTF-8 string body "Hello, SpinHttp!" and return a 200 OK response that
+    /// includes a single header "lorem: ipsum" and a UTF-8 string body "dolor sit amet".
+    pub http_trigger: Result<(), String>,
+
+    /// Result of the Spin Redis trigger test
+    ///
+    /// The guest module should expect a call to `handle-redis-message` with the text "Hello, SpinRedis!" and
+    /// return `ok(unit)` as the result.
+    pub redis_trigger: Result<(), String>,
+
+    /// Result of the Spin config test
+    ///
+    /// The guest module should expect a call according to [`InvocationStyle`] with \["config", "foo"\] as
+    /// arguments.  The module should call the host-implemented `spin-config::get-config` function with "foo" as
+    /// the argument and expect `ok("bar")` as the result.  The host will assert that said function is called
+    /// exactly once with the expected argument.
+    pub config: Result<(), String>,
+
+    /// Result of the Spin outbound HTTP test
+    ///
+    /// The guest module should expect a call according to [`InvocationStyle`] with \["outbound-http",
+    /// "http://127.0.0.1/test"\] as arguments.  The module should call the host-implemented
+    /// `wasi-outbound-http::request` function with a GET request for the URL "http://127.0.0.1/test" with no
+    /// headers, params, or body, and expect `ok({ status: 200, headers: none, body: some("Jabberwocky"))` as the
+    /// result.  The host will assert that said function is called exactly once with the specified argument.
+    pub outbound_http: Result<(), String>,
+
+    /// Results of the Spin outbound Redis tests
+    ///
+    /// See [`RedisReport`] for details.
+    pub outbound_redis: RedisReport,
+
+    /// Results of the Spin outbound PostgreSQL tests
+    ///
+    /// See [`PgReport`] for details.
+    pub outbound_pg: PgReport,
+
+    /// Results of the WASI tests
+    ///
+    /// See [`WasiReport`] for details.
+    pub wasi: WasiReport,
+}
+
+/// Run a test for each Spin-related function the specified `module` imports or exports, returning the results as a
+/// [`Report`].
+///
+/// See the fields of [`Report`] and the structs from which it is composed for descriptions of each test.
+pub fn test(module: &Module, config: Config) -> Result<Report> {
+    let mut store = Store::new(
+        module.engine(),
+        Context {
+            config,
+            wasi: WasiCtxBuilder::new().arg("<wasm module>")?.build(),
+            outbound_http: OutboundHttp::default(),
+            outbound_redis: OutboundRedis::default(),
+            outbound_pg: OutboundPg::default(),
+            spin_http: SpinHttpData {},
+            spin_redis: SpinRedisData {},
+            spin_config: SpinConfig::default(),
+        },
+    );
+
+    let mut linker = Linker::<Context>::new(module.engine());
+    wasmtime_wasi::add_to_linker(&mut linker, |context| &mut context.wasi)?;
+    outbound_http::add_to_linker(&mut linker, |context| &mut context.outbound_http)?;
+    outbound_redis::add_to_linker(&mut linker, |context| &mut context.outbound_redis)?;
+    outbound_pg::add_to_linker(&mut linker, |context| &mut context.outbound_pg)?;
+    spin_config::add_to_linker(&mut linker, |context| &mut context.spin_config)?;
+
+    let pre = linker.instantiate_pre(&mut store, module)?;
+
+    Ok(Report {
+        http_trigger: spin_http::test(&mut store, &pre),
+
+        redis_trigger: spin_redis::test(&mut store, &pre),
+
+        config: spin_config::test(&mut store, &pre),
+
+        outbound_http: outbound_http::test(&mut store, &pre),
+
+        outbound_redis: outbound_redis::test(&mut store, &pre)?,
+
+        outbound_pg: outbound_pg::test(&mut store, &pre)?,
+
+        wasi: wasi::test(&mut store, &pre)?,
+    })
+}
+
+struct Context {
+    config: Config,
+    wasi: WasiCtx,
+    outbound_http: OutboundHttp,
+    outbound_redis: OutboundRedis,
+    outbound_pg: OutboundPg,
+    spin_http: SpinHttpData,
+    spin_redis: SpinRedisData,
+    spin_config: SpinConfig,
+}
+
+fn run(fun: impl FnOnce() -> Result<()>) -> Result<(), String> {
+    fun().map_err(|e| format!("{e:?}"))
+}
+
+fn run_command(
+    store: &mut Store<Context>,
+    pre: &InstancePre<Context>,
+    arguments: &[&str],
+    fun: impl FnOnce(&mut Store<Context>) -> Result<()>,
+) -> Result<(), String> {
+    run(|| {
+        let stderr = WritePipe::new_in_memory();
+        store.data_mut().wasi.set_stderr(Box::new(stderr.clone()));
+
+        let instance = &pre.instantiate(&mut *store)?;
+
+        let result = match store.data().config.invocation_style {
+            InvocationStyle::HttpTrigger => {
+                let handle =
+                    SpinHttp::new(&mut *store, instance, |context| &mut context.spin_http)?;
+
+                handle
+                    .handle_http_request(
+                        &mut *store,
+                        Request {
+                            method: Method::Post,
+                            uri: "/",
+                            headers: &[],
+                            params: &[],
+                            body: Some(&serde_json::to_vec(arguments)?),
+                        },
+                    )
+                    .map(drop) // Ignore the response and make this a `Result<(), Trap>` to match the `_start` case
+                               // below
+            }
+
+            InvocationStyle::Command => {
+                for argument in arguments {
+                    store.data_mut().wasi.push_arg(argument)?;
+                }
+
+                instance
+                    .get_typed_func::<(), (), _>(&mut *store, "_start")?
+                    .call(&mut *store, ())
+            }
+        };
+
+        // Reset `Context::wasi` so the next test has a clean slate and also to ensure there are no more references
+        // to the `stderr` pipe, ensuring `try_into_inner` succeeds below.  This is also needed in case the caller
+        // attached its own pipes for e.g. stdin and/or stdout and expects exclusive ownership once we return.
+        store.data_mut().wasi = WasiCtxBuilder::new().arg("<wasm module>")?.build();
+
+        result.with_context(|| {
+            String::from_utf8_lossy(&stderr.try_into_inner().unwrap().into_inner()).into_owned()
+        })?;
+
+        fun(store)
+    })
+}

--- a/crates/abi-conformance/src/outbound_http.rs
+++ b/crates/abi-conformance/src/outbound_http.rs
@@ -1,0 +1,49 @@
+use super::Context;
+use anyhow::ensure;
+use std::collections::HashMap;
+use wasi_outbound_http::{HttpError, Request, Response, WasiOutboundHttp};
+use wasmtime::{InstancePre, Store};
+
+pub use wasi_outbound_http::add_to_linker;
+
+wit_bindgen_wasmtime::export!("../../wit/ephemeral/wasi-outbound-http.wit");
+
+#[derive(Default)]
+pub(super) struct OutboundHttp {
+    map: HashMap<String, String>,
+}
+
+impl WasiOutboundHttp for OutboundHttp {
+    fn request(&mut self, req: Request) -> Result<Response, HttpError> {
+        self.map
+            .remove(req.uri)
+            .map(|body| Response {
+                status: 200,
+                headers: None,
+                body: Some(body.into_bytes()),
+            })
+            .ok_or(HttpError::InvalidUrl)
+    }
+}
+
+pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<(), String> {
+    store
+        .data_mut()
+        .outbound_http
+        .map
+        .insert("http://127.0.0.1/test".into(), "Jabberwocky".into());
+
+    super::run_command(
+        store,
+        pre,
+        &["outbound-http", "http://127.0.0.1/test"],
+        |store| {
+            ensure!(
+                store.data().outbound_http.map.is_empty(),
+                "expected module to call `wasi-outbound-http::request` exactly once"
+            );
+
+            Ok(())
+        },
+    )
+}

--- a/crates/abi-conformance/src/outbound_pg.rs
+++ b/crates/abi-conformance/src/outbound_pg.rs
@@ -1,0 +1,160 @@
+use super::Context;
+use anyhow::{ensure, Result};
+use outbound_pg::{Column, DbDataType, DbValue, ParameterValue, PgError, RowSet};
+use serde::Serialize;
+use std::{collections::HashMap, iter};
+use wasmtime::{InstancePre, Store};
+
+pub(super) use outbound_pg::add_to_linker;
+
+/// Report of which outbound PostgreSQL functions a module successfully used, if any
+#[derive(Serialize)]
+pub struct PgReport {
+    /// Result of the PostgreSQL statement execution test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["outbound-pg-execute",
+    /// "127.0.0.1", "INSERT INTO foo (x) VALUES ($1)", "int8:42"\] as arguments.  The module should call the
+    /// host-implemented `outbound-pg::execute` function with the arguments \["127.0.0.1", "INSERT INTO foo (x)
+    /// VALUES ($1)", `\[int8(42)\]`\] and expect `ok(1)` as the result.  The host will assert that said function
+    /// is called exactly once with the specified arguments.
+    pub execute: Result<(), String>,
+
+    /// Result of the PostgreSQL query execution test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["outbound-pg-query",
+    /// "127.0.0.1", "SELECT x FROM foo"\] as arguments.  The module should call the host-implemented
+    /// `outbound-pg::execute` function with the arguments \["127.0.0.1", "SELECT x FROM foo"\] and expect `ok({
+    /// columns: \[ { name: "x", data_type: int8 } \], rows: \[ \[ int8(42) \] \]})` as the result.  The host will
+    /// assert that said function is called exactly once with the specified arguments.
+    pub query: Result<(), String>,
+}
+
+wit_bindgen_wasmtime::export!("../../wit/ephemeral/outbound-pg.wit");
+
+#[derive(Default)]
+pub(super) struct OutboundPg {
+    execute_map: HashMap<(String, String, String), u64>,
+    query_map: HashMap<(String, String, String), RowSet>,
+}
+
+impl outbound_pg::OutboundPg for OutboundPg {
+    fn execute(
+        &mut self,
+        address: &str,
+        statement: &str,
+        params: Vec<ParameterValue<'_>>,
+    ) -> Result<u64, PgError> {
+        self.execute_map
+            .remove(&(
+                address.to_owned(),
+                statement.to_owned(),
+                format!("{params:?}"),
+            ))
+            .ok_or_else(|| {
+                PgError::OtherError(format!(
+                    "expected {:?}, got {:?}",
+                    self.execute_map.keys(),
+                    iter::once(&(
+                        address.to_owned(),
+                        statement.to_owned(),
+                        format!("{params:?}")
+                    ))
+                ))
+            })
+    }
+
+    fn query(
+        &mut self,
+        address: &str,
+        statement: &str,
+        params: Vec<ParameterValue<'_>>,
+    ) -> Result<RowSet, PgError> {
+        self.query_map
+            .remove(&(
+                address.to_owned(),
+                statement.to_owned(),
+                format!("{params:?}"),
+            ))
+            .ok_or_else(|| {
+                PgError::OtherError(format!(
+                    "expected {:?}, got {:?}",
+                    self.query_map.keys(),
+                    iter::once(&(
+                        address.to_owned(),
+                        statement.to_owned(),
+                        format!("{params:?}")
+                    ))
+                ))
+            })
+    }
+}
+
+pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<PgReport> {
+    Ok(PgReport {
+        execute: test_execute(store, pre),
+        query: test_query(store, pre),
+    })
+}
+
+fn test_execute(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<(), String> {
+    store.data_mut().outbound_pg.execute_map.insert(
+        (
+            "127.0.0.1".into(),
+            "INSERT INTO foo (x) VALUES ($1)".into(),
+            format!("{:?}", vec![ParameterValue::Int8(42)]),
+        ),
+        1,
+    );
+
+    super::run_command(
+        store,
+        pre,
+        &[
+            "outbound-pg-execute",
+            "127.0.0.1",
+            "INSERT INTO foo (x) VALUES ($1)",
+            "int8:42",
+        ],
+        |store| {
+            ensure!(
+                store.data().outbound_pg.execute_map.is_empty(),
+                "expected module to call `outbound-pg::execute` exactly once"
+            );
+
+            Ok(())
+        },
+    )
+}
+
+fn test_query(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<(), String> {
+    let row_set = RowSet {
+        columns: vec![Column {
+            name: "x".into(),
+            data_type: DbDataType::Int8,
+        }],
+        rows: vec![vec![DbValue::Int8(42)]],
+    };
+
+    store.data_mut().outbound_pg.query_map.insert(
+        (
+            "127.0.0.1".into(),
+            "SELECT x FROM foo".into(),
+            format!("{:?}", Vec::<()>::new()),
+        ),
+        row_set,
+    );
+
+    super::run_command(
+        store,
+        pre,
+        &["outbound-pg-query", "127.0.0.1", "SELECT x FROM foo"],
+        |store| {
+            ensure!(
+                store.data().outbound_pg.query_map.is_empty(),
+                "expected module to call `outbound-pg::query` exactly once"
+            );
+
+            Ok(())
+        },
+    )
+}

--- a/crates/abi-conformance/src/outbound_redis.rs
+++ b/crates/abi-conformance/src/outbound_redis.rs
@@ -1,0 +1,187 @@
+use super::Context;
+use anyhow::{ensure, Result};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use wasmtime::{InstancePre, Store};
+
+pub(super) use outbound_redis::add_to_linker;
+
+/// Report of which outbound Redis tests succeeded or failed
+#[derive(Serialize)]
+pub struct RedisReport {
+    /// Result of the Redis `PUBLISH` test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with
+    /// \["outbound-redis-publish", "127.0.0.1", "foo", "bar"\] as arguments.  The module should call the
+    /// host-implemented `outbound-redis::publish` function with the arguments \["127.0.0.1", "foo", "bar"\] and
+    /// expect `ok(unit)` as the result.  The host will assert that said function is called exactly once with the
+    /// specified arguments.
+    pub publish: Result<(), String>,
+
+    /// Result of the Redis `SET` test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["outbound-redis-set",
+    /// "127.0.0.1", "foo", "bar"\] as arguments.  The module should call the host-implemented
+    /// `outbound-redis::set` function with the arguments \["127.0.0.1", "foo", "bar"\] and expect `ok(unit)` as
+    /// the result.  The host will assert that said function is called exactly once with the specified arguments.
+    pub set: Result<(), String>,
+
+    /// Result of the Redis `GET` test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["outbound-redis-get",
+    /// "127.0.0.1", "foo"\] as arguments.  The module should call the host-implemented `outbound-redis::get`
+    /// function with the arguments \["127.0.0.1", "foo"\] and expect `ok("bar")` (UTF-8-encoded) as the result.
+    /// The host will assert that said function is called exactly once with the specified arguments.
+    pub get: Result<(), String>,
+
+    /// Result of the Redis `INCR` test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["outbound-redis-incr",
+    /// "127.0.0.1", "foo"\] as arguments.  The module should call the host-implemented `outbound-redis::incr`
+    /// function with the arguments \["127.0.0.1", "foo"\] and expect `ok(42)` as the result.  The host will assert
+    /// that said function is called exactly once with the specified arguments.
+    pub incr: Result<(), String>,
+}
+
+wit_bindgen_wasmtime::export!("../../wit/ephemeral/outbound-redis.wit");
+
+#[derive(Default)]
+pub(super) struct OutboundRedis {
+    publish_set: HashSet<(String, String, Vec<u8>)>,
+    set_set: HashSet<(String, String, Vec<u8>)>,
+    get_map: HashMap<(String, String), Vec<u8>>,
+    incr_map: HashMap<(String, String), i64>,
+}
+
+impl outbound_redis::OutboundRedis for OutboundRedis {
+    fn publish(
+        &mut self,
+        address: &str,
+        channel: &str,
+        payload: &[u8],
+    ) -> Result<(), outbound_redis::Error> {
+        if self
+            .publish_set
+            .remove(&(address.to_owned(), channel.to_owned(), payload.to_vec()))
+        {
+            Ok(())
+        } else {
+            Err(outbound_redis::Error::Error)
+        }
+    }
+
+    fn get(&mut self, address: &str, key: &str) -> Result<Vec<u8>, outbound_redis::Error> {
+        self.get_map
+            .remove(&(address.to_owned(), key.to_owned()))
+            .ok_or(outbound_redis::Error::Error)
+    }
+
+    fn set(&mut self, address: &str, key: &str, value: &[u8]) -> Result<(), outbound_redis::Error> {
+        if self
+            .set_set
+            .remove(&(address.to_owned(), key.to_owned(), value.to_vec()))
+        {
+            Ok(())
+        } else {
+            Err(outbound_redis::Error::Error)
+        }
+    }
+
+    fn incr(&mut self, address: &str, key: &str) -> Result<i64, outbound_redis::Error> {
+        self.incr_map
+            .remove(&(address.to_owned(), key.to_owned()))
+            .map(|value| value + 1)
+            .ok_or(outbound_redis::Error::Error)
+    }
+}
+
+pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<RedisReport> {
+    Ok(RedisReport {
+        publish: {
+            store.data_mut().outbound_redis.publish_set.insert((
+                "127.0.0.1".into(),
+                "foo".into(),
+                "bar".as_bytes().to_vec(),
+            ));
+
+            super::run_command(
+                store,
+                pre,
+                &["outbound-redis-publish", "127.0.0.1", "foo", "bar"],
+                |store| {
+                    ensure!(
+                        store.data().outbound_redis.publish_set.is_empty(),
+                        "expected module to call `outbound-redis::publish` exactly once"
+                    );
+
+                    Ok(())
+                },
+            )
+        },
+
+        set: {
+            store.data_mut().outbound_redis.set_set.insert((
+                "127.0.0.1".into(),
+                "foo".into(),
+                "bar".as_bytes().to_vec(),
+            ));
+
+            super::run_command(
+                store,
+                pre,
+                &["outbound-redis-set", "127.0.0.1", "foo", "bar"],
+                |store| {
+                    ensure!(
+                        store.data().outbound_redis.set_set.is_empty(),
+                        "expected module to call `outbound-redis::set` exactly once"
+                    );
+
+                    Ok(())
+                },
+            )
+        },
+
+        get: {
+            store.data_mut().outbound_redis.get_map.insert(
+                ("127.0.0.1".into(), "foo".into()),
+                "bar".as_bytes().to_vec(),
+            );
+
+            super::run_command(
+                store,
+                pre,
+                &["outbound-redis-get", "127.0.0.1", "foo"],
+                |store| {
+                    ensure!(
+                        store.data().outbound_redis.get_map.is_empty(),
+                        "expected module to call `outbound-redis::get` exactly once"
+                    );
+
+                    Ok(())
+                },
+            )
+        },
+
+        incr: {
+            store
+                .data_mut()
+                .outbound_redis
+                .incr_map
+                .insert(("127.0.0.1".into(), "foo".into()), 41);
+
+            super::run_command(
+                store,
+                pre,
+                &["outbound-redis-incr", "127.0.0.1", "foo"],
+                |store| {
+                    ensure!(
+                        store.data().outbound_redis.incr_map.is_empty(),
+                        "expected module to call `outbound-redis::incr` exactly once"
+                    );
+
+                    Ok(())
+                },
+            )
+        },
+    })
+}

--- a/crates/abi-conformance/src/spin_config.rs
+++ b/crates/abi-conformance/src/spin_config.rs
@@ -1,0 +1,53 @@
+use super::Context;
+use anyhow::ensure;
+use std::{collections::HashMap, error, fmt};
+use wasmtime::{InstancePre, Store};
+
+pub use spin_config::add_to_linker;
+
+wit_bindgen_wasmtime::export!("../../wit/ephemeral/spin-config.wit");
+
+impl fmt::Display for spin_config::Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Provider(provider_err) => write!(f, "provider error: {}", provider_err),
+            Self::InvalidKey(invalid_key) => write!(f, "invalid key: {}", invalid_key),
+            Self::InvalidSchema(invalid_schema) => {
+                write!(f, "invalid schema: {}", invalid_schema)
+            }
+            Self::Other(other) => write!(f, "other: {}", other),
+        }
+    }
+}
+
+impl error::Error for spin_config::Error {}
+
+#[derive(Default)]
+pub(super) struct SpinConfig {
+    map: HashMap<String, String>,
+}
+
+impl spin_config::SpinConfig for SpinConfig {
+    fn get_config(&mut self, key: &str) -> Result<String, spin_config::Error> {
+        self.map
+            .remove(key)
+            .ok_or_else(|| spin_config::Error::InvalidKey(key.to_owned()))
+    }
+}
+
+pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<(), String> {
+    store
+        .data_mut()
+        .spin_config
+        .map
+        .insert("foo".into(), "bar".into());
+
+    super::run_command(store, pre, &["config", "foo"], |store| {
+        ensure!(
+            store.data().spin_config.map.is_empty(),
+            "expected module to call `spin-config::get-config` exactly once"
+        );
+
+        Ok(())
+    })
+}

--- a/crates/abi-conformance/src/spin_http.rs
+++ b/crates/abi-conformance/src/spin_http.rs
@@ -1,0 +1,49 @@
+use super::Context;
+use anyhow::ensure;
+use wasmtime::{InstancePre, Store};
+
+pub use spin_http::{Method, Request, SpinHttp, SpinHttpData};
+
+wit_bindgen_wasmtime::import!("../../wit/ephemeral/spin-http.wit");
+
+pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<(), String> {
+    super::run(|| {
+        let instance = &pre.instantiate(&mut *store)?;
+        let handle = SpinHttp::new(&mut *store, instance, |context| &mut context.spin_http)?;
+        let response = handle.handle_http_request(
+            store,
+            Request {
+                method: Method::Post,
+                uri: "/foo",
+                headers: &[("foo", "bar")],
+                params: &[],
+                body: Some(b"Hello, SpinHttp!"),
+            },
+        )?;
+
+        ensure!(
+            response.status == 200,
+            "expected response status 200, got {}",
+            response.status
+        );
+
+        ensure!(
+            response.headers == Some(vec![("lorem".to_owned(), "ipsum".to_owned())]),
+            "expected a single response header, \"lorem: ipsum\", got {:?}",
+            response.headers
+        );
+
+        let expected_body = "dolor sit amet";
+
+        ensure!(
+            response.body == Some(expected_body.as_bytes().to_vec()),
+            "expected a response body containing the string {expected_body:?}, got {:?}",
+            response
+                .body
+                .as_ref()
+                .map(|body| String::from_utf8_lossy(body))
+        );
+
+        Ok(())
+    })
+}

--- a/crates/abi-conformance/src/spin_redis.rs
+++ b/crates/abi-conformance/src/spin_redis.rs
@@ -1,0 +1,29 @@
+use super::Context;
+use spin_redis::SpinRedis;
+use std::{error, fmt};
+use wasmtime::{InstancePre, Store};
+
+pub use spin_redis::SpinRedisData;
+
+wit_bindgen_wasmtime::import!("../../wit/ephemeral/spin-redis.wit");
+
+impl fmt::Display for spin_redis::Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Success => f.write_str("redis success"),
+            Self::Error => f.write_str("redis error"),
+        }
+    }
+}
+
+impl error::Error for spin_redis::Error {}
+
+pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<(), String> {
+    super::run(|| {
+        let instance = &pre.instantiate(&mut *store)?;
+        let handle = SpinRedis::new(&mut *store, instance, |context| &mut context.spin_redis)?;
+        handle.handle_redis_message(store, b"Hello, SpinRedis!")??;
+
+        Ok(())
+    })
+}

--- a/crates/abi-conformance/src/wasi.rs
+++ b/crates/abi-conformance/src/wasi.rs
@@ -1,0 +1,290 @@
+use super::Context;
+use anyhow::{ensure, Result};
+use cap_std::time::SystemTime as CapStdSystemTime;
+use rand::SeedableRng;
+use rand_chacha::ChaCha12Core;
+use rand_core::block::{BlockRng, BlockRngCore};
+use serde::Serialize;
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::Write,
+    ops::Deref,
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime},
+};
+use wasi_common::{
+    pipe::{ReadPipe, WritePipe},
+    WasiSystemClock,
+};
+use wasmtime::{InstancePre, Store};
+use wasmtime_wasi::{sync::dir::Dir, Dir as CapStdDir};
+
+/// Report of which WASI functions a module successfully used, if any
+///
+/// This represents the subset of WASI which is relevant to Spin and does not include e.g. network sockets,
+/// filesystem odification, etc.
+#[derive(Serialize)]
+pub struct WasiReport {
+    /// Result of the WASI environment variable test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["wasi-env", "foo"\] as
+    /// arguments.  The module should call the host-implemented `wasi_snapshot_preview1::environ_get` function
+    /// w`ok("foo=bar")` as the result.  The module should extract the value of the "foo" variable and write the
+    /// result to `stdout` as a UTF-8 string.  The host will assert the output matches the expected value.
+    pub env: Result<(), String>,
+
+    /// Result of the WASI system clock test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["wasi-epoch"\] as the
+    /// argument.  The module should call the host-implemented `wasi_snapshot_preview1::clock_time_get` function
+    /// with `realtime` as the clock ID and expect `ok(1663014331719000000)` as the result.  The module should then
+    /// divide that value by 1000000 to convert to milliseconds and write the result to `stdout` as a UTF-8 string.
+    /// The host will assert the output matches the expected value.
+    pub epoch: Result<(), String>,
+
+    /// Result of the WASI system random number generator test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["wasi-random"\] as the
+    /// argument.  The module should call the host-implemented `wasi_snapshot_preview1::random_get` function at
+    /// least once.  The host will assert that said function was called at least once.
+    pub random: Result<(), String>,
+
+    /// Result of the WASI stdio test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["wasi-stdio"\] as the
+    /// argument.  The module should call the host-implemented `wasi_snapshot_preview1::fd_read` and
+    /// `wasi_snapshot_preview1::fd_write` functions as necessary to read the UTF-8 string "All mimsy were the
+    /// borogroves" from `stdin` and write the same string back to `stdout`.  The host will assert that the output
+    /// matches the input.
+    pub stdio: Result<(), String>,
+
+    /// Result of the WASI filesystem read test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["wasi-read",
+    /// "foo.txt"\] as arguments.  The module should call the relevant `wasi_snapshot_preview1` functions to open
+    /// the file "foo.txt" in the preopened directory descriptor 3 and read its content, which will be the UTF-8
+    /// string "And the mome raths outgrabe".  The module should then write that string to `stdout`.  The host will
+    /// assert that the output matches the contents of the file.
+    pub read: Result<(), String>,
+
+    /// Result of the WASI filesystem readdir test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["wasi-readdir", "/"\]
+    /// as arguments.  The module should call the relevant `wasi_snapshot_preview1` functions to read the contents
+    /// of the preopened directory named "/" and write them to `stdout` as comma-delimited, UTF-8-encoded strings
+    /// (in arbitrary order), skipping the "." and ".." entries.  The host will assert that the output matches the
+    /// contents of the directory: "bar.txt", "baz.txt", and "foo.txt".
+    pub readdir: Result<(), String>,
+
+    /// Result of the WASI filesystem stat test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with \["wasi-stat",
+    /// "foo.txt"\] as arguments.  The module should call the relevant `wasi_snapshot_preview1` functions to
+    /// retrieve metadata from the file "foo.txt" in the preopened directory descriptor 3.  The module should then
+    /// write a UTF-8-encoded string of the form "length:<length>,modified:<modified>" to `stdout`, where
+    /// "<length>" is the length of the file and "<modified>" is the last-modified time in milliseconds since 1970
+    /// UTC.  The host will assert that the output matches the metdata of the file.
+    pub stat: Result<(), String>,
+}
+
+pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Result<WasiReport> {
+    Ok(WasiReport {
+        env: {
+            let stdout = WritePipe::new_in_memory();
+            store.data_mut().wasi.set_stdout(Box::new(stdout.clone()));
+            store.data_mut().wasi.push_env("foo", "bar")?;
+
+            super::run_command(store, pre, &["wasi-env", "foo"], move |_| {
+                let stdout = String::from_utf8(stdout.try_into_inner().unwrap().into_inner())?;
+                ensure!(
+                    "bar" == stdout.deref(),
+                    "expected module to write \"bar\" to stdout, got {stdout:?}"
+                );
+
+                Ok(())
+            })
+        },
+
+        epoch: {
+            const TIME: u64 = 1663014331719;
+
+            struct MyClock;
+
+            impl WasiSystemClock for MyClock {
+                fn resolution(&self) -> Duration {
+                    Duration::from_millis(1)
+                }
+
+                fn now(&self, _precision: Duration) -> CapStdSystemTime {
+                    CapStdSystemTime::from_std(
+                        SystemTime::UNIX_EPOCH
+                            .checked_add(Duration::from_millis(TIME))
+                            .unwrap(),
+                    )
+                }
+            }
+
+            let stdout = WritePipe::new_in_memory();
+            {
+                let context = store.data_mut();
+                context.wasi.set_stdout(Box::new(stdout.clone()));
+                context.wasi.clocks.system = Box::new(MyClock);
+            }
+
+            super::run_command(store, pre, &["wasi-epoch"], move |_| {
+                let stdout = String::from_utf8(stdout.try_into_inner().unwrap().into_inner())?;
+                ensure!(
+                    TIME.to_string() == stdout,
+                    "expected module to write {TIME:?} to stdout, got {stdout:?}"
+                );
+
+                Ok(())
+            })
+        },
+
+        random: {
+            #[derive(Clone)]
+            struct MyRngCore {
+                cha_cha_12: ChaCha12Core,
+                called: Arc<AtomicBool>,
+            }
+
+            impl BlockRngCore for MyRngCore {
+                type Item = <ChaCha12Core as BlockRngCore>::Item;
+                type Results = <ChaCha12Core as BlockRngCore>::Results;
+
+                fn generate(&mut self, results: &mut Self::Results) {
+                    self.called.store(true, Ordering::Relaxed);
+                    self.cha_cha_12.generate(results)
+                }
+            }
+
+            let called = Arc::new(AtomicBool::default());
+            store.data_mut().wasi.random = Box::new(BlockRng::new(MyRngCore {
+                cha_cha_12: ChaCha12Core::seed_from_u64(42),
+                called: called.clone(),
+            }));
+
+            super::run_command(store, pre, &["wasi-random"], move |_| {
+                ensure!(
+                    called.load(Ordering::Relaxed),
+                    "expected module to call `wasi_snapshot_preview1::random_get` at least once"
+                );
+
+                Ok(())
+            })
+        },
+
+        stdio: {
+            let stdin = ReadPipe::from("All mimsy were the borogroves");
+            let stdout = WritePipe::new_in_memory();
+
+            store.data_mut().wasi.set_stdin(Box::new(stdin.clone()));
+            store.data_mut().wasi.set_stdout(Box::new(stdout.clone()));
+
+            super::run_command(store, pre, &["wasi-stdio"], move |_| {
+                let stdin = stdin.try_into_inner().unwrap().into_inner();
+                let stdout = String::from_utf8(stdout.try_into_inner().unwrap().into_inner())?;
+                ensure!(
+                    stdin == stdout.deref(),
+                    "expected module to write {stdin:?} to stdout, got {stdout:?}"
+                );
+
+                Ok(())
+            })
+        },
+
+        read: {
+            let stdout = WritePipe::new_in_memory();
+            let message = "And the mome raths outgrabe";
+            let dir = tempfile::tempdir()?;
+            let mut file = File::create(dir.path().join("foo.txt"))?;
+            file.write_all(message.as_bytes())?;
+
+            store.data_mut().wasi.set_stdout(Box::new(stdout.clone()));
+            add_dir(store, dir.path())?;
+
+            super::run_command(store, pre, &["wasi-read", "foo.txt"], move |_| {
+                let stdout = String::from_utf8(stdout.try_into_inner().unwrap().into_inner())?;
+                ensure!(
+                    message == stdout.deref(),
+                    "expected module to write {message:?} to stdout, got {stdout:?}"
+                );
+
+                Ok(())
+            })
+        },
+
+        readdir: {
+            let stdout = WritePipe::new_in_memory();
+            let dir = tempfile::tempdir()?;
+
+            let names = ["foo.txt", "bar.txt", "baz.txt"];
+            for &name in &names {
+                File::create(dir.path().join(name))?;
+            }
+
+            store.data_mut().wasi.set_stdout(Box::new(stdout.clone()));
+            add_dir(store, dir.path())?;
+
+            super::run_command(store, pre, &["wasi-readdir", "/"], move |_| {
+                let expected = names.iter().copied().collect::<HashSet<_>>();
+                let stdout = String::from_utf8(stdout.try_into_inner().unwrap().into_inner())?;
+                let got = stdout.split(',').collect();
+                ensure!(
+                    expected == got,
+                    "expected module to write {expected:?} to stdout (in any order), got {got:?}"
+                );
+
+                Ok(())
+            })
+        },
+
+        stat: {
+            let stdout = WritePipe::new_in_memory();
+            let message = "O frabjous day! Callooh! Callay!";
+            let dir = tempfile::tempdir()?;
+            let mut file = File::create(dir.path().join("foo.txt"))?;
+            file.write_all(message.as_bytes())?;
+            let metadata = file.metadata()?;
+
+            store.data_mut().wasi.set_stdout(Box::new(stdout.clone()));
+            add_dir(store, dir.path())?;
+
+            super::run_command(store, pre, &["wasi-stat", "foo.txt"], move |_| {
+                let expected = format!(
+                    "length:{},modified:{}",
+                    metadata.len(),
+                    metadata
+                        .modified()?
+                        .duration_since(SystemTime::UNIX_EPOCH)?
+                        .as_millis()
+                );
+                let got = String::from_utf8(stdout.try_into_inner().unwrap().into_inner())?;
+
+                ensure!(
+                    expected == got,
+                    "expected module to write {expected:?} to stdout, got {got:?}"
+                );
+
+                Ok(())
+            })
+        },
+    })
+}
+
+fn add_dir(store: &mut Store<Context>, path: &Path) -> Result<()> {
+    store.data_mut().wasi.push_preopened_dir(
+        Box::new(Dir::from_cap_std(CapStdDir::from_std_file(File::open(
+            path,
+        )?))),
+        "/",
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
This crate provides a suite of tests to determine which features of Spin a guest module is capable of exercising.  The suite may be run via the `test` function, which accepts a `wasmtime::Module` and returns a `Report` which details which features the module does or does not support.  Alternatively, there is also a CLI version which generates a report in JSON form.

See the doc comments for `Report` and friends for details on what is tested.

Note that the current implementation is quite simple, and there are a few ways a module implementation could "cheat", i.e. hard-code output to match what the test expects without actually doing the thing it was asked to do.  We could prevent that by randomly generating parameters, but I don't consider that a high priority.

I will soon be creating a separate repository to host guest module implementations for various languages which uses this crate to generate a language support matrix automatically.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>