### PR TITLE
trim trailing slash on --url

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -361,7 +361,7 @@ impl LoginCommand {
 
     fn url(&self) -> &str {
         if let Some(u) = &self.hippo_server_url {
-            u
+            u.trim().trim_end_matches('/')
         } else {
             DEFAULT_CLOUD_URL
         }


### PR DESCRIPTION
fixes issues where a user appends a slash to the end of the URL.