### PR TITLE
dependencies: bump bindle to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "bindle"
 version = "0.8.0"
-source = "git+https://github.com/fermyon/bindle?tag=v0.8.1#0dd1e7a7747d9f0ea8fda61d5f0f8cc3550f65dd"
+source = "git+https://github.com/fermyon/bindle?tag=v0.8.2#84ea1dd86fab6ffe27235e268f47f632421db8f9"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 anyhow = "1.0"
 async-trait = "0.1"
 atty = "0.2"
-bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.1", default-features = false, features = ["client"] }
+bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-features = false, features = ["client"] }
 bytes = "1.1"
 chrono = "0.4"
 clap = { version = "3.1.15", features = ["derive", "env"] }

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -37,6 +37,6 @@ uuid = "1"
 
 [dependencies.bindle]
 git = "https://github.com/fermyon/bindle"
-tag = "v0.8.1"
+tag = "v0.8.2"
 default-features = false
 features = ["client"]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -7,13 +7,13 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.52"
-bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.1", default-features = false, features = ["client"] }
+bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-features = false, features = ["client"] }
 bytes = "1.1.0"
 futures = "0.3.17"
 glob = "0.3.0"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-outbound-http = { path = "../outbound-http" } 
+outbound-http = { path = "../outbound-http" }
 path-absolutize = "3.0.11"
 regex = "1.5.4"
 reqwest = "0.11.9"

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.52"
-bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.1", default-features = false, features = ["client"] }
+bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-features = false, features = ["client"] }
 dunce = "1.0"
 futures = "0.3.14"
 itertools = "0.10.3"


### PR DESCRIPTION
Rate limits the number of concurrent requests to a remote bindle server.

Signed-off-by: Danielle Lancashire <dani@builds.terrible.systems>