### PR TITLE
fix(deploy): Prevent swallowing the error

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -162,7 +162,7 @@ impl DeployCommand {
 
             self.deploy_cloud(login_connection)
                 .await
-                .map_err(|e| anyhow!("{}\n\nLearn more at {}", e, DEVELOPER_CLOUD_FAQ))
+                .map_err(|e| anyhow!("{:?}\n\nLearn more at {}", e, DEVELOPER_CLOUD_FAQ))
         }
     }
 


### PR DESCRIPTION
When I tried to deploy example before building it, it failed with quite confusing error.

An explicit recommendation to run `spin build` could be even better solution but this workaround should be good enough before a more long-term solution is introduced.

Also, I wonder should `spin deploy` check that build artifacts are outdated?

Before:

```
$ ../../target/debug/spin deploy
Error: Failed to expand 'spin.toml' to a bindle

Learn more at https://developer.fermyon.com/cloud/faq
```

After:

```
$ ../../target/debug/spin deploy
Error: Failed to expand 'spin.toml' to a bindle

Caused by:
    0: Failed to convert components to Bindle format
    1: Failed to get parcel id for 'examples/http-rust-outbound-http/target/wasm32-wasi/release/http_rust_outbound_http.wasm'
    2: No such file or directory (os error 2)

Learn more at https://developer.fermyon.com/cloud/faq
```

Signed-off-by: Konstantin Shabanov <mail@etehtsea.me>