### PR TITLE
outbound-redis: Don't keep connections alive between requests

### DIFF
--- a/crates/outbound-redis/src/host_component.rs
+++ b/crates/outbound-redis/src/host_component.rs
@@ -1,0 +1,20 @@
+use spin_core::HostComponent;
+
+use crate::OutboundRedis;
+
+pub struct OutboundRedisComponent;
+
+impl HostComponent for OutboundRedisComponent {
+    type Data = OutboundRedis;
+
+    fn add_to_linker<T: Send>(
+        linker: &mut spin_core::Linker<T>,
+        get: impl Fn(&mut spin_core::Data<T>) -> &mut Self::Data + Send + Sync + Copy + 'static,
+    ) -> anyhow::Result<()> {
+        super::outbound_redis::add_to_linker(linker, get)
+    }
+
+    fn build_data(&self) -> Self::Data {
+        Default::default()
+    }
+}

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -1,78 +1,56 @@
-use std::{collections::HashMap, sync::Arc};
+mod host_component;
+
+use std::collections::{hash_map::Entry, HashMap};
 
 use anyhow::Result;
 use redis::{aio::Connection, AsyncCommands};
-use spin_core::{HostComponent, Linker};
-use tokio::sync::{Mutex, RwLock};
 use wit_bindgen_wasmtime::async_trait;
+
+pub use host_component::OutboundRedisComponent;
 
 wit_bindgen_wasmtime::export!({paths: ["../../wit/ephemeral/outbound-redis.wit"], async: *});
 use outbound_redis::Error;
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct OutboundRedis {
-    connections: Arc<RwLock<HashMap<String, Arc<Mutex<Connection>>>>>,
-}
-
-impl HostComponent for OutboundRedis {
-    type Data = Self;
-
-    fn add_to_linker<T: Send>(
-        linker: &mut Linker<T>,
-        get: impl Fn(&mut spin_core::Data<T>) -> &mut Self::Data + Send + Sync + Copy + 'static,
-    ) -> anyhow::Result<()> {
-        crate::outbound_redis::add_to_linker(linker, get)
-    }
-
-    fn build_data(&self) -> Self::Data {
-        self.clone()
-    }
+    connections: HashMap<String, Connection>,
 }
 
 #[async_trait]
 impl outbound_redis::OutboundRedis for OutboundRedis {
     async fn publish(&mut self, address: &str, channel: &str, payload: &[u8]) -> Result<(), Error> {
         let conn = self.get_conn(address).await.map_err(log_error)?;
-        conn.lock()
-            .await
-            .publish(channel, payload)
-            .await
-            .map_err(log_error)?;
+        conn.publish(channel, payload).await.map_err(log_error)?;
         Ok(())
     }
 
     async fn get(&mut self, address: &str, key: &str) -> Result<Vec<u8>, Error> {
         let conn = self.get_conn(address).await.map_err(log_error)?;
-        let value = conn.lock().await.get(key).await.map_err(log_error)?;
+        let value = conn.get(key).await.map_err(log_error)?;
         Ok(value)
     }
 
     async fn set(&mut self, address: &str, key: &str, value: &[u8]) -> Result<(), Error> {
         let conn = self.get_conn(address).await.map_err(log_error)?;
-        conn.lock().await.set(key, value).await.map_err(log_error)?;
+        conn.set(key, value).await.map_err(log_error)?;
         Ok(())
     }
 
     async fn incr(&mut self, address: &str, key: &str) -> Result<i64, Error> {
         let conn = self.get_conn(address).await.map_err(log_error)?;
-        let value = conn.lock().await.incr(key, 1).await.map_err(log_error)?;
+        let value = conn.incr(key, 1).await.map_err(log_error)?;
         Ok(value)
     }
 }
 
 impl OutboundRedis {
-    async fn get_conn(&self, address: &str) -> Result<Arc<Mutex<Connection>>> {
-        let conn_map = self.connections.read().await;
-        let conn = if let Some(conn) = conn_map.get(address) {
-            conn.clone()
-        } else {
-            let conn = redis::Client::open(address)?.get_async_connection().await?;
-            let conn = Arc::new(Mutex::new(conn));
-            self.connections
-                .write()
-                .await
-                .insert(address.to_string(), conn.clone());
-            conn
+    async fn get_conn(&mut self, address: &str) -> Result<&mut Connection> {
+        let conn = match self.connections.entry(address.to_string()) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => {
+                let conn = redis::Client::open(address)?.get_async_connection().await?;
+                v.insert(conn)
+            }
         };
         Ok(conn)
     }

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -93,7 +93,7 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
             let mut builder = Engine::builder(&self.config)?;
 
             if !self.disable_default_host_components {
-                builder.add_host_component(outbound_redis::OutboundRedis::default())?;
+                builder.add_host_component(outbound_redis::OutboundRedisComponent)?;
                 builder.add_host_component(outbound_pg::OutboundPg::default())?;
                 self.loader.add_dynamic_host_component(
                     &mut builder,


### PR DESCRIPTION
This would keep connections open indefinitely, which could lead to connections being "stuck" in a bad state and potentially leak resources if addresses were dynamic.

Switch to per-request connection persistence, like outbound-pg.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>