### PR TITLE
Revert "ci: update release workflow ubuntu version"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-22.04",
+              os: "ubuntu-18.04",
               arch: "amd64",
               extension: "",
               # Ubuntu 22.04 no longer ships libssl1.1, so we statically


### PR DESCRIPTION
Reverts fermyon/spin#871

This caused a glibc compatibility regression in Ubuntu 18.04 (among others, probably).