### PR TITLE
Improve error message when app needs to be built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,6 +4258,7 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "spin-loader",
+ "thiserror",
  "tokio",
  "toml",
 ]

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -15,5 +15,6 @@ reqwest = "0.11"
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 spin-loader = { path = "../loader" }
+thiserror = "1.0.37"
 tokio = "1.16.1"
 toml = "0.5"

--- a/crates/publish/src/error.rs
+++ b/crates/publish/src/error.rs
@@ -1,0 +1,39 @@
+/// A specialized Result type for publish operations
+pub type PublishResult<T> = std::result::Result<T, PublishError>;
+
+/// Describes various errors that can be returned during publishing
+#[derive(Debug, thiserror::Error)]
+pub enum PublishError {
+    /// The bindle already exists
+    #[error("Bindle {0} already exists on the server")]
+    BindleAlreadyExists(String),
+    /// Bindle client failure
+    #[error("Error creating bindle client")]
+    BindleClient(#[from] bindle::client::ClientError),
+    /// Malformed bindle id
+    #[error("App name and version '{0}' do not form a bindle ID")]
+    BindleId(String),
+    /// Publishing of components whose sources are already bindles is not supported
+    #[error("This version of Spin can't publish components whose sources are already bindles")]
+    BindlePushingNotImplemented,
+    /// IO errors from interacting with the file system
+    #[error("{description}")]
+    Io {
+        /// Error description
+        description: String,
+        /// Underlying lower level error that caused your error
+        source: std::io::Error,
+    },
+    /// Invalid TOML serialization that can occur when serializing an object to a request
+    #[error("{description}")]
+    TomlSerialization {
+        /// Error description
+        description: String,
+        /// Underlying lower level error that caused your error
+        source: toml::ser::Error,
+    },
+    /// A catch-all for anyhow errors.
+    /// Contains an error message describing the underlying issue.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/crates/publish/src/error.rs
+++ b/crates/publish/src/error.rs
@@ -24,6 +24,9 @@ pub enum PublishError {
         /// Underlying lower level error that caused your error
         source: std::io::Error,
     },
+    /// Build artifact is missing
+    #[error("Missing build artifact: '{0}'")]
+    MissingBuildArtifact(String),
     /// Invalid TOML serialization that can occur when serializing an object to a request
     #[error("{description}")]
     TomlSerialization {

--- a/crates/publish/src/expander.rs
+++ b/crates/publish/src/expander.rs
@@ -99,6 +99,13 @@ async fn bindle_component_manifest(
     let source_digest = match &local.source {
         local_schema::RawModuleSource::FileReference(path) => {
             let full_path = base_dir.join(path);
+
+            if let Ok(false) = Path::try_exists(&full_path) {
+                return Err(PublishError::MissingBuildArtifact(
+                    full_path.display().to_string(),
+                ));
+            }
+
             sha256_digest(&full_path)?
         }
         local_schema::RawModuleSource::Bindle(_) => {

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -4,7 +4,9 @@
 
 mod bindle_pusher;
 mod bindle_writer;
+mod error;
 mod expander;
 
 pub use bindle_pusher::push_all;
 pub use bindle_writer::prepare_bindle;
+pub use error::{PublishError, PublishResult};

--- a/src/commands/bindle.rs
+++ b/src/commands/bindle.rs
@@ -167,9 +167,11 @@ impl Push {
             self.bindle_server_url
         ));
 
-        spin_publish::push_all(&dest_dir, &bindle_id, bindle_connection_info)
+        spin_publish::push_all(&dest_dir, &bindle_id, bindle_connection_info.clone())
             .await
-            .context("Failed to push bindle to server")?;
+            .with_context(|| {
+                crate::push_all_failed_msg(dest_dir, bindle_connection_info.base_url())
+            })?;
 
         println!("pushed: {}", bindle_id);
         Ok(())

--- a/src/commands/bindle.rs
+++ b/src/commands/bindle.rs
@@ -126,7 +126,9 @@ impl Prepare {
             .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
 
         let dest_dir = &self.staging_dir;
-        let bindle_id = spin_publish::prepare_bindle(app_file, self.buildinfo, dest_dir).await?;
+        let bindle_id = spin_publish::prepare_bindle(app_file, self.buildinfo, dest_dir)
+            .await
+            .map_err(crate::wrap_prepare_bindle_error)?;
 
         // We can't try to canonicalize it until the directory has been created
         let full_dest_dir =
@@ -160,7 +162,9 @@ impl Push {
             Some(path) => path.as_path(),
         };
 
-        let bindle_id = spin_publish::prepare_bindle(app_file, self.buildinfo, dest_dir).await?;
+        let bindle_id = spin_publish::prepare_bindle(app_file, self.buildinfo, dest_dir)
+            .await
+            .map_err(crate::wrap_prepare_bindle_error)?;
 
         let _sloth_warning = warn_if_slow_response(format!(
             "Uploading application to {}",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -569,7 +569,9 @@ impl DeployCommand {
             Some(path) => path.as_path(),
         };
 
-        let bindle_id = spin_publish::prepare_bindle(&self.app, buildinfo, dest_dir).await?;
+        let bindle_id = spin_publish::prepare_bindle(&self.app, buildinfo, dest_dir)
+            .await
+            .map_err(crate::wrap_prepare_bindle_error)?;
 
         println!(
             "Uploading {} version {}...",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -438,6 +438,7 @@ impl DeployCommand {
                 config::RawModuleSource::Bindle(_b) => {}
                 config::RawModuleSource::Url(us) => sha256.update(us.digest.as_bytes()),
             }
+
             if let Some(files) = &x.wasm.files {
                 let exclude_files = x.wasm.exclude_files.clone().unwrap_or_default();
                 let fm = assets::collect(files, &exclude_files, &app_folder)?;
@@ -576,35 +577,22 @@ impl DeployCommand {
             bindle_id.version()
         );
 
-        let publish_result =
-            spin_publish::push_all(&dest_dir, &bindle_id, bindle_connection_info.clone()).await;
-
-        if let Err(publish_err) = publish_result {
-            // TODO: maybe use `thiserror` to return type errors.
-            let already_exists = publish_err
-                .to_string()
-                .contains("already exists on the server");
-            if already_exists {
+        match spin_publish::push_all(dest_dir, &bindle_id, bindle_connection_info.clone()).await {
+            Err(spin_publish::PublishError::BindleAlreadyExists(err_msg)) => {
                 if self.redeploy {
-                    return Ok(bindle_id.clone());
+                    Ok(bindle_id.clone())
                 } else {
-                    return Err(anyhow!(
+                    Err(anyhow!(
                         "Failed to push bindle to server.\n{}\nTry using the --deploy-existing-bindle flag",
-                        publish_err
-                    ));
+                        err_msg
+                    ))
                 }
-            } else {
-                return Err(publish_err).with_context(|| {
-                    format!(
-                        "Failed to push bindle {} to server {}",
-                        bindle_id,
-                        bindle_connection_info.base_url()
-                    )
-                });
             }
+            Err(err) => Err(err).with_context(|| {
+                crate::push_all_failed_msg(dest_dir, bindle_connection_info.base_url())
+            }),
+            Ok(()) => Ok(bindle_id.clone()),
         }
-
-        Ok(bindle_id.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,15 @@ mod sloth;
 
 use anyhow::Result;
 use semver::BuildMetadata;
+use std::path::Path;
+
+pub(crate) fn push_all_failed_msg(path: &Path, server_url: &str) -> String {
+    format!(
+        "Failed to push bindle from '{}' to the server at '{}'",
+        path.display(),
+        server_url
+    )
+}
 
 pub(crate) fn parse_buildinfo(buildinfo: &str) -> Result<BuildMetadata> {
     Ok(BuildMetadata::new(buildinfo)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,9 @@ pub mod commands;
 pub(crate) mod opts;
 mod sloth;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use semver::BuildMetadata;
+use spin_publish::PublishError;
 use std::path::Path;
 
 pub(crate) fn push_all_failed_msg(path: &Path, server_url: &str) -> String {
@@ -12,6 +13,15 @@ pub(crate) fn push_all_failed_msg(path: &Path, server_url: &str) -> String {
         path.display(),
         server_url
     )
+}
+
+pub(crate) fn wrap_prepare_bindle_error(err: PublishError) -> anyhow::Error {
+    match err {
+        PublishError::MissingBuildArtifact(_) => {
+            anyhow!("{}\n\nPlease try to run `spin build` first", err)
+        }
+        e => anyhow!(e),
+    }
 }
 
 pub(crate) fn parse_buildinfo(buildinfo: &str) -> Result<BuildMetadata> {


### PR DESCRIPTION
### Context
- Replaces `anyhow` with `thiserror` inside `spin_publish` library. Tried to preserve the original behavior.
- Improves UX when app needs to be built. Please see the first example in the comparison list.

### Comparison

#### Project needs to be built

Before:

```
spin/examples/http-rust $ /tmp/spin bindle prepare --staging-dir /tmp/http-rust
Error: Failed to expand 'spin.toml' to a bindle

Caused by:
    0: Failed to convert components to Bindle format
    1: Failed to get parcel id for '<redacted>spin/examples/http-rust/target/wasm32-wasi/release/http_rust.wasm'
    2: No such file or directory (os error 2)
```

After (`spin bundle prepare`):

```
spin/examples/http-rust 859-publish $ ../../target/release/spin bindle prepare --staging-dir /tmp/http-rust
Error: Missing build artifact: '<redacted>/spin/examples/http-rust/target/wasm32-wasi/release/http_rust.wasm'

Please try to run `spin build` first
```

After (`spin deploy`):

```
 ../../target/release/spin deploy
Error: Missing build artifact: '<redacted>/spin/examples/http-rust/target/wasm32-wasi/release/http_rust.wasm'

Please try to run `spin build` first

Learn more at https://developer.fermyon.com/cloud/faq
```

After (`spin bindle push`):
```
 ../../target/release/spin bindle push --bindle-server http://localhost:8080
Error: Missing build artifact: '<redacted>/spin/examples/http-rust/target/wasm32-wasi/release/http_rust.wasm'

Please try to run `spin build` first
```
#### Bindle server is unavailable

Before:

```
/tmp/spin bindle push --bindle-server http://localhost:8000/v1
Error: Failed to push bindle to server

Caused by:
    0: Failed to push bindle from '/tmp/.tmpaDtdJm' to server at 'http://localhost:8000/v1'
    1: Error creating request
    2: error sending request for url (http://localhost:8000/v1/_i): error trying to connect: tcp connect error: Connection refused (os error 111)
    3: error trying to connect: tcp connect error: Connection refused (os error 111)
    4: tcp connect error: Connection refused (os error 111)
    5: Connection refused (os error 111)
```

After:

```
../../target/release/spin bindle push --bindle-server http://localhost:8000/v1 
Error: Failed to push bindle from '/tmp/.tmpxJ6f3N' to the server at 'http://localhost:8000/v1'

Caused by:
    0: Error creating bindle client
    1: Error creating request
    2: error sending request for url (http://localhost:8000/v1/_i): error trying to connect: tcp connect error: Connection refused (os error 111)
    3: error trying to connect: tcp connect error: Connection refused (os error 111)
    4: tcp connect error: Connection refused (os error 111)
    5: Connection refused (os error 111)
```

#### Bindle already exists

Before:

```
$ /tmp/spin bindle push --bindle-server http://localhost:8080/v1
Error: Failed to push bindle to server

Caused by:
    Bindle spin-hello-world/1.0.0 already exists on the server
```

```
 ../../target/release/spin bindle push --bindle-server http://localhost:8080/v1
Error: Failed to push bindle from '/tmp/.tmpwe3qBS' to the server at 'http://localhost:8080/v1'

Caused by:
    Bindle spin-hello-world/1.0.0 already exists on the server
```

#### Unable to write into the staging dir

Before:

```
/tmp/spin bindle prepare --staging-dir /tmp/foo
Error: Failed to expand 'spin.toml' to a bindle

Caused by:
    0: Failed to save app manifest to temporary file
    1: Permission denied (os error 13)
```

After:

```
../../target/release/spin bindle prepare --staging-dir /tmp/pd 
Error: Failed to create directory: '/tmp/pd/manifests'

Caused by:
    Permission denied (os error 13)
```

#### Network error

Before:

```
/tmp/spin deploy                               
Error: error sending request for url (https://non-existing-domain-asldkhasdfkljhsdflijsdf.com/healthz): error trying to connect: dns error: failed to lookup address information: Name or service not known

Caused by:
    0: error trying to connect: dns error: failed to lookup address information: Name or service not known
    1: dns error: failed to lookup address information: Name or service not known
    2: failed to lookup address information: Name or service not known
```

After:

```
 ../../target/release/spin deploy
Error: error sending request for url (https://non-existing-domain-asldkhasdfkljhsdflijsdf.com/healthz): error trying to connect: dns error: failed to lookup address information: Name or service not known

Caused by:
    0: error trying to connect: dns error: failed to lookup address information: Name or service not known
    1: dns error: failed to lookup address information: Name or service not known
    2: failed to lookup address information: Name or service not known
```

Fixes #859.