### PR TITLE
Improve deployment experience

### DIFF
--- a/src/commands/bindle.rs
+++ b/src/commands/bindle.rs
@@ -180,7 +180,7 @@ impl Push {
             .await
             .with_context(|| crate::write_failed_msg(bindle_id, dest_dir))?;
 
-        let _sloth_warning = warn_if_slow_response(&self.bindle_server_url);
+        let _sloth_warning = warn_if_slow_response(format!("Uploading application to {}", self.bindle_server_url));
 
         spin_publish::push_all(&dest_dir, bindle_id, bindle_connection_info)
             .await

--- a/src/commands/bindle.rs
+++ b/src/commands/bindle.rs
@@ -180,7 +180,10 @@ impl Push {
             .await
             .with_context(|| crate::write_failed_msg(bindle_id, dest_dir))?;
 
-        let _sloth_warning = warn_if_slow_response(format!("Uploading application to {}", self.bindle_server_url));
+        let _sloth_warning = warn_if_slow_response(format!(
+            "Uploading application to {}",
+            self.bindle_server_url
+        ));
 
         spin_publish::push_all(&dest_dir, bindle_id, bindle_connection_info)
             .await

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -145,7 +145,7 @@ impl DeployCommand {
             }
         }
 
-        let sloth_warning = warn_if_slow_response(&login_connection.url);
+        let sloth_warning = warn_if_slow_response(format!("Checking status ({})", login_connection.url));
         check_healthz(&login_connection.url).await?;
         // Hippo has responded - we don't want to keep the sloth timer running.
         drop(sloth_warning);
@@ -188,8 +188,6 @@ impl DeployCommand {
             None
         };
 
-        let sloth_warning = warn_if_slow_response(login_connection.bindle_url.as_deref().unwrap());
-
         let bindle_connection_info = BindleConnectionInfo::new(
             login_connection.bindle_url.unwrap(),
             login_connection.danger_accept_invalid_certs,
@@ -200,9 +198,6 @@ impl DeployCommand {
         let bindle_id = self
             .create_and_push_bindle(buildinfo, bindle_connection_info)
             .await?;
-
-        // Bindle has responded - we don't want to keep the sloth timer running.
-        drop(sloth_warning);
 
         let hippo_client = Client::new(ConnectionInfo {
             url: login_connection.url.clone(),
@@ -569,7 +564,7 @@ impl DeployCommand {
             .await
             .with_context(|| crate::write_failed_msg(bindle_id, dest_dir))?;
 
-        let _sloth_warning = warn_if_slow_response(bindle_connection_info.base_url());
+        let _sloth_warning = warn_if_slow_response(format!("Uploading application to {}", bindle_connection_info.base_url()));
 
         let publish_result =
             spin_publish::push_all(&dest_dir, bindle_id, bindle_connection_info.clone()).await;

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -390,6 +390,12 @@ impl DeployCommand {
             .await
             .context("Problem getting channel by id")?;
         if let Ok(http_config) = HttpTriggerConfiguration::try_from(cfg.info.trigger.clone()) {
+            wait_for_ready(
+                &channel.domain,
+                &login_connection.url,
+                &cfg,
+                self.readiness_timeout_secs)
+            .await;
             print_available_routes(
                 &channel.domain,
                 &http_config.base,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -145,7 +145,8 @@ impl DeployCommand {
             }
         }
 
-        let sloth_warning = warn_if_slow_response(format!("Checking status ({})", login_connection.url));
+        let sloth_warning =
+            warn_if_slow_response(format!("Checking status ({})", login_connection.url));
         check_healthz(&login_connection.url).await?;
         // Hippo has responded - we don't want to keep the sloth timer running.
         drop(sloth_warning);
@@ -394,7 +395,8 @@ impl DeployCommand {
                 &channel.domain,
                 &login_connection.url,
                 &cfg,
-                self.readiness_timeout_secs)
+                self.readiness_timeout_secs,
+            )
             .await;
             print_available_routes(
                 &channel.domain,
@@ -570,7 +572,10 @@ impl DeployCommand {
             .await
             .with_context(|| crate::write_failed_msg(bindle_id, dest_dir))?;
 
-        let _sloth_warning = warn_if_slow_response(format!("Uploading application to {}", bindle_connection_info.base_url()));
+        let _sloth_warning = warn_if_slow_response(format!(
+            "Uploading application to {}",
+            bindle_connection_info.base_url()
+        ));
 
         let publish_result =
             spin_publish::push_all(&dest_dir, bindle_id, bindle_connection_info.clone()).await;

--- a/src/sloth.rs
+++ b/src/sloth.rs
@@ -13,14 +13,14 @@ impl<T> Drop for SlothWarning<T> {
     }
 }
 
-pub(crate) fn warn_if_slow_response(url: &str) -> SlothWarning<()> {
-    let url = url.to_owned();
-    let warning = tokio::spawn(warn_slow_response(url));
+pub(crate) fn warn_if_slow_response(message: impl Into<String>) -> SlothWarning<()> {
+    let message = message.into();
+    let warning = tokio::spawn(warn_slow_response(message));
     SlothWarning { warning }
 }
 
-async fn warn_slow_response(url: String) {
+async fn warn_slow_response(message: String) {
     sleep(Duration::from_millis(SLOW_UPLOAD_WARNING_DELAY_MILLIS)).await;
-    eprintln!("{} is responding slowly or not responding...", url);
+    eprintln!("{}", message);
     eprintln!();
 }


### PR DESCRIPTION
This PR:

* modifies the sloth warnings to be "checking status" (for the Hippo health check) and "uploading application" (for Bindle) instead of warning about a slow response
* adds the "wait for application ready" UI when deploying using a GH token, so the user is less likely to see the 404 of application not ready

It also removes what seems to have been a duplicate sloth warning for the bindle upload, probably a spurious leftover from an earlier merge.