### PR TITLE
feat(outbound-redis): Add DEL command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ vergen = { version = "7", default-features = false, features = [ "build", "git" 
 [features]
 default = []
 e2e-tests = []
+outbound-redis-tests = []
 
 [workspace]
 members = [

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 .PHONY: test
 test: lint test-unit test-integration
 
-.PHONY: lint 
+.PHONY: lint
 lint:
 	cargo clippy --all-targets --all-features -- -D warnings
 	cargo fmt --all -- --check
@@ -30,8 +30,12 @@ test-integration:
 
 .PHONY: test-e2e
 test-e2e:
-	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --features e2e-tests --no-fail-fast  -- integration_tests::test_dependencies --nocapture 
+	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --features e2e-tests --no-fail-fast  -- integration_tests::test_dependencies --nocapture
 	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --features e2e-tests --no-fail-fast -- --skip integration_tests::test_dependencies --nocapture
+
+.PHONY: test-outbound-redis
+test-outbound-redis:
+	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --features outbound-redis-tests --no-fail-fast -- --nocapture
 
 .PHONY: test-sdk-go
 test-sdk-go:

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ use cargo_target_dep::build_target_dep;
 
 const RUST_HTTP_INTEGRATION_TEST: &str = "tests/http/simple-spin-rust";
 const RUST_HTTP_INTEGRATION_ENV_TEST: &str = "tests/http/headers-env-routes-test";
+const RUST_OUTBOUND_REDIS_INTEGRATION_TEST: &str = "tests/outbound-redis/http-rust-outbound-redis";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -53,6 +54,7 @@ error: the `wasm32-wasi` target is not installed
 
     cargo_build(RUST_HTTP_INTEGRATION_TEST);
     cargo_build(RUST_HTTP_INTEGRATION_ENV_TEST);
+    cargo_build(RUST_OUTBOUND_REDIS_INTEGRATION_TEST);
 
     let mut config = vergen::Config::default();
     *config.git_mut().sha_kind_mut() = vergen::ShaKind::Short;

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -41,6 +41,12 @@ impl outbound_redis::OutboundRedis for OutboundRedis {
         let value = conn.incr(key, 1).await.map_err(log_error)?;
         Ok(value)
     }
+
+    async fn del(&mut self, address: &str, keys: Vec<&str>) -> Result<i64, Error> {
+        let conn = self.get_conn(address).await.map_err(log_error)?;
+        let value = conn.del(keys).await.map_err(log_error)?;
+        Ok(value)
+    }
 }
 
 impl OutboundRedis {

--- a/examples/tinygo-outbound-redis/main.go
+++ b/examples/tinygo-outbound-redis/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"os"
+	"strconv"
 
 	spin_http "github.com/fermyon/spin/sdk/go/http"
 	"github.com/fermyon/spin/sdk/go/redis"
@@ -41,6 +42,25 @@ func init() {
 		} else {
 			w.Write([]byte("mykey value was: "))
 			w.Write(payload)
+			w.Write([]byte("\n"))
+		}
+
+		// incr `spin-go-incr` by 1
+		if payload, err := redis.Incr(addr, "spin-go-incr"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		} else {
+			w.Write([]byte("spin-go-incr value: "))
+			w.Write([]byte(strconv.FormatInt(payload, 10)))
+			w.Write([]byte("\n"))
+		}
+
+		// delete `spin-go-incr` and `mykey`
+		if payload, err := redis.Del(addr, []string{"spin-go-incr", "mykey", "non-existing-key"}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		} else {
+			w.Write([]byte("deleted keys num: "))
+			w.Write([]byte(strconv.FormatInt(payload, 10)))
+			w.Write([]byte("\n"))
 		}
 	})
 }

--- a/sdk/go/redis/outbound-redis.c
+++ b/sdk/go/redis/outbound-redis.c
@@ -56,9 +56,22 @@ typedef struct {
     outbound_redis_error_t err;
   } val;
 } outbound_redis_expected_payload_error_t;
+typedef struct {
+  bool is_err;
+  union {
+    int64_t ok;
+    outbound_redis_error_t err;
+  } val;
+} outbound_redis_expected_s64_error_t;
+void outbound_redis_list_string_free(outbound_redis_list_string_t *ptr) {
+  for (size_t i = 0; i < ptr->len; i++) {
+    outbound_redis_string_free(&ptr->ptr[i]);
+  }
+  canonical_abi_free(ptr->ptr, ptr->len * 8, 4);
+}
 
-__attribute__((aligned(4)))
-static uint8_t RET_AREA[12];
+__attribute__((aligned(8)))
+static uint8_t RET_AREA[16];
 __attribute__((import_module("outbound-redis"), import_name("publish")))
 void __wasm_import_outbound_redis_publish(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
 outbound_redis_error_t outbound_redis_publish(outbound_redis_string_t *address, outbound_redis_string_t *channel, outbound_redis_payload_t *payload) {
@@ -122,4 +135,48 @@ outbound_redis_error_t outbound_redis_set(outbound_redis_string_t *address, outb
       break;
     }
   }return expected.is_err ? expected.val.err : -1;
+}
+__attribute__((import_module("outbound-redis"), import_name("incr")))
+void __wasm_import_outbound_redis_incr(int32_t, int32_t, int32_t, int32_t, int32_t);
+outbound_redis_error_t outbound_redis_incr(outbound_redis_string_t *address, outbound_redis_string_t *key, int64_t *ret0) {
+  int32_t ptr = (int32_t) &RET_AREA;
+  __wasm_import_outbound_redis_incr((int32_t) (*address).ptr, (int32_t) (*address).len, (int32_t) (*key).ptr, (int32_t) (*key).len, ptr);
+  outbound_redis_expected_s64_error_t expected;
+  switch ((int32_t) (*((uint8_t*) (ptr + 0)))) {
+    case 0: {
+      expected.is_err = false;
+      
+      expected.val.ok = *((int64_t*) (ptr + 8));
+      break;
+    }
+    case 1: {
+      expected.is_err = true;
+      
+      expected.val.err = (int32_t) (*((uint8_t*) (ptr + 8)));
+      break;
+    }
+  }*ret0 = expected.val.ok;
+  return expected.is_err ? expected.val.err : -1;
+}
+__attribute__((import_module("outbound-redis"), import_name("del")))
+void __wasm_import_outbound_redis_del(int32_t, int32_t, int32_t, int32_t, int32_t);
+outbound_redis_error_t outbound_redis_del(outbound_redis_string_t *address, outbound_redis_list_string_t *keys, int64_t *ret0) {
+  int32_t ptr = (int32_t) &RET_AREA;
+  __wasm_import_outbound_redis_del((int32_t) (*address).ptr, (int32_t) (*address).len, (int32_t) (*keys).ptr, (int32_t) (*keys).len, ptr);
+  outbound_redis_expected_s64_error_t expected;
+  switch ((int32_t) (*((uint8_t*) (ptr + 0)))) {
+    case 0: {
+      expected.is_err = false;
+      
+      expected.val.ok = *((int64_t*) (ptr + 8));
+      break;
+    }
+    case 1: {
+      expected.is_err = true;
+      
+      expected.val.err = (int32_t) (*((uint8_t*) (ptr + 8)));
+      break;
+    }
+  }*ret0 = expected.val.ok;
+  return expected.is_err ? expected.val.err : -1;
 }

--- a/sdk/go/redis/outbound-redis.h
+++ b/sdk/go/redis/outbound-redis.h
@@ -24,9 +24,16 @@ extern "C"
     size_t len;
   } outbound_redis_payload_t;
   void outbound_redis_payload_free(outbound_redis_payload_t *ptr);
+  typedef struct {
+    outbound_redis_string_t *ptr;
+    size_t len;
+  } outbound_redis_list_string_t;
+  void outbound_redis_list_string_free(outbound_redis_list_string_t *ptr);
   outbound_redis_error_t outbound_redis_publish(outbound_redis_string_t *address, outbound_redis_string_t *channel, outbound_redis_payload_t *payload);
   outbound_redis_error_t outbound_redis_get(outbound_redis_string_t *address, outbound_redis_string_t *key, outbound_redis_payload_t *ret0);
   outbound_redis_error_t outbound_redis_set(outbound_redis_string_t *address, outbound_redis_string_t *key, outbound_redis_payload_t *value);
+  outbound_redis_error_t outbound_redis_incr(outbound_redis_string_t *address, outbound_redis_string_t *key, int64_t *ret0);
+  outbound_redis_error_t outbound_redis_del(outbound_redis_string_t *address, outbound_redis_list_string_t *keys, int64_t *ret0);
   #ifdef __cplusplus
 }
 #endif

--- a/sdk/go/redis/redis.go
+++ b/sdk/go/redis/redis.go
@@ -36,3 +36,16 @@ func Get(addr, key string) ([]byte, error) {
 func Set(addr, key string, payload []byte) error {
 	return set(addr, key, payload)
 }
+
+// Increments the number stored at key by one. If the key does not exist,
+// it is set to 0 before performing the operation. An error is returned if
+// the key contains a value of the wrong type or contains a string that can not
+// be represented as integer.
+func Incr(addr, key string) (int64, error) {
+	return incr(addr, key)
+}
+
+// Removes the specified keys. A key is ignored if it does not exist.
+func Del(addr string, keys []string) (int64, error) {
+	return del(addr, keys)
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -602,6 +602,30 @@ mod integration_tests {
         }
     }
 
+    #[cfg(feature = "outbound-redis-tests")]
+    mod outbound_pg_tests {
+        use super::*;
+
+        const RUST_OUTBOUND_REDIS_INTEGRATION_TEST: &str =
+            "tests/outbound-redis/http-rust-outbound-redis";
+
+        #[tokio::test]
+        async fn test_outbound_redis_rust_local() -> Result<()> {
+            let s = SpinTestController::with_manifest(
+                &format!(
+                    "{}/{}",
+                    RUST_OUTBOUND_REDIS_INTEGRATION_TEST, DEFAULT_MANIFEST_LOCATION
+                ),
+                &[],
+                None,
+            )
+            .await?;
+
+            assert_status(&s, "/test", 204).await?;
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn test_simple_rust_local() -> Result<()> {
         let s = SpinTestController::with_manifest(

--- a/tests/outbound-redis/http-rust-outbound-redis/.cargo/config.toml
+++ b/tests/outbound-redis/http-rust-outbound-redis/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/tests/outbound-redis/http-rust-outbound-redis/Cargo.toml
+++ b/tests/outbound-redis/http-rust-outbound-redis/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "http-rust-outbound-redis"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# General-purpose crate with common HTTP types.
+http = "0.2"
+# The Spin SDK.
+spin-sdk = { path = "../../../sdk/rust" }
+# Crate that generates Rust Wasm bindings from a WebAssembly interface.
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[workspace]

--- a/tests/outbound-redis/http-rust-outbound-redis/spin.toml
+++ b/tests/outbound-redis/http-rust-outbound-redis/spin.toml
@@ -1,0 +1,15 @@
+spin_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+name = "rust-outbound-redis-example"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+environment = { REDIS_ADDRESS = "redis://127.0.0.1:6379" }
+id = "outbound-redis"
+source = "target/wasm32-wasi/release/http_rust_outbound_redis.wasm"
+[component.trigger]
+route = "/test"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -1,0 +1,30 @@
+use anyhow::{anyhow, Result};
+use spin_sdk::{
+    http::{Request, Response},
+    http_component, redis,
+};
+
+const REDIS_ADDRESS_ENV: &str = "REDIS_ADDRESS";
+
+#[http_component]
+fn test(_req: Request) -> Result<Response> {
+    let address = std::env::var(REDIS_ADDRESS_ENV)?;
+
+    redis::set(&address, "spin-example-get-set", &b"Eureka!"[..])
+        .map_err(|_| anyhow!("Error executing Redis set command"))?;
+
+    let payload = redis::get(&address, "spin-example-get-set")
+        .map_err(|_| anyhow!("Error querying Redis"))?;
+
+    assert_eq!(std::str::from_utf8(&payload).unwrap(), "Eureka!");
+
+    redis::set(&address, "spin-example-incr", &b"0"[..])
+        .map_err(|_| anyhow!("Error querying Redis set command"))?;
+
+    let int_value = redis::incr(&address, "spin-example-incr")
+        .map_err(|_| anyhow!("Error executing Redis incr command"))?;
+
+    assert_eq!(int_value, 1);
+
+    Ok(http::Response::builder().status(204).body(None)?)
+}

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -10,7 +10,7 @@ const REDIS_ADDRESS_ENV: &str = "REDIS_ADDRESS";
 fn test(_req: Request) -> Result<Response> {
     let address = std::env::var(REDIS_ADDRESS_ENV)?;
 
-    redis::set(&address, "spin-example-get-set", &b"Eureka!"[..])
+    redis::set(&address, "spin-example-get-set", b"Eureka!")
         .map_err(|_| anyhow!("Error executing Redis set command"))?;
 
     let payload = redis::get(&address, "spin-example-get-set")
@@ -18,13 +18,20 @@ fn test(_req: Request) -> Result<Response> {
 
     assert_eq!(std::str::from_utf8(&payload).unwrap(), "Eureka!");
 
-    redis::set(&address, "spin-example-incr", &b"0"[..])
+    redis::set(&address, "spin-example-incr", b"0")
         .map_err(|_| anyhow!("Error querying Redis set command"))?;
 
     let int_value = redis::incr(&address, "spin-example-incr")
         .map_err(|_| anyhow!("Error executing Redis incr command"))?;
 
     assert_eq!(int_value, 1);
+
+    let keys = vec!["spin-example-get-set", "spin-example-incr"];
+
+    let del_keys = redis::del(&address, &keys)
+        .map_err(|_| anyhow!("Error executing Redis incr command"))?;
+
+    assert_eq!(del_keys, 2);
 
     Ok(http::Response::builder().status(204).body(None)?)
 }

--- a/wit/ephemeral/outbound-redis.wit
+++ b/wit/ephemeral/outbound-redis.wit
@@ -12,3 +12,6 @@ set: func(address: string, key: string, value: payload) -> expected<unit, error>
 // Increments the number stored at key by one. If the key does not exist, it is set to 0 before performing the operation.
 // An error is returned if the key contains a value of the wrong type or contains a string that can not be represented as integer.
 incr: func(address: string, key: string) -> expected<s64, error>
+
+// Removes the specified keys. A key is ignored if it does not exist.
+del: func(address: string, keys: list<string>) -> expected<s64, error>


### PR DESCRIPTION
Closes #801.

Also:
- adds basic integration test for outbound-redis crate
- adds `incr`/`del` support into go sdk

PR into https://github.com/fermyon/spin-language-support-matrix/pull/1
Not included into the default test suite because redis container has to be set up on CI first.