### PR TITLE
feat: Include manifest file name into error output

### DIFF
--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -63,7 +63,9 @@ pub async fn raw_manifest_from_file(app: &impl AsRef<Path>) -> Result<RawAppMani
         .await
         .with_context(|| anyhow!("Cannot read manifest file from {:?}", app.as_ref()))?;
 
-    let manifest: RawAppManifestAnyVersion = toml::from_slice(&buf)?;
+    let manifest: RawAppManifestAnyVersion = toml::from_slice(&buf)
+        .with_context(|| anyhow!("Cannot read manifest file from {:?}", app.as_ref()))?;
+
     Ok(manifest)
 }
 

--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -99,6 +99,23 @@ fn test_manifest() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_invalid_manifest() -> Result<()> {
+    const MANIFEST: &str = "tests/invalid-manifest.toml";
+
+    let temp_dir = tempfile::tempdir()?;
+    let dir = temp_dir.path();
+    let app = from_file(MANIFEST, dir, &None, false).await;
+
+    let e = app.unwrap_err().to_string();
+    assert!(
+        e.contains("invalid-manifest.toml"),
+        "Expected error to contain the manifest name"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_unknown_version_is_rejected() {
     const MANIFEST: &str = include_str!("../../tests/invalid-version.toml");

--- a/crates/loader/tests/invalid-manifest.toml
+++ b/crates/loader/tests/invalid-manifest.toml
@@ -1,0 +1,6 @@
+spin_version = "1"
+authors = ["Gul Madred", "Edward Jellico", "JL"]
+description = "A simple application that returns the number of lights"
+name = "chain-of-command"
+trigger = {type = "http", base = "/"}
+ver


### PR DESCRIPTION
Before:

```
$ ../../target/debug/spin build
Error: expected a comma, found an identifier at line 9 column 28
```

After:

```
$ ../../target/debug/spin build
Error: Cannot read manifest file from "spin.toml"

Caused by:
    expected a comma, found an identifier at line 9 column 28
```

Refs: #769
Signed-off-by: Konstantin Shabanov <mail@etehtsea.me>