### PR TITLE
Add spin-trigger TriggerHooks

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::{Args, IntoApp, Parser};
 use serde::de::DeserializeOwned;
 
+use crate::stdio::StdioLoggingTriggerHooks;
 use crate::{loader::TriggerLoader, stdio::FollowComponents};
 use crate::{TriggerExecutor, TriggerExecutorBuilder};
 
@@ -105,10 +106,10 @@ where
         let executor: Executor = {
             let mut builder = TriggerExecutorBuilder::new(loader);
             self.update_wasmtime_config(builder.wasmtime_config_mut())?;
-            builder.follow_components(self.follow_components());
-            if let Some(log_dir) = self.log {
-                builder.log_dir(log_dir);
-            }
+
+            let logging_hooks = StdioLoggingTriggerHooks::new(self.follow_components(), self.log);
+            builder.hooks(logging_hooks);
+
             builder.build(locked_url).await?
         };
 

--- a/crates/trigger/src/stdio.rs
+++ b/crates/trigger/src/stdio.rs
@@ -1,4 +1,12 @@
-use std::{collections::HashSet, fs::File, path::Path};
+use std::{
+    collections::HashSet,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+
+use crate::{TriggerHooks, SPIN_HOME};
 
 /// Which components should have their logs followed on stdout/stderr.
 #[derive(Clone, Debug)]
@@ -25,6 +33,66 @@ impl FollowComponents {
 impl Default for FollowComponents {
     fn default() -> Self {
         Self::None
+    }
+}
+
+/// Implements TriggerHooks, writing logs to a log file and (optionally) stderr
+pub struct StdioLoggingTriggerHooks {
+    follow_components: FollowComponents,
+    log_dir: Option<PathBuf>,
+}
+
+impl StdioLoggingTriggerHooks {
+    pub fn new(follow_components: FollowComponents, log_dir: Option<PathBuf>) -> Self {
+        Self {
+            follow_components,
+            log_dir,
+        }
+    }
+
+    fn component_stdio_writer(
+        &self,
+        component_id: &str,
+        log_suffix: &str,
+    ) -> Result<ComponentStdioWriter> {
+        let sanitized_component_id = sanitize_filename::sanitize(component_id);
+        let log_path = self
+            .log_dir
+            .as_deref()
+            .expect("log_dir should have been initialized in app_loaded")
+            .join(format!("{sanitized_component_id}_{log_suffix}.txt"));
+        let follow = self.follow_components.should_follow(component_id);
+        ComponentStdioWriter::new(&log_path, follow)
+            .with_context(|| format!("Failed to open log file {log_path:?}"))
+    }
+}
+
+impl TriggerHooks for StdioLoggingTriggerHooks {
+    fn app_loaded(&mut self, app: &spin_app::App) -> anyhow::Result<()> {
+        let app_name: &str = app.require_metadata("name")?;
+        // Set default log_dir (if not explicitly passed)
+        let log_dir = self.log_dir.get_or_insert_with(|| {
+            let parent_dir = match dirs::home_dir() {
+                Some(home) => home.join(SPIN_HOME),
+                None => PathBuf::new(), // "./"
+            };
+            let sanitized_app = sanitize_filename::sanitize(app_name);
+            parent_dir.join(sanitized_app).join("logs")
+        });
+        // Ensure log dir exists
+        std::fs::create_dir_all(&log_dir)
+            .with_context(|| format!("Failed to create log dir {log_dir:?}"))?;
+        Ok(())
+    }
+
+    fn component_store_builder(
+        &self,
+        component: spin_app::AppComponent,
+        builder: &mut spin_core::StoreBuilder,
+    ) -> anyhow::Result<()> {
+        builder.stdout_pipe(self.component_stdio_writer(component.id(), "stdout")?);
+        builder.stderr_pipe(self.component_stdio_writer(component.id(), "stderr")?);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
These provide a mechanism for Spin embedders to hook into TriggerAppEngine, customizing its execution behavior.

Reimplemented TriggerExecutorCommand's stdio log/follow behavior in terms of the new TriggerHooks. Fixed broken `--log-dir` along the way.

Signed-off-by: Lann Martin <lann.martin@fermyon.com>