### PR TITLE
build: rely on bash from 'PATH'

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -129,6 +129,6 @@ fn get_os_process() -> String {
     if cfg!(target_os = "windows") {
         String::from("powershell.exe")
     } else {
-        String::from("/bin/bash")
+        String::from("bash")
     }
 }


### PR DESCRIPTION
/bin/bash isn't guaranteed to exist on any platform (unlike /bin/sh), here we switch to relying on bash from the path instead, this lets us build on systems like NixOS without breaking other systems.

Signed-off-by: Danielle Lancashire <dani@builds.terrible.systems>

---

Tested on NixOS (amd64) and macOS Monterey (arm)