### PR TITLE
feat: make http_trigger::loader public

### DIFF
--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod cli;
-mod loader;
+pub mod loader;
 pub mod locked;
 mod stdio;
 


### PR DESCRIPTION
This allows applications that embed spin triggers reuse loader logic. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>