### PR TITLE
Remove `.cargo/config.toml` from Rust Spin templates to easily enable unit tests

### DIFF
--- a/templates/http-rust/content/.cargo/config.toml
+++ b/templates/http-rust/content/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-wasi"

--- a/templates/redis-rust/content/.cargo/config.toml
+++ b/templates/redis-rust/content/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-wasi"


### PR DESCRIPTION
fixes #672 by using the proposed solution of removing the `.cargo/config.toml`

we can close this if we think we are still investigating a better solution

Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>