### PR TITLE
Fix redeploy readiness

### DIFF
--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -19,6 +19,7 @@ indexmap = "1"
 percent-encoding = "2"
 rustls-pemfile = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-trigger = { path = "../trigger" }
@@ -35,7 +36,6 @@ wit-bindgen-wasmtime = { workspace = true }
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio"] }
 num_cpus = "1"
-serde_json = "1"
 spin-testing = { path = "../testing" }
 
 [[bench]]

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -362,11 +362,11 @@ impl HttpTrigger {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppInfo {
-    name: String,
+    pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    version: Option<String>,
+    pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    bindle_version: Option<String>,
+    pub bindle_version: Option<String>,
 }
 
 fn parse_listen_addr(addr: &str) -> anyhow::Result<SocketAddr> {

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -265,11 +265,8 @@ impl HttpTrigger {
     fn app_info(&self) -> Result<Response<Body>> {
         let info = AppInfo {
             name: self.engine.app_name.clone(),
-            version: self
-                .engine
-                .app()
-                .get_metadata("version")?
-                .unwrap_or_default(),
+            version: self.engine.app().get_metadata("version")?,
+            bindle_version: self.engine.app().get_metadata("bindle_version")?,
         };
         let body = serde_json::to_vec_pretty(&info)?;
         Ok(Response::builder()
@@ -366,7 +363,10 @@ impl HttpTrigger {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppInfo {
     name: String,
-    version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    bindle_version: Option<String>,
 }
 
 fn parse_listen_addr(addr: &str) -> anyhow::Result<SocketAddr> {

--- a/crates/trigger/src/locked.rs
+++ b/crates/trigger/src/locked.rs
@@ -11,8 +11,8 @@ use spin_app::{
     values::{ValuesMap, ValuesMapBuilder},
 };
 use spin_manifest::{
-    Application, ApplicationInformation, ApplicationTrigger, CoreComponent, HttpConfig,
-    HttpTriggerConfiguration, RedisConfig, TriggerConfig,
+    Application, ApplicationInformation, ApplicationOrigin, ApplicationTrigger, CoreComponent,
+    HttpConfig, HttpTriggerConfiguration, RedisConfig, TriggerConfig,
 };
 
 const WASM_CONTENT_TYPE: &str = "application/wasm";
@@ -48,15 +48,16 @@ impl LockedAppBuilder {
             .string_option("description", info.description.as_deref())
             .serializable("trigger", info.trigger)?;
         // Convert ApplicationOrigin to a URL
-        builder.string(
-            "origin",
-            match info.origin {
-                spin_manifest::ApplicationOrigin::File(path) => file_uri(&path)?,
-                spin_manifest::ApplicationOrigin::Bindle { id, server } => {
-                    format!("bindle+{server}?id={id}")
+        let origin = match info.origin {
+            ApplicationOrigin::File(path) => file_uri(&path)?,
+            ApplicationOrigin::Bindle { id, server } => {
+                if let Some((_, version)) = id.split_once('/') {
+                    builder.string("bindle_version", version);
                 }
-            },
-        );
+                format!("bindle+{server}?id={id}")
+            }
+        };
+        builder.string("origin", origin);
         Ok(builder.build())
     }
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,3 +1,4 @@
+use anyhow::ensure;
 use anyhow::{anyhow, bail, Context, Result};
 use bindle::Id;
 use chrono::{DateTime, Utc};
@@ -189,6 +190,8 @@ impl DeployCommand {
         let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app).await?;
         let RawAppManifestAnyVersion::V1(cfg) = cfg_any;
 
+        ensure!(!cfg.components.is_empty(), "No components in spin.toml!");
+
         let buildinfo = if !self.no_buildinfo {
             match &self.buildinfo {
                 Some(i) => Some(i.clone()),
@@ -210,7 +213,7 @@ impl DeployCommand {
             .await?;
 
         let hippo_client = Client::new(ConnectionInfo {
-            url: login_connection.url.clone(),
+            url: login_connection.url.to_string(),
             danger_accept_invalid_certs: login_connection.danger_accept_invalid_certs,
             api_key: Some(login_connection.token),
         });
@@ -286,21 +289,15 @@ impl DeployCommand {
         let channel = Client::get_channel_by_id(&hippo_client, &channel_id.to_string())
             .await
             .context("Problem getting channel by id")?;
+        let app_base_url = build_app_base_url(&channel.domain, &login_connection.url)?;
         if let Ok(http_config) = HttpTriggerConfiguration::try_from(cfg.info.trigger.clone()) {
             wait_for_ready(
-                &channel.domain,
-                &login_connection.url,
-                &cfg,
+                &app_base_url,
                 &bindle_id.version_string(),
                 self.readiness_timeout_secs,
             )
             .await;
-            print_available_routes(
-                &channel.domain,
-                &http_config.base,
-                &login_connection.url,
-                &cfg,
-            );
+            print_available_routes(&app_base_url, &http_config.base, &cfg);
         } else {
             println!("Application is running at {}", channel.domain);
         }
@@ -310,7 +307,7 @@ impl DeployCommand {
 
     async fn deploy_cloud(self, login_connection: LoginConnection) -> Result<()> {
         let connection_config = ConnectionConfig {
-            url: login_connection.url.clone(),
+            url: login_connection.url.to_string(),
             insecure: login_connection.danger_accept_invalid_certs,
             token: TokenInfo {
                 token: Some(login_connection.token.clone()),
@@ -322,6 +319,8 @@ impl DeployCommand {
 
         let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app).await?;
         let RawAppManifestAnyVersion::V1(cfg) = cfg_any;
+
+        ensure!(!cfg.components.is_empty(), "No components in spin.toml!");
 
         match cfg.info.trigger {
             ApplicationTrigger::Http(_) => {}
@@ -405,21 +404,15 @@ impl DeployCommand {
         let channel = CloudClient::get_channel_by_id(&client, &channel_id.to_string())
             .await
             .context("Problem getting channel by id")?;
+        let app_base_url = build_app_base_url(&channel.domain, &login_connection.url)?;
         if let Ok(http_config) = HttpTriggerConfiguration::try_from(cfg.info.trigger.clone()) {
             wait_for_ready(
-                &channel.domain,
-                &login_connection.url,
-                &cfg,
+                &app_base_url,
                 &bindle_id.version_string(),
                 self.readiness_timeout_secs,
             )
             .await;
-            print_available_routes(
-                &channel.domain,
-                &http_config.base,
-                &login_connection.url,
-                &cfg,
-            );
+            print_available_routes(&app_base_url, &http_config.base, &cfg);
         } else {
             println!("Application is running at {}", channel.domain);
         }
@@ -608,10 +601,17 @@ fn random_buildinfo() -> BuildMetadata {
     BuildMetadata::new(&format!("r{random_hex}")).unwrap()
 }
 
-async fn check_healthz(url: &str) -> Result<()> {
-    let base_url = url::Url::parse(url)?;
-    let healthz_url = base_url.join("/healthz")?;
-    reqwest::get(healthz_url.to_string())
+fn build_app_base_url(app_domain: &str, hippo_url: &Url) -> Result<Url> {
+    // HACK: We assume that the scheme (https vs http) of apps will match that of Hippo...
+    let scheme = hippo_url.scheme();
+    Url::parse(&format!("{scheme}://{app_domain}/")).with_context(|| {
+        format!("Could not construct app base URL for {app_domain:?} (Hippo URL: {hippo_url:?})",)
+    })
+}
+
+async fn check_healthz(base_url: &Url) -> Result<()> {
+    let healthz_url = base_url.join("healthz")?;
+    reqwest::get(healthz_url)
         .await?
         .error_for_status()
         .with_context(|| format!("Server {} is unhealthy", base_url))?;
@@ -620,38 +620,26 @@ async fn check_healthz(url: &str) -> Result<()> {
 
 const READINESS_POLL_INTERVAL_SECS: u64 = 2;
 
-async fn wait_for_ready(
-    app_domain: &str,
-    hippo_url: &str,
-    cfg: &spin_loader::local::config::RawAppManifest,
-    bindle_version: &str,
-    readiness_timeout_secs: u16,
-) {
+async fn wait_for_ready(app_base_url: &Url, bindle_version: &str, readiness_timeout_secs: u16) {
     if readiness_timeout_secs == 0 {
         return;
     }
 
-    if cfg.components.is_empty() {
-        return;
-    }
-
-    let url_result = Url::parse(hippo_url);
-    let scheme = match &url_result {
-        Ok(url) => url.scheme(),
-        Err(_) => "http",
-    };
-
-    let path = WELL_KNOWN_PREFIX.to_string() + "health";
-    let health_check_url = format!("{}://{}{}", scheme, app_domain, path);
+    let app_info_url = app_base_url
+        .join(WELL_KNOWN_PREFIX.trim_start_matches('/'))
+        .unwrap()
+        .join("info")
+        .unwrap()
+        .to_string();
 
     let start = std::time::Instant::now();
     let readiness_timeout = std::time::Duration::from_secs(u64::from(readiness_timeout_secs));
     let poll_interval = tokio::time::Duration::from_secs(READINESS_POLL_INTERVAL_SECS);
 
     print!("Waiting for application to become ready");
-    std::io::stdout().flush().unwrap_or_default();
+    let _ = std::io::stdout().flush();
     loop {
-        match is_ready(&health_check_url, bindle_version).await {
+        match is_ready(&app_info_url, bindle_version).await {
             Err(err) => {
                 println!("... readiness check failed: {err:?}");
                 return;
@@ -664,7 +652,7 @@ async fn wait_for_ready(
         }
 
         print!(".");
-        std::io::stdout().flush().unwrap_or_default();
+        let _ = std::io::stdout().flush();
 
         if start.elapsed() >= readiness_timeout {
             println!();
@@ -676,21 +664,26 @@ async fn wait_for_ready(
 }
 
 #[instrument(level = "debug")]
-async fn is_ready(app_info_url: &str, bindle_version: &str) -> Result<bool> {
-    // If the request fails, the app isn't ready
-    let resp = reqwest::get(app_info_url).await?;
+async fn is_ready(app_info_url: &str, expected_version: &str) -> Result<bool> {
+    // If the request fails, we assume the app isn't ready
+    let resp = match reqwest::get(app_info_url).await {
+        Ok(resp) => resp,
+        Err(err) => {
+            tracing::warn!("Readiness check failed: {err:?}");
+            return Ok(false);
+        }
+    };
+    // If the response status isn't success, the app isn't ready
     if !resp.status().is_success() {
         tracing::debug!("App not ready: {}", resp.status());
         return Ok(false);
     }
-    if let Some(active_version) = resp
-        .json::<AppInfo>()
-        .await
-        .ok()
-        .and_then(|info| info.bindle_version)
-    {
-        if active_version != bindle_version {
-            tracing::debug!("Active version {active_version:?} != new version {bindle_version:?}");
+    // If the app was previously deployed then it will have an outdated bindle
+    // version, in which case the app isn't ready
+    if let Ok(app_info) = resp.json::<AppInfo>().await {
+        let active_version = app_info.bindle_version;
+        if active_version.as_deref() != Some(expected_version) {
+            tracing::debug!("Active version {active_version:?} != expected {expected_version:?}");
             return Ok(false);
         }
     }
@@ -698,9 +691,8 @@ async fn is_ready(app_info_url: &str, bindle_version: &str) -> Result<bool> {
 }
 
 fn print_available_routes(
-    address: &str,
+    app_base_url: &Url,
     base: &str,
-    hippo_url: &str,
     cfg: &spin_loader::local::config::RawAppManifest,
 ) {
     if cfg.components.is_empty() {
@@ -710,14 +702,9 @@ fn print_available_routes(
     println!("Available Routes:");
     for component in &cfg.components {
         if let TriggerConfig::Http(http_cfg) = &component.trigger {
-            let url_result = Url::parse(hippo_url);
-            let scheme = match &url_result {
-                Ok(url) => url.scheme(),
-                Err(_) => "http",
-            };
-
             let route = RoutePattern::from(base, &http_cfg.route);
-            println!("  {}: {}://{}{}", component.id, scheme, address, route);
+            let route_url = app_base_url.join(&route.to_string()).unwrap();
+            println!("  {}: {}", component.id, route_url);
             if let Some(description) = &component.description {
                 println!("    {}", description);
             }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 use semver::BuildMetadata;
 use sha2::{Digest, Sha256};
 use spin_http::routes::RoutePattern;
-use spin_http::WELL_KNOWN_HEALTH_PATH;
+use spin_http::WELL_KNOWN_PREFIX;
 use spin_loader::bindle::BindleConnectionInfo;
 use spin_loader::local::config::{RawAppManifest, RawAppManifestAnyVersion};
 use spin_loader::local::{assets, config, parent_dir};
@@ -636,7 +636,7 @@ async fn wait_for_ready(
         Err(_) => "http",
     };
 
-    let path = WELL_KNOWN_HEALTH_PATH;
+    let path = WELL_KNOWN_PREFIX.to_string() + "health";
     let health_check_url = format!("{}://{}{}", scheme, app_domain, path);
 
     let start = std::time::Instant::now();


### PR DESCRIPTION
Currently, a redeploy of an existing app will be seen as "ready" immediately, since the previous version is ready. This means that after a successful deploy a user might still see the old version active for a while.

This fixes the issue by introducing a new `/.well-known/spin/info` endpoint that returns some app info including the currently deployed bindle version. That version will be checked in the `spin deploy` readiness check loop to ensure that the currently deploying version is active before returning.

Additionally, refactor a bunch of stuff in here that has been bothering me :sweat_smile: 