### PR TITLE
rename example and test crates to avoid cargo warnings

### DIFF
--- a/examples/http-rust/Cargo.toml
+++ b/examples/http-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spinhelloworld"
+name = "http-rust"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/http-rust/spin.toml
+++ b/examples/http-rust/spin.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 
 [[component]]
 id = "hello"
-source = "target/wasm32-wasi/release/spinhelloworld.wasm"
+source = "target/wasm32-wasi/release/http_rust.wasm"
 description = "A simple component that returns hello."
 [component.trigger]
 route = "/hello"

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -127,6 +127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-spin-rust"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "spin-sdk",
+ "wit-bindgen-rust",
+]
+
+[[package]]
 name = "spin-macro"
 version = "0.1.0"
 dependencies = [
@@ -150,17 +161,6 @@ dependencies = [
  "form_urlencoded",
  "http",
  "spin-macro",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "spinhelloworld"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "spin-sdk",
  "wit-bindgen-rust",
 ]
 

--- a/tests/http/simple-spin-rust/Cargo.toml
+++ b/tests/http/simple-spin-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "spinhelloworld"
+name    = "simple-spin-rust"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/http/simple-spin-rust/spin.toml
+++ b/tests/http/simple-spin-rust/spin.toml
@@ -10,7 +10,7 @@ object = { default = "teapot" }
 
 [[component]]
 id = "hello"
-source = "target/wasm32-wasi/release/spinhelloworld.wasm"
+source = "target/wasm32-wasi/release/simple_spin_rust.wasm"
 files = [ { source = "assets", destination = "/" } ]
 [component.trigger]
 route = "/hello/..."

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -244,7 +244,7 @@ mod integration_tests {
                 .join("target")
                 .join("wasm32-wasi")
                 .join("release")
-                .join("spinhelloworld.wasm");
+                .join("simple_spin_rust.wasm");
             let parcel_sha = file_digest_string(&wasm_path).expect("failed to get sha for parcel");
 
             // start the Bindle registry.


### PR DESCRIPTION
This should address "skipping duplicate package" warnings, e.g. when using the Rust Spin SDK.

Fixes #793.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>