### PR TITLE
feat: add support to override Spin compatibility checks for plugins

### DIFF
--- a/crates/plugins/src/manager.rs
+++ b/crates/plugins/src/manager.rs
@@ -98,6 +98,7 @@ impl PluginManager {
         &self,
         plugin_manifest: &PluginManifest,
         spin_version: &str,
+        override_compatibility_check: bool,
         allow_downgrades: bool,
     ) -> Result<()> {
         // Disallow installing plugins with the same name as spin internal subcommands
@@ -129,7 +130,7 @@ impl PluginManager {
             }
         }
 
-        check_supported_version(plugin_manifest, spin_version)
+        check_supported_version(plugin_manifest, spin_version, override_compatibility_check)
     }
 
     /// Fetches a manifest from a local, remote, or repository location and returned the parsed

--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -88,23 +88,32 @@ impl Architecture {
 }
 
 /// Checks whether the plugin supports the currently running version of Spin.
-pub fn check_supported_version(manifest: &PluginManifest, spin_version: &str) -> Result<()> {
+pub fn check_supported_version(
+    manifest: &PluginManifest,
+    spin_version: &str,
+    override_compatibility_check: bool,
+) -> Result<()> {
     let supported_on = &manifest.spin_compatibility;
-    inner_check_supported_version(supported_on, spin_version)
+    inner_check_supported_version(supported_on, spin_version, override_compatibility_check)
 }
 
-fn inner_check_supported_version(supported_on: &str, spin_version: &str) -> Result<()> {
+fn inner_check_supported_version(
+    supported_on: &str,
+    spin_version: &str,
+    override_compatibility_check: bool,
+) -> Result<()> {
     let comparator = VersionReq::parse(supported_on).with_context(|| {
-        format!(
-            "Could not parse manifest compatibility version {} as valid semver",
-            &supported_on,
-        )
+        format!("Could not parse manifest compatibility version {supported_on} as valid semver")
     })?;
     let version = Version::parse(spin_version)?;
     if !comparator.matches(&version) {
-        return Err(anyhow!(
-            "Spin version compatibility check failed (supported: {supported_on}, actual: {spin_version}). Try running `spin plugin update` to get latest."
+        if override_compatibility_check {
+            eprintln!("Plugin is not compatible with this version of Spin (supported: {supported_on}, actual: {spin_version}). Check overridden ... continuing to install or execute plugin.");
+        } else {
+            return Err(anyhow!(
+            "Plugin is not compatible with this version of Spin (supported: {supported_on}, actual: {spin_version}). Try running `spin plugin update && spin plugin upgrade --all` to install latest or override with `--override-compatibility-check`."
         ));
+        }
     }
     Ok(())
 }
@@ -172,9 +181,12 @@ mod test {
             ("1.9.0", false),
             ("1.2.0", false),
         ];
-        input_output
-            .into_iter()
-            .for_each(|(i, o)| assert_eq!(inner_check_supported_version(test_case, i).is_ok(), o));
+        input_output.into_iter().for_each(|(i, o)| {
+            assert_eq!(
+                inner_check_supported_version(test_case, i, false).is_ok(),
+                o
+            )
+        });
     }
 
     #[test]

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -1,3 +1,4 @@
+use crate::opts::PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG;
 use anyhow::{anyhow, Result};
 use clap::App;
 use spin_plugins::{error::Error, manifest::check_supported_version, PluginStore};
@@ -5,23 +6,43 @@ use std::{collections::HashMap, env, process};
 use tokio::process::Command;
 use tracing::log;
 
+fn override_flag() -> String {
+    format!("--{}", PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG)
+}
+
+// Returns true if the argument was removed from the list
+fn remove_arg(arg: &str, args: &mut Vec<String>) -> bool {
+    let contained = args.contains(&arg.to_owned());
+    args.retain(|a| a != arg);
+    contained
+}
+
+// Parses the subcommand to get the plugin name, args, and override compatibility check flag
+fn parse_subcommand(mut cmd: Vec<String>) -> anyhow::Result<(String, Vec<String>, bool)> {
+    let override_compatibility_check = remove_arg(&override_flag(), &mut cmd);
+    let (plugin_name, args) = cmd
+        .split_first()
+        .ok_or_else(|| anyhow!("Expected subcommand"))?;
+    Ok((
+        plugin_name.into(),
+        args.to_vec(),
+        override_compatibility_check,
+    ))
+}
+
 /// Executes a Spin plugin as a subprocess, expecting the first argument to
 /// indicate the plugin to execute. Passes all subsequent arguments on to the
 /// subprocess.
 pub async fn execute_external_subcommand(cmd: Vec<String>, app: App<'_>) -> anyhow::Result<()> {
-    let (plugin_name, args) = cmd
-        .split_first()
-        .ok_or_else(|| anyhow!("Expected subcommand"))?;
+    let (plugin_name, args, override_compatibility_check) = parse_subcommand(cmd)?;
     let plugin_store = PluginStore::default()?;
-    match plugin_store.read_plugin_manifest(plugin_name) {
+    match plugin_store.read_plugin_manifest(&plugin_name) {
         Ok(manifest) => {
             let spin_version = env!("VERGEN_BUILD_SEMVER");
-            if let Err(e) = check_supported_version(&manifest, spin_version) {
+            if let Err(e) =
+                check_supported_version(&manifest, spin_version, override_compatibility_check)
+            {
                 eprintln!("{e}");
-                eprintln!(
-                    "Try running `spin plugin upgrade {}` to get the latest version of the plugin.",
-                    manifest.name()
-                );
                 process::exit(1);
             }
         }
@@ -34,7 +55,7 @@ pub async fn execute_external_subcommand(cmd: Vec<String>, app: App<'_>) -> anyh
         Err(e) => return Err(e.into()),
     }
 
-    let mut command = Command::new(plugin_store.installed_binary_path(plugin_name));
+    let mut command = Command::new(plugin_store.installed_binary_path(&plugin_name));
     command.args(args);
     command.envs(get_env_vars_map()?);
     log::info!("Executing command {:?}", command);
@@ -67,4 +88,77 @@ fn get_env_vars_map() -> Result<HashMap<String, String>> {
     .into_iter()
     .collect();
     Ok(map)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{override_flag, parse_subcommand};
+
+    #[test]
+    fn test_remove_arg() {
+        let override_flag = override_flag();
+        let plugin_name = "example";
+
+        let cmd = vec![plugin_name.to_string()];
+        assert_eq!(
+            parse_subcommand(cmd).unwrap(),
+            (plugin_name.to_string(), vec![], false)
+        );
+
+        let cmd_with_args = "example arg1 arg2"
+            .split(' ')
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+        assert_eq!(
+            parse_subcommand(cmd_with_args).unwrap(),
+            (
+                plugin_name.to_string(),
+                vec!["arg1".to_string(), "arg2".to_string()],
+                false
+            )
+        );
+
+        let cmd_with_args_override = format!("example arg1 arg2 {}", override_flag)
+            .split(' ')
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+        assert_eq!(
+            parse_subcommand(cmd_with_args_override).unwrap(),
+            (
+                plugin_name.to_string(),
+                vec!["arg1".to_string(), "arg2".to_string()],
+                true
+            )
+        );
+
+        let cmd_with_args_override = format!("example {} arg1 arg2", override_flag)
+            .split(' ')
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+        assert_eq!(
+            parse_subcommand(cmd_with_args_override).unwrap(),
+            (
+                plugin_name.to_string(),
+                vec!["arg1".to_string(), "arg2".to_string()],
+                true
+            )
+        );
+
+        let cmd_with_args_override = format!("{} example arg1 arg2", override_flag)
+            .split(' ')
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+        assert_eq!(
+            parse_subcommand(cmd_with_args_override).unwrap(),
+            (
+                plugin_name.to_string(),
+                vec!["arg1".to_string(), "arg2".to_string()],
+                true
+            )
+        );
+    }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -15,3 +15,4 @@ pub const PLUGIN_NAME_OPT: &str = "PLUGIN_NAME";
 pub const PLUGIN_REMOTE_PLUGIN_MANIFEST_OPT: &str = "REMOTE_PLUGIN_MANIFEST";
 pub const PLUGIN_LOCAL_PLUGIN_MANIFEST_OPT: &str = "LOCAL_PLUGIN_MANIFEST";
 pub const PLUGIN_ALL_OPT: &str = "ALL";
+pub const PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG: &str = "override-compatibility-check";


### PR DESCRIPTION
Spin plugins state which versions of Spin they are compatible with in their plugin manifest. Currently, Spin checks if the plugin is compatible before allowing it to be installed or executed. If incompatible, the operation fails. This allows overriding that failure with an `--override-compatibility-check` flag. When specified during Spin plugin installs, upgrades and executions, the action will continue even if the plugin is incompatible with the current version of Spin.

More context on the decision to add this override can be found in this thread: https://github.com/fermyon/spin/pull/735#issuecomment-1246356616