### PR TITLE
fix(loader): make new method public

### DIFF
--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -18,7 +18,7 @@ pub struct TriggerLoader {
 }
 
 impl TriggerLoader {
-    pub(crate) fn new(working_dir: impl Into<PathBuf>, allow_transient_write: bool) -> Self {
+    pub fn new(working_dir: impl Into<PathBuf>, allow_transient_write: bool) -> Self {
         Self {
             working_dir: working_dir.into(),
             allow_transient_write,


### PR DESCRIPTION
This is a follow up on #810 and makes `new` method public so that applications that embed spin can construct a `TriggerLoader`. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>