### PR TITLE
fix: Use `block_in_place` in outbound-pg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,6 +2207,7 @@ dependencies = [
  "postgres",
  "spin-engine",
  "spin-manifest",
+ "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
 ]

--- a/crates/outbound-pg/Cargo.toml
+++ b/crates/outbound-pg/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 postgres = { version = "0.19.3" }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
+tokio = { version = "1", features = [ "rt-multi-thread" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 
 [dependencies.wit-bindgen-wasmtime]

--- a/examples/rust-outbound-pg/Cargo.lock
+++ b/examples/rust-outbound-pg/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
This is required because the `postgres` crate is a wrapper around `tokio-postgres` which calls `block_on` internally.

Fixes #768 