### PR TITLE
Revert "ci: update release workflow ubuntu version"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-22.04",
+              os: "ubuntu-18.04",
               arch: "amd64",
               extension: "",
               # Ubuntu 22.04 no longer ships libssl1.1, so we statically


### PR DESCRIPTION
This change broke release binaries on some Linux distro versions (notably Ubuntu 18.04).

Ref #708 
Ref #871 