### PR TITLE
Update default Cloud URL

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -26,7 +26,7 @@ use crate::opts::{
 // this is the client ID registered in the Cloud's backend
 const SPIN_CLIENT_ID: &str = "583e63e9-461f-4fbe-a246-23e0fb1cad10";
 
-const DEFAULT_CLOUD_URL: &str = "http://localhost:5309";
+const DEFAULT_CLOUD_URL: &str = "https://cloud.fermyon.com/";
 
 /// Log into the server
 #[derive(Parser, Debug)]


### PR DESCRIPTION
This commit updates the default URL used by `spin deploy` from `http://localhost:5309` (which is the local endpoint for Hippo) to `https://cloud.fermyon.com/`.

This is configurable both through the `--url` flag, and through the `HIPPO_URL` environment variable.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>