### PR TITLE
command(deploy): Parse connection URL for bindle path construction

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -322,8 +322,9 @@ impl DeployCommand {
             None
         };
 
+        let su = Url::parse(login_connection.url.as_str())?;
         let bindle_connection_info = BindleConnectionInfo::from_token(
-            format!("{}/{}", login_connection.url, BINDLE_REGISTRY_URL_PATH),
+            su.join(BINDLE_REGISTRY_URL_PATH)?.to_string(),
             login_connection.danger_accept_invalid_certs,
             login_connection.token,
         );


### PR DESCRIPTION
🙈  - I accidentally broke things earlier when refactoring validation. This fixes the one super obvious case of URL munging, but I'll follow up with a longer term fix tomorrow.

Signed-off-by: Danielle Lancashire <dani@builds.terrible.systems>