### PR TITLE
Tweak `spin deploy` output

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -336,10 +336,18 @@ impl DeployCommand {
             login_connection.token,
         );
 
+        println!("Uploading...");
+
         let bindle_id = self
             .create_and_push_bindle(buildinfo, bindle_connection_info)
             .await?;
         let name = bindle_id.name().to_string();
+
+        println!(
+            "Deploying {} version {} ...",
+            &name,
+            bindle_id.version_string()
+        );
 
         // Create or update app
         // TODO: this process involves many calls to Hippo. Should be able to update the channel
@@ -390,11 +398,6 @@ impl DeployCommand {
             }
         };
 
-        println!(
-            "Deployed {} version {}",
-            name.clone(),
-            bindle_id.version_string()
-        );
         let channel = CloudClient::get_channel_by_id(&client, &channel_id.to_string())
             .await
             .context("Problem getting channel by id")?;


### PR DESCRIPTION
The main thing this adds is a `Uploading...` message immediately after running `spin deploy` just to give quicker feedback.

Before:
```console
$ spin deploy
[...no output until things are done...]
Deployed fermyon-com version 0.3.0+q7bdd566
Waiting for application to become ready............. ready
```
After:
```console
$ spin deploy
Uploading...
Deploying fermyon-com version 0.3.1+q8c7dfa0 ...
Waiting for application to become ready... ready
```
^ first message is immediate
