### PR TITLE
Update example `Cargo.lock`s

### DIFF
--- a/examples/config-rust/Cargo.lock
+++ b/examples/config-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/redis-rust/Cargo.lock
+++ b/examples/redis-rust/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/rust-outbound-redis/Cargo.lock
+++ b/examples/rust-outbound-redis/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Make sure they are pointing at the most recent spin-sdk.

This unbreaks `rust-outbound-redis`