### PR TITLE
use `tokio-postgres` in `outbound-pg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,10 +2204,10 @@ name = "outbound-pg"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "postgres",
  "spin-engine",
  "spin-manifest",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "wit-bindgen-wasmtime",
 ]
@@ -2453,20 +2453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "postgres"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960c214283ef8f0027974c03e9014517ced5db12f021a9abb66185a5751fab0a"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
 ]
 
 [[package]]

--- a/crates/outbound-pg/Cargo.toml
+++ b/crates/outbound-pg/Cargo.toml
@@ -8,7 +8,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-postgres = { version = "0.19.3" }
+tokio-postgres = { version = "0.7.7" }
 spin-engine = { path = "../engine" }
 spin-manifest = { path = "../manifest" }
 tokio = { version = "1", features = [ "rt-multi-thread" ] }
@@ -18,4 +18,3 @@ tracing = { version = "0.1", features = [ "log" ] }
 git = "https://github.com/bytecodealliance/wit-bindgen"
 rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
 features = ["async"]
-

--- a/crates/outbound-pg/src/lib.rs
+++ b/crates/outbound-pg/src/lib.rs
@@ -55,12 +55,12 @@ impl outbound_pg::OutboundPg for OutboundPg {
             .iter()
             .map(to_sql_parameter)
             .collect::<anyhow::Result<Vec<_>>>()
-            .map_err(|e| PgError::QueryFailed(format!("{:?}", e)))?;
+            .map_err(|e| PgError::ValueConversionFailed(format!("{:?}", e)))?;
 
         let nrow = client
             .execute(statement, params.as_slice())
             .await
-            .map_err(|e| PgError::ValueConversionFailed(format!("{:?}", e)))?;
+            .map_err(|e| PgError::QueryFailed(format!("{:?}", e)))?;
 
         Ok(nrow)
     }


### PR DESCRIPTION
Since `postgres` just wraps the async `tokio-postgres` library in a synchronous wrapper, and `outbound-pg` exports async methods, it makes more sense to use `tokio-postgres` directly.

Addresses #776 

Signed-off-by: Joel Dice <joel.dice@fermyon.com>