### PR TITLE
More flexibility and guidance in the `spin new` experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,7 @@ dependencies = [
  "clap 3.2.19",
  "comfy-table",
  "ctrlc",
+ "dialoguer 0.10.2",
  "dirs 4.0.0",
  "dunce",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bytes = "1.1"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 comfy-table = "5.0"
 ctrlc = { version = "3.2", features = ["termination"] }
+dialoguer = "0.10"
 dirs = "4.0"
 dunce = "1.0"
 env_logger = "0.9"


### PR DESCRIPTION
Currently, a developer new to Spin and wanting to create an application needs to manually install templates, and needs to know the ID of the template they want to use.

This PR makes it optional to pass the template ID on the command line.  If the template ID is omitted, `spin new` prompts with a list of installed templates:

![image](https://user-images.githubusercontent.com/865538/193940768-7eda1c2c-0e42-4ddf-84c0-21e32debeae6.png)

Additionally, if `spin new` needs to prompt but _no_ templates are installed, `spin new` offers to install the "default" set:

![image](https://user-images.githubusercontent.com/865538/193940914-d4048bbb-49cd-4863-8c04-1bd672a27f01.png)

If the template ID and project name _are_ passed on the command line, `spin new` continues to behave as it did before.

**Note:** Because the ID and project name are positional args, this PR necessarily also makes the name optional.  It will be prompted for if not provided.  This creates an additional experience of `spin new <template_id>` where you will be prompted for the name but not the template.  I don't think this is vastly valuable but it's benign so I haven't worried about it.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>