### PR TITLE
implement `spin login`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "oauth2",
  "rand 0.7.3",
  "reqwest",
- "semver 1.0.13",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -462,17 +462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
 ]
 
 [[package]]
@@ -814,18 +803,6 @@ dependencies = [
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "dialoguer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61579ada4ec0c6031cfac3f86fdba0d195a7ebeb5e36693bd53cb5999a25beeb"
-dependencies = [
- "console",
- "lazy_static",
- "tempfile",
  "zeroize",
 ]
 
@@ -1397,31 +1374,15 @@ dependencies = [
 
 [[package]]
 name = "hippo"
-version = "0.16.1"
-source = "git+https://github.com/deislabs/hippo-cli?tag=v0.16.1#73315f55fadd2bb027bb2277c2d42c8fd4843922"
+version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
- "clap 3.2.19",
- "colored",
- "dialoguer 0.9.0",
  "dirs 4.0.0",
- "dunce",
- "env_logger",
- "futures",
- "glob",
  "hippo-openapi",
- "itertools",
- "log",
- "mime_guess",
- "regex",
  "reqwest",
- "semver 0.11.0",
  "serde",
  "serde_json",
- "sha2 0.9.9",
- "tokio",
- "toml",
+ "tracing",
  "uuid",
 ]
 
@@ -2985,30 +2946,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -3308,7 +3250,7 @@ dependencies = [
  "path-absolutize",
  "regex",
  "reqwest",
- "semver 1.0.13",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.3",
@@ -3463,7 +3405,7 @@ dependencies = [
  "flate2",
  "log",
  "reqwest",
- "semver 1.0.13",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.3",
@@ -3487,7 +3429,7 @@ dependencies = [
  "mime_guess",
  "path-absolutize",
  "reqwest",
- "semver 1.0.13",
+ "semver",
  "serde",
  "sha2 0.10.3",
  "spin-loader",
@@ -3535,7 +3477,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "console",
- "dialoguer 0.10.2",
+ "dialoguer",
  "dirs 3.0.2",
  "env_logger",
  "fs_extra",
@@ -3552,7 +3494,7 @@ dependencies = [
  "path-absolutize",
  "pathdiff",
  "regex",
- "semver 1.0.13",
+ "semver",
  "serde",
  "sha2 0.10.3",
  "symlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ dirs = "4.0"
 dunce = "1.0"
 env_logger = "0.9"
 futures = "0.3"
+hippo = { path = "crates/hippo" }
 hippo-openapi = "0.10"
-hippo = { git = "https://github.com/deislabs/hippo-cli", tag = "v0.16.1" }
 lazy_static = "1.4.0"
 nix = { version = "0.24", features = ["signal"] }
 outbound-http = { path = "crates/outbound-http" }

--- a/crates/hippo/Cargo.toml
+++ b/crates/hippo/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hippo"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+
+[dependencies]
+anyhow = "1.0"
+dirs = "4.0"
+hippo-openapi = "0.10"
+reqwest = { version = "0.11", features = ["stream"] }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0.82"
+tracing = { version = "0.1", features = [ "log" ] }
+uuid = "^1.0"

--- a/crates/hippo/src/client.rs
+++ b/crates/hippo/src/client.rs
@@ -1,0 +1,373 @@
+use hippo_openapi::apis::channels_api::api_channels_id_put;
+use hippo_openapi::models::GetChannelLogsVm;
+use hippo_openapi::models::PatchChannelCommand;
+use hippo_openapi::models::UpdateChannelCommand;
+use std::collections::HashMap;
+
+use hippo_openapi::apis::accounts_api::api_accounts_post;
+use hippo_openapi::apis::apps_api::{api_apps_get, api_apps_id_delete, api_apps_post};
+use hippo_openapi::apis::auth_tokens_api::api_auth_tokens_post;
+use hippo_openapi::apis::certificates_api::{
+    api_certificates_get, api_certificates_id_delete, api_certificates_post,
+};
+use hippo_openapi::apis::channels_api::{
+    api_channels_get, api_channels_id_delete, api_channels_id_get, api_channels_id_logs_get,
+    api_channels_id_patch, api_channels_post,
+};
+use hippo_openapi::apis::configuration::{ApiKey, Configuration};
+use hippo_openapi::apis::revisions_api::{api_revisions_get, api_revisions_post};
+use hippo_openapi::apis::Error;
+use hippo_openapi::models::{
+    AppItemPage, CertificateItemPage, ChannelItem, ChannelItemPage,
+    ChannelRevisionSelectionStrategy, CreateAccountCommand, CreateAppCommand,
+    CreateCertificateCommand, CreateChannelCommand, CreateTokenCommand, EnvironmentVariableItem,
+    RegisterRevisionCommand, RevisionItemPage, TokenInfo, UpdateEnvironmentVariableDto,
+};
+
+use uuid::Uuid;
+
+use reqwest::header;
+use serde::Deserialize;
+
+use crate::config::ConnectionInfo;
+
+const JSON_MIME_TYPE: &str = "application/json";
+
+pub struct Client {
+    configuration: Configuration,
+}
+
+impl Client {
+    pub fn new(conn_info: ConnectionInfo) -> Self {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(header::ACCEPT, JSON_MIME_TYPE.parse().unwrap());
+        headers.insert(header::CONTENT_TYPE, JSON_MIME_TYPE.parse().unwrap());
+
+        let base_path = match conn_info.url.strip_suffix("/") {
+            Some(s) => s.to_owned(),
+            None => conn_info.url,
+        };
+        let configuration = Configuration {
+            base_path: base_path,
+            user_agent: Some(format!(
+                "{}/{}",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION")
+            )),
+            client: reqwest::Client::builder()
+                .danger_accept_invalid_certs(conn_info.danger_accept_invalid_certs)
+                .default_headers(headers)
+                .build()
+                .unwrap(),
+            basic_auth: None,
+            oauth_access_token: None,
+            bearer_access_token: None,
+            api_key: conn_info.token.token.map_or(None, |t| {
+                Some(ApiKey {
+                    prefix: Some("Bearer".to_owned()),
+                    key: t,
+                })
+            }),
+        };
+
+        Self { configuration }
+    }
+
+    pub async fn register(&self, username: String, password: String) -> anyhow::Result<String> {
+        api_accounts_post(
+            &self.configuration,
+            Some(CreateAccountCommand {
+                user_name: username,
+                password: password,
+            }),
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn login(&self, username: String, password: String) -> anyhow::Result<TokenInfo> {
+        api_auth_tokens_post(
+            &self.configuration,
+            Some(CreateTokenCommand {
+                user_name: username,
+                password: password,
+            }),
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn add_app(&self, name: String, storage_id: String) -> anyhow::Result<Uuid> {
+        api_apps_post(
+            &self.configuration,
+            Some(CreateAppCommand {
+                name: name,
+                storage_id: storage_id,
+            }),
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn remove_app(&self, id: String) -> anyhow::Result<()> {
+        api_apps_id_delete(&self.configuration, &id)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn list_apps(&self) -> anyhow::Result<AppItemPage> {
+        api_apps_get(&self.configuration, None, None, None, None, None)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn add_certificate(
+        &self,
+        name: String,
+        public_key: String,
+        private_key: String,
+    ) -> anyhow::Result<Uuid> {
+        api_certificates_post(
+            &self.configuration,
+            Some(CreateCertificateCommand {
+                name: name,
+                public_key: public_key,
+                private_key: private_key,
+            }),
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn list_certificates(&self) -> anyhow::Result<CertificateItemPage> {
+        api_certificates_get(&self.configuration, None, None, None, None, None)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn remove_certificate(&self, id: String) -> anyhow::Result<()> {
+        api_certificates_id_delete(&self.configuration, &id)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn add_channel(
+        &self,
+        app_id: Uuid,
+        name: String,
+        domain: Option<String>,
+        revision_selection_strategy: ChannelRevisionSelectionStrategy,
+        range_rule: Option<String>,
+        active_revision_id: Option<Uuid>,
+        certificate_id: Option<Uuid>,
+    ) -> anyhow::Result<Uuid> {
+        let command = CreateChannelCommand {
+            app_id: app_id,
+            name: name,
+            domain,
+            revision_selection_strategy,
+            range_rule,
+            active_revision_id,
+            certificate_id,
+        };
+        api_channels_post(&self.configuration, Some(command))
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn get_channel_by_id(&self, id: &str) -> anyhow::Result<ChannelItem> {
+        api_channels_id_get(&self.configuration, id)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn list_channels(&self) -> anyhow::Result<ChannelItemPage> {
+        api_channels_get(&self.configuration, Some(""), None, None, Some("Name"), None)
+            .await
+            .map_err(format_response_error)
+    }
+
+    #[allow(dead_code)]
+    pub async fn patch_channel(
+        &self,
+        id: Uuid,
+        name: Option<String>,
+        domain: Option<String>,
+        revision_selection_strategy: Option<ChannelRevisionSelectionStrategy>,
+        range_rule: Option<String>,
+        active_revision_id: Option<Uuid>,
+        certificate_id: Option<Uuid>,
+        environment_variables: Option<Vec<UpdateEnvironmentVariableDto>>,
+    ) -> anyhow::Result<()> {
+        let command = PatchChannelCommand {
+            channel_id: Some(id),
+            name: name.map(Box::new),
+            domain: domain.map(Box::new),
+            revision_selection_strategy: revision_selection_strategy.map(Box::new),
+            range_rule: range_rule.map(Box::new),
+            active_revision_id: active_revision_id.map(Box::new),
+            certificate_id: certificate_id.map(Box::new),
+            environment_variables: environment_variables.map(Box::new),
+        };
+
+        api_channels_id_patch(&self.configuration, &id.to_string(), Some(command))
+            .await
+            .map_err(format_response_error)
+    }
+
+    #[allow(dead_code)]
+    pub async fn put_channel(
+        &self,
+        id: Uuid,
+        name: String,
+        domain: String,
+        revision_selection_strategy: ChannelRevisionSelectionStrategy,
+        range_rule: Option<String>,
+        active_revision_id: Option<Uuid>,
+        certificate_id: Option<Uuid>
+    ) -> anyhow::Result<()> {
+        let command = UpdateChannelCommand {
+            id,
+            name: name,
+            domain,
+            revision_selection_strategy,
+            range_rule,
+            active_revision_id,
+            certificate_id,
+            // TODO: remove in next Hippo release
+            last_publish_date: None,
+        };
+        api_channels_id_put(&self.configuration, &id.to_string(), Some(command))
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn remove_channel(&self, id: String) -> anyhow::Result<()> {
+        api_channels_id_delete(&self.configuration, &id)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn channel_logs(&self, id: String) -> anyhow::Result<GetChannelLogsVm> {
+        api_channels_id_logs_get(&self.configuration, &id)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn add_environment_variable(
+        &self,
+        key: String,
+        value: String,
+        channel_id: Uuid,
+    ) -> anyhow::Result<()> {
+        let mut environment_variables = self.list_environment_variables(channel_id.clone()).await?;
+        environment_variables.push(EnvironmentVariableItem {
+            // TODO: fix this in hippo 0.19 - shouldn't need to reference the channel ID
+            channel_id: channel_id.clone(),
+            key: key,
+            value: value,
+        });
+        api_channels_id_patch(
+            &self.configuration,
+            &channel_id.to_string(),
+            Some(PatchChannelCommand {
+                // TODO: fix this in hippo 0.19 - this is a very ugly type cast that shouldn't exist
+                environment_variables: Some(Box::new(
+                    environment_variables
+                        .iter()
+                        .map(|e| UpdateEnvironmentVariableDto {
+                            key: e.key.clone(),
+                            value: e.value.clone(),
+                        })
+                        .collect(),
+                )),
+                ..Default::default()
+            }),
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn list_environment_variables(
+        &self,
+        channel_id: Uuid,
+    ) -> anyhow::Result<Vec<EnvironmentVariableItem>> {
+        let channel = self.get_channel_by_id(&channel_id.to_string()).await?;
+        Ok(channel.environment_variables)
+    }
+
+    pub async fn remove_environment_variable(
+        &self,
+        channel_id: Uuid,
+        key: String,
+    ) -> anyhow::Result<()> {
+        let mut environment_variables = self.list_environment_variables(channel_id.clone()).await?;
+        let index = environment_variables
+            .iter()
+            .position(|e| e.key == key)
+            .unwrap();
+        environment_variables.remove(index);
+        api_channels_id_patch(
+            &self.configuration,
+            &channel_id.to_string(),
+            Some(PatchChannelCommand {
+                // TODO: fix this in hippo 0.19 - this is a very ugly type cast that shouldn't exist
+                environment_variables: Some(Box::new(
+                    environment_variables
+                        .iter()
+                        .map(|e| UpdateEnvironmentVariableDto {
+                            key: e.key.clone(),
+                            value: e.value.clone(),
+                        })
+                        .collect(),
+                )),
+                ..Default::default()
+            }),
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn add_revision(
+        &self,
+        app_storage_id: String,
+        revision_number: String,
+    ) -> anyhow::Result<()> {
+        api_revisions_post(
+            &self.configuration,
+            Some(RegisterRevisionCommand {
+                app_storage_id: app_storage_id,
+                revision_number: revision_number,
+            }),
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn list_revisions(&self) -> anyhow::Result<RevisionItemPage> {
+        api_revisions_get(&self.configuration, None, None)
+            .await
+            .map_err(format_response_error)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct ValidationExceptionMessage {
+    title: String,
+    errors: HashMap<String, Vec<String>>,
+}
+
+fn format_response_error<T>(e: Error<T>) -> anyhow::Error {
+    match e {
+        Error::ResponseError(r) => {
+            match serde_json::from_str::<ValidationExceptionMessage>(&r.content) {
+                Ok(m) => anyhow::anyhow!("{} {:?}", m.title, m.errors),
+                _ => anyhow::anyhow!(r.content),
+            }
+        }
+        Error::Serde(err ) => {
+            anyhow::anyhow!(format!("could not parse JSON object: {}", err))
+        }
+        _ => anyhow::anyhow!(e.to_string()),
+    }
+}

--- a/crates/hippo/src/config.rs
+++ b/crates/hippo/src/config.rs
@@ -1,0 +1,94 @@
+use std::{
+    fs::{File, OpenOptions},
+    path::PathBuf,
+};
+
+use anyhow::{bail, Context, Result};
+use hippo_openapi::models::TokenInfo;
+use serde::{Deserialize, Serialize};
+use tracing::log;
+
+pub const DEFAULT_FERMYON_DIRECTORY: &str = "fermyon";
+pub const DEFAULT_CONFIGURATION_FILE: &str = "config.json";
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct ConnectionInfo {
+    pub url: String,
+    pub danger_accept_invalid_certs: bool,
+    pub token: TokenInfo,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Config {
+    /// Root directory for all data and configuration.
+    pub root: PathBuf,
+
+    /// Configuration for the connection to the platform.
+    pub connection: ConnectionInfo,
+}
+
+impl Config {
+    pub async fn new(root: Option<PathBuf>) -> Result<Self> {
+        let root = match root {
+            Some(p) => p.join(DEFAULT_FERMYON_DIRECTORY),
+            None => dirs::config_dir()
+                .context("Cannot find configuration directory")?
+                .join(DEFAULT_FERMYON_DIRECTORY),
+        };
+
+        ensure(&root)?;
+
+        let p = root.join(DEFAULT_CONFIGURATION_FILE);
+        let connection = match p.exists() {
+            true => {
+                let cfg_file = File::open(&p).context("cannot open configuration file")?;
+                log::trace!("Using configuration file {:?}", &p);
+                serde_json::from_reader(cfg_file)
+                    .context(format!("Cannot deserialize configuration file {:?}", &p))?
+            }
+            false => ConnectionInfo::default(),
+        };
+
+        Ok(Self { root, connection })
+    }
+
+    /// Persist a configuration change.
+    pub async fn commit(&self) -> Result<()> {
+        let cfg_file = self.root.join(DEFAULT_CONFIGURATION_FILE);
+        let f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&cfg_file)?;
+
+        serde_json::to_writer_pretty(f, &self.connection)?;
+        tracing::debug!("Configuration saved to {:?}", cfg_file);
+        Ok(())
+    }
+}
+
+/// Ensure the root directory exists, or else create it.
+fn ensure(root: &PathBuf) -> Result<()> {
+    log::trace!("Ensuring root directory {:?}", root);
+    if !root.exists() {
+        log::trace!("Creating configuration root directory `{}`", root.display());
+        std::fs::create_dir_all(root).with_context(|| {
+            format!(
+                "Failed to create configuration root directory `{}`",
+                root.display()
+            )
+        })?;
+    } else if !root.is_dir() {
+        bail!(
+            "Configuration root `{}` already exists and is not a directory",
+            root.display()
+        );
+    } else {
+        log::trace!(
+            "Using existing configuration root directory `{}`",
+            root.display()
+        );
+    }
+
+    Ok(())
+}

--- a/crates/hippo/src/lib.rs
+++ b/crates/hippo/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod config;

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use spin_cli::commands::{
     bindle::BindleCommands, build::BuildCommand, deploy::DeployCommand,
     external::execute_external_subcommand, new::NewCommand, plugins::PluginCommands,
-    templates::TemplateCommands, up::UpCommand,
+    templates::TemplateCommands, up::UpCommand, login::LoginCommand,
 };
 use spin_http::HttpTrigger;
 use spin_redis_engine::RedisTrigger;
@@ -42,8 +42,9 @@ enum SpinApp {
     Up(UpCommand),
     #[clap(subcommand)]
     Bindle(BindleCommands),
-    Deploy(DeployCommand),
     Build(BuildCommand),
+    Deploy(DeployCommand),
+    Login(LoginCommand),
     #[clap(subcommand)]
     Plugin(PluginCommands),
     #[clap(subcommand, hide = true)]
@@ -68,6 +69,7 @@ impl SpinApp {
             Self::Bindle(cmd) => cmd.run().await,
             Self::Deploy(cmd) => cmd.run().await,
             Self::Build(cmd) => cmd.run().await,
+            Self::Login(cmd) => cmd.run().await,
             Self::Trigger(TriggerCommands::Http(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::Redis(cmd)) => cmd.run().await,
             Self::Plugin(cmd) => cmd.run().await,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,9 @@
 //! Commands for the Spin CLI.
 
+use std::path::PathBuf;
+
+use clap::Parser;
+
 /// Command for creating bindles.
 pub mod bindle;
 /// Commands for building Spin applications.
@@ -8,6 +12,8 @@ pub mod build;
 pub mod deploy;
 /// Commands for external subcommands (i.e. plugins)
 pub mod external;
+/// Commands for signing in to Hippo
+pub mod login;
 /// Command for creating a new application.
 pub mod new;
 /// Command for adding a plugin to Spin
@@ -16,3 +22,11 @@ pub mod plugins;
 pub mod templates;
 /// Commands for starting the runtime.
 pub mod up;
+
+
+#[derive(Parser, Debug)]
+pub struct CommonOpts {
+    /// Sets a custom configuration directory
+    #[clap(short, long, parse(from_os_str), value_name = "SPIN_CONFIG_DIR")]
+    pub dir: Option<PathBuf>,
+}

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use bindle::Id;
 use clap::Parser;
-use hippo::{Client, ConnectionInfo};
+use hippo::{client::Client, config::ConnectionInfo};
 use hippo_openapi::models::ChannelRevisionSelectionStrategy;
 use semver::BuildMetadata;
 use serde::{Deserialize, Serialize};
@@ -146,21 +146,21 @@ impl DeployCommand {
             &Client::new(ConnectionInfo {
                 url: self.hippo_server_url.clone(),
                 danger_accept_invalid_certs: self.insecure,
-                api_key: None,
+                token: Default::default(),
             }),
             self.hippo_username.clone(),
             self.hippo_password.clone(),
         )
         .await
         {
-            Ok(token_info) => token_info.token.unwrap_or_default(),
+            Ok(token_info) => token_info,
             Err(err) => bail!(format_login_error(&err)?),
         };
 
         let hippo_client = Client::new(ConnectionInfo {
             url: self.hippo_server_url.clone(),
             danger_accept_invalid_certs: self.insecure,
-            api_key: Some(token),
+            token: token,
         });
 
         let name = bindle_id.name().to_string();

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,0 +1,140 @@
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use hippo::{client::Client, config::{ConnectionInfo, Config}};
+use serde::{Deserialize, Serialize};
+
+use crate::{sloth::warn_if_slow_response, opts::{BINDLE_SERVER_URL_OPT, BINDLE_URL_ENV, BINDLE_USERNAME, BINDLE_PASSWORD, INSECURE_OPT, HIPPO_SERVER_URL_OPT, HIPPO_URL_ENV}};
+
+use super::CommonOpts;
+
+/// Sign in to Hippo
+#[derive(Parser, Debug)]
+#[clap(about = "Sign in to Hippo")]
+pub struct LoginCommand {
+    #[clap(flatten)]
+    pub opts: CommonOpts,
+
+    /// URL of bindle server
+    #[clap(
+        name = BINDLE_SERVER_URL_OPT,
+        long = "bindle-server",
+        env = BINDLE_URL_ENV,
+    )]
+    pub bindle_server_url: String,
+
+    /// Basic http auth username for the bindle server
+    #[clap(
+        name = BINDLE_USERNAME,
+        long = "bindle-username",
+        env = BINDLE_USERNAME,
+        requires = BINDLE_PASSWORD
+    )]
+    pub bindle_username: Option<String>,
+
+    /// Basic http auth password for the bindle server
+    #[clap(
+        name = BINDLE_PASSWORD,
+        long = "bindle-password",
+        env = BINDLE_PASSWORD,
+        requires = BINDLE_USERNAME
+    )]
+    pub bindle_password: Option<String>,
+
+    /// Ignore server certificate errors from bindle and hippo
+    #[clap(
+        name = INSECURE_OPT,
+        short = 'k',
+        long = "insecure",
+        takes_value = false,
+    )]
+    pub insecure: bool,
+
+    /// URL of hippo server
+    #[clap(
+        name = HIPPO_SERVER_URL_OPT,
+        long = "hippo-server",
+        env = HIPPO_URL_ENV,
+    )]
+    pub hippo_server_url: String,
+
+    /// Hippo username
+    #[clap(
+        name = "HIPPO_USERNAME",
+        long = "hippo-username",
+        env = "HIPPO_USERNAME"
+    )]
+    pub hippo_username: String,
+
+    /// Hippo password
+    #[clap(
+        name = "HIPPO_PASSWORD",
+        long = "hippo-password",
+        env = "HIPPO_PASSWORD"
+    )]
+    pub hippo_password: String,
+}
+
+impl LoginCommand {
+    pub async fn run(self) -> Result<()> {
+        self.check_hippo_healthz().await?;
+
+        let _sloth_warning = warn_if_slow_response(&self.hippo_server_url);
+
+        let mut hippo_client_config = Config::new(self.opts.dir).await?;
+        hippo_client_config.connection = ConnectionInfo {
+            url: self.hippo_server_url.clone(),
+            danger_accept_invalid_certs: self.insecure,
+            token: Default::default(),
+        };
+
+        let token = match Client::login(
+            &Client::new(hippo_client_config.connection),
+            self.hippo_username.clone(),
+            self.hippo_password.clone(),
+        )
+        .await
+        {
+            Ok(token_info) => token_info,
+            Err(err) => bail!(format_login_error(&err)?),
+        };
+
+        hippo_client_config.connection = ConnectionInfo {
+            danger_accept_invalid_certs: self.insecure,
+            token,
+            url: self.hippo_server_url,
+        };
+        hippo_client_config.commit().await?;
+
+        println!("Login successful.");
+
+        Ok(())
+    }
+
+    async fn check_hippo_healthz(&self) -> Result<()> {
+        let hippo_base_url = url::Url::parse(&self.hippo_server_url)?;
+        let hippo_healthz_url = hippo_base_url.join("/healthz")?;
+        reqwest::get(hippo_healthz_url.to_string())
+            .await?
+            .error_for_status()
+            .with_context(|| format!("Hippo server {} is unhealthy", hippo_base_url))?;
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct LoginHippoError {
+    title: String,
+    detail: String,
+}
+
+fn format_login_error(err: &anyhow::Error) -> anyhow::Result<String> {
+    let error: LoginHippoError = serde_json::from_str(err.to_string().as_str())?;
+    if error.detail.ends_with(": ") {
+        Ok(format!(
+            "Problem logging into Hippo: {}",
+            error.detail.replace(": ", ".")
+        ))
+    } else {
+        Ok(format!("Problem logging into Hippo: {}", error.detail))
+    }
+}


### PR DESCRIPTION
To differentiate between different login mechanisms (sign in with username/password, sign in with GitHub, etc.), we need to split out the "login" functionality from `spin deploy`.

As of this writing, I have implemented a `spin login` command. I am working on removing the login functionality from `spin deploy` and will mark this as ready for review once complete.