### PR TITLE
Add option to use --follow-all when running Redis Trigger (to see messages interactively, as apposed to via logs)

### DIFF
--- a/docs/content/rust-components.md
+++ b/docs/content/rust-components.md
@@ -194,8 +194,15 @@ message on the `messages` channel, the `echo-message` component will be executed
 $ redis-server --port 6379
 # then, start the Spin application
 $ spin up --file spin.toml
+# the logs will output the following
 INFO spin_redis_engine: Connecting to Redis server at redis://localhost:6379
 INFO spin_redis_engine: Subscribed component 0 (echo-message) to channel: messages
+```
+
+**Please note**: By default, `stdout` goes only to the logs. This is because Spin is intended to run as a server. If you would like to see the published messages interactively please use the `--follow-all` option, when starting the spin application. For example:
+
+```bash
+spin up --file spin.toml --follow-all
 ```
 
 For every new message on the  `messages` channel:

--- a/docs/content/rust-components.md
+++ b/docs/content/rust-components.md
@@ -194,15 +194,9 @@ message on the `messages` channel, the `echo-message` component will be executed
 $ redis-server --port 6379
 # then, start the Spin application
 $ spin up --file spin.toml
-# the logs will output the following
+# the application log file will output the following
 INFO spin_redis_engine: Connecting to Redis server at redis://localhost:6379
 INFO spin_redis_engine: Subscribed component 0 (echo-message) to channel: messages
-```
-
-**Please note**: By default, `stdout` goes only to the logs. This is because Spin is intended to run as a server. If you would like to see the published messages interactively please use the `--follow-all` option, when starting the spin application. For example:
-
-```bash
-spin up --file spin.toml --follow-all
 ```
 
 For every new message on the  `messages` channel:
@@ -212,11 +206,17 @@ $ redis-cli
 127.0.0.1:6379> publish messages "Hello, there!"
 ```
 
-Spin will instantiate and execute the component we just built:
+Spin will instantiate and execute the component we just built, which will emit the `println!` message to the application log file:
 
 ```
 INFO spin_redis_engine: Received message on channel "messages"
 Hello, there!
+```
+
+If you would also like to see the `println!` messages echoed to the console as they happen, please include the additional `--follow-all` option, when starting the spin application. For example:
+
+```bash
+spin up --file spin.toml --follow-all
 ```
 
 > You can find a complete example for a Redis triggered component in the


### PR DESCRIPTION
Signed-off-by: tpmccallum <tim.mccallum@fermyon.com>