### PR TITLE
Fix links to WIT documentation

### DIFF
--- a/docs/content/extending-and-embedding.md
+++ b/docs/content/extending-and-embedding.md
@@ -25,7 +25,7 @@ timer, executing Spin components at configured time interval.
 
 The current application types that can be implemented with Spin have entry points
 defined using
-[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md):
+[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/README.md):
 
 ```fsharp
 // The entry point for an HTTP handler.

--- a/docs/content/http-trigger.md
+++ b/docs/content/http-trigger.md
@@ -109,7 +109,7 @@ Spin HTTP _executor_ is defined using WebAssembly interfaces.
 > handler functions will become asynchronous.
 
 We define the HTTP objects as
-[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md)
+[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/README.md)
 objects, currently using _records_:
 
 ```fsharp

--- a/docs/content/redis-trigger.md
+++ b/docs/content/redis-trigger.md
@@ -38,7 +38,7 @@ channel = "messages"
 The Redis trigger is built on top of the
 [WebAssembly component model](https://github.com/WebAssembly/component-model).
 The current interface is defined using the
-[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/WIT.md)
+[WebAssembly Interface (WIT)](https://github.com/bytecodealliance/wit-bindgen/blob/main/README.md)
 format, and is a function that takes the message payload as its only parameter:
 
 ```fsharp


### PR DESCRIPTION

This PR fixes broken links to WIT documentation as reported here https://github.com/fermyon/spin/issues/789

Signed-off-by: Raymundo Vásquez Ruiz <raymundo.vr@protonmail.com>