### PR TITLE
chore(go-sdk): Disable integration test caching

### DIFF
--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -8,7 +8,7 @@ test: test-integration
 
 .PHONY: test-integration
 test-integration: http/testdata/http-tinygo/main.wasm
-	go test -v .
+	go test -v -count=1 .
 
 http/testdata/http-tinygo/main.wasm: generate
 http/testdata/http-tinygo/main.wasm: http/testdata/http-tinygo/main.go


### PR DESCRIPTION
TIL:

```
When 'go test' runs in package list mode, 'go test' caches successful package test results to avoid
unnecessary repeated running of tests. To disable test caching, use any test flag or argument other than
the cacheable flags. The idiomatic way to disable test caching explicitly is to use -count=1.[1]
```

Because the integration test is calling the external command, from the go-lang standpoint it's OK to cache test results. IRL, you'll continue to see cached test results even if you break one of the examples after the first test run.

[1]: https://pkg.go.dev/cmd/go/internal/test

Signed-off-by: Konstantin Shabanov <mail@etehtsea.me>