### PR TITLE
`spin new`: add component to existing application

### DIFF
--- a/crates/plugins/src/lib.rs
+++ b/crates/plugins/src/lib.rs
@@ -7,10 +7,11 @@ mod store;
 pub use store::PluginStore;
 
 /// List of Spin internal subcommands
-pub(crate) const SPIN_INTERNAL_COMMANDS: [&str; 9] = [
+pub(crate) const SPIN_INTERNAL_COMMANDS: [&str; 10] = [
     "templates",
     "up",
     "new",
+    "add",
     "bindle",
     "deploy",
     "build",

--- a/crates/templates/src/app_info.rs
+++ b/crates/templates/src/app_info.rs
@@ -1,0 +1,64 @@
+// Information about the application manifest that is of
+// interest to the template system.  spin_loader does too
+// much processing to fit our needs here.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use crate::store::TemplateLayout;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(tag = "spin_version")]
+pub(crate) enum AppInfo {
+    /// A manifest with API version 1.
+    #[serde(rename = "1")]
+    V1(AppInfoV1),
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct AppInfoV1 {
+    trigger: TriggerInfo,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct TriggerInfo {
+    #[serde(rename = "type")]
+    trigger_type: String,
+}
+
+impl AppInfo {
+    pub(crate) fn from_layout(layout: &TemplateLayout) -> Option<anyhow::Result<AppInfo>> {
+        Self::layout_manifest_path(layout)
+            .map(|manifest_path| Self::from_existent_file(&manifest_path))
+    }
+
+    pub(crate) fn from_file(manifest_path: &Path) -> Option<anyhow::Result<AppInfo>> {
+        if manifest_path.exists() {
+            Some(Self::from_existent_file(manifest_path))
+        } else {
+            None
+        }
+    }
+
+    fn layout_manifest_path(layout: &TemplateLayout) -> Option<PathBuf> {
+        let manifest_path = layout.content_dir().join("spin.toml");
+        if manifest_path.exists() {
+            Some(manifest_path)
+        } else {
+            None
+        }
+    }
+
+    fn from_existent_file(manifest_path: &Path) -> anyhow::Result<AppInfo> {
+        let manifest_text =
+            std::fs::read_to_string(manifest_path).context("Can't read manifest file")?;
+        toml::from_str(&manifest_text).context("Can't parse manifest file")
+    }
+
+    pub(crate) fn trigger_type(&self) -> &str {
+        match self {
+            Self::V1(info) => &info.trigger.trigger_type,
+        }
+    }
+}

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -1,7 +1,8 @@
 //! Package for working with Wasm component templates.
 
-#![deny(missing_docs)]
+#![allow(missing_docs)]
 
+mod app_info;
 mod constraints;
 mod custom_filters;
 mod directory;
@@ -18,4 +19,4 @@ mod template;
 pub use manager::*;
 pub use run::{Run, RunOptions, TemplatePreparationResult};
 pub use source::TemplateSource;
-pub use template::Template;
+pub use template::{Template, TemplateVariantKind};

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -1,6 +1,6 @@
 //! Package for working with Wasm component templates.
 
-#![allow(missing_docs)]
+#![deny(missing_docs)]
 
 mod app_info;
 mod constraints;

--- a/crates/templates/src/reader.rs
+++ b/crates/templates/src/reader.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Context;
 use indexmap::IndexMap;
 use serde::Deserialize;
@@ -15,8 +17,18 @@ pub(crate) enum RawTemplateManifest {
 pub(crate) struct RawTemplateManifestV1 {
     pub id: String,
     pub description: Option<String>,
+    pub trigger_type: Option<String>,
+    pub add_component: Option<RawTemplateVariant>,
     pub parameters: Option<IndexMap<String, RawParameter>>,
     pub custom_filters: Option<Vec<RawCustomFilter>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub(crate) struct RawTemplateVariant {
+    pub skip_files: Option<Vec<String>>,
+    pub skip_parameters: Option<Vec<String>>,
+    pub snippets: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/templates/src/store.rs
+++ b/crates/templates/src/store.rs
@@ -73,6 +73,7 @@ pub(crate) struct TemplateLayout {
 const METADATA_DIR_NAME: &str = "metadata";
 const FILTERS_DIR_NAME: &str = "filters";
 const CONTENT_DIR_NAME: &str = "content";
+const SNIPPETS_DIR_NAME: &str = "snippets";
 
 const MANIFEST_FILE_NAME: &str = "spin-template.toml";
 
@@ -101,5 +102,9 @@ impl TemplateLayout {
 
     pub fn content_dir(&self) -> PathBuf {
         self.template_dir.join(CONTENT_DIR_NAME)
+    }
+
+    pub fn snippets_dir(&self) -> PathBuf {
+        self.metadata_dir().join(SNIPPETS_DIR_NAME)
     }
 }

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -25,13 +25,17 @@ pub struct Template {
     content_dir: Option<PathBuf>, // TODO: maybe always need a spin.toml file in there?
 }
 
+/// The variant mode in which a template should be run.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum TemplateVariantKind {
+    /// Create a new application from the template.
     NewApplication,
+    /// Create a new component in an existing application from the template.
     AddComponent,
 }
 
 impl TemplateVariantKind {
+    /// A human-readable description of the variant.
     pub fn description(&self) -> &'static str {
         match self {
             Self::NewApplication => "new application",
@@ -158,6 +162,7 @@ impl Template {
         &self.snippets_dir
     }
 
+    /// Checks if the template supports the specified variant mode.
     pub fn supports_variant(&self, variant: &TemplateVariantKind) -> bool {
         self.variants.contains_key(variant)
     }

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{anyhow, Context};
 use indexmap::IndexMap;
@@ -7,7 +7,7 @@ use regex::Regex;
 use crate::{
     constraints::StringConstraints,
     custom_filters::CustomFilterParser,
-    reader::{RawCustomFilter, RawParameter, RawTemplateManifest},
+    reader::{RawCustomFilter, RawParameter, RawTemplateManifest, RawTemplateVariant},
     run::{Run, RunOptions},
     store::TemplateLayout,
 };
@@ -17,9 +17,40 @@ use crate::{
 pub struct Template {
     id: String,
     description: Option<String>,
+    trigger: TemplateTriggerCompatibility,
+    variants: HashMap<TemplateVariantKind, TemplateVariant>,
     parameters: Vec<TemplateParameter>,
     custom_filters: Vec<CustomFilterParser>,
+    snippets_dir: Option<PathBuf>,
     content_dir: Option<PathBuf>, // TODO: maybe always need a spin.toml file in there?
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum TemplateVariantKind {
+    NewApplication,
+    AddComponent,
+}
+
+impl TemplateVariantKind {
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::NewApplication => "new application",
+            Self::AddComponent => "add component",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TemplateVariant {
+    skip_files: Vec<String>,
+    skip_parameters: Vec<String>,
+    snippets: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub(crate) enum TemplateTriggerCompatibility {
+    Any,
+    Only(String),
 }
 
 #[derive(Clone, Debug)]
@@ -58,12 +89,21 @@ impl Template {
             None
         };
 
+        let snippets_dir = if layout.snippets_dir().exists() {
+            Some(layout.snippets_dir())
+        } else {
+            None
+        };
+
         let template = match raw {
             RawTemplateManifest::V1(raw) => Self {
                 id: raw.id.clone(),
                 description: raw.description.clone(),
+                trigger: Self::parse_trigger_type(raw.trigger_type, layout),
+                variants: Self::parse_template_variants(raw.add_component),
                 parameters: Self::parse_parameters(&raw.parameters)?,
                 custom_filters: Self::load_custom_filters(layout, &raw.custom_filters)?,
+                snippets_dir,
                 content_dir,
             },
         };
@@ -92,8 +132,14 @@ impl Template {
         }
     }
 
-    pub(crate) fn parameters(&self) -> impl Iterator<Item = &TemplateParameter> {
-        self.parameters.iter()
+    pub(crate) fn parameters(
+        &self,
+        variant_kind: &TemplateVariantKind,
+    ) -> impl Iterator<Item = &TemplateParameter> {
+        let variant = self.variants.get(variant_kind).unwrap(); // TODO: for now
+        self.parameters
+            .iter()
+            .filter(|p| !variant.skip_parameter(p))
     }
 
     pub(crate) fn parameter(&self, name: impl AsRef<str>) -> Option<&TemplateParameter> {
@@ -108,12 +154,68 @@ impl Template {
         &self.content_dir
     }
 
+    pub(crate) fn snippets_dir(&self) -> &Option<PathBuf> {
+        &self.snippets_dir
+    }
+
+    pub fn supports_variant(&self, variant: &TemplateVariantKind) -> bool {
+        self.variants.contains_key(variant)
+    }
+
+    pub(crate) fn snippets(&self, variant_kind: &TemplateVariantKind) -> &HashMap<String, String> {
+        let variant = self.variants.get(variant_kind).unwrap(); // TODO: for now
+        &variant.snippets
+    }
+
     /// Creates a runner for the template, governed by the given options. Call
     /// the relevant associated function of the `Run` to execute the template
     /// as appropriate to your application (e.g. `interactive()` to prompt the user
     /// for values and interact with the user at the console).
     pub fn run(self, options: RunOptions) -> Run {
         Run::new(self, options)
+    }
+
+    fn parse_trigger_type(
+        raw: Option<String>,
+        layout: &TemplateLayout,
+    ) -> TemplateTriggerCompatibility {
+        match raw {
+            None => Self::infer_trigger_type(layout),
+            Some(t) => TemplateTriggerCompatibility::Only(t),
+        }
+    }
+
+    fn infer_trigger_type(layout: &TemplateLayout) -> TemplateTriggerCompatibility {
+        match crate::app_info::AppInfo::from_layout(layout) {
+            Some(Ok(app_info)) => {
+                TemplateTriggerCompatibility::Only(app_info.trigger_type().to_owned())
+            }
+            _ => TemplateTriggerCompatibility::Any, // Fail forgiving
+        }
+    }
+
+    fn parse_template_variants(
+        add_component: Option<RawTemplateVariant>,
+    ) -> HashMap<TemplateVariantKind, TemplateVariant> {
+        let mut variants = HashMap::default();
+        // TODO: in future we might have component-only templates
+        variants.insert(
+            TemplateVariantKind::NewApplication,
+            TemplateVariant::default(),
+        );
+        if let Some(ac) = add_component {
+            let vt = Self::parse_template_variant(ac);
+            variants.insert(TemplateVariantKind::AddComponent, vt);
+        }
+        variants
+    }
+
+    fn parse_template_variant(raw: RawTemplateVariant) -> TemplateVariant {
+        TemplateVariant {
+            skip_files: raw.skip_files.unwrap_or_default(),
+            skip_parameters: raw.skip_parameters.unwrap_or_default(),
+            snippets: raw.snippets.unwrap_or_default(),
+        }
     }
 
     fn parse_parameters(
@@ -147,6 +249,32 @@ impl Template {
     ) -> anyhow::Result<CustomFilterParser> {
         let wasm_path = layout.filter_path(&raw.wasm);
         CustomFilterParser::load(&raw.name, &wasm_path)
+    }
+
+    pub(crate) fn included_files(
+        &self,
+        base: &std::path::Path,
+        all_files: Vec<PathBuf>,
+        variant_kind: &TemplateVariantKind,
+    ) -> Vec<PathBuf> {
+        let variant = self.variants.get(variant_kind).unwrap(); // TODO: for now
+        all_files
+            .into_iter()
+            .filter(|path| !variant.skip_file(base, path))
+            .collect()
+    }
+
+    pub(crate) fn check_compatible_trigger(&self, app_trigger: &str) -> anyhow::Result<()> {
+        match &self.trigger {
+            TemplateTriggerCompatibility::Any => Ok(()),
+            TemplateTriggerCompatibility::Only(t) => {
+                if app_trigger == t {
+                    Ok(())
+                } else {
+                    Err(anyhow!("Component trigger type '{t}' does not match application trigger type '{app_trigger}'"))
+                }
+            }
+        }
     }
 }
 
@@ -195,6 +323,19 @@ impl TemplateParameterDataType {
         match self {
             TemplateParameterDataType::String(constraints) => constraints.validate(value),
         }
+    }
+}
+
+impl TemplateVariant {
+    pub(crate) fn skip_file(&self, base: &std::path::Path, path: &std::path::Path) -> bool {
+        self.skip_files
+            .iter()
+            .map(|s| base.join(s))
+            .any(|f| path == f)
+    }
+
+    pub(crate) fn skip_parameter(&self, parameter: &TemplateParameter) -> bool {
+        self.skip_parameters.iter().any(|p| &parameter.id == p)
     }
 }
 

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -2,9 +2,15 @@ use anyhow::Error;
 use clap::{CommandFactory, Parser, Subcommand};
 use lazy_static::lazy_static;
 use spin_cli::commands::{
-    bindle::BindleCommands, build::BuildCommand, deploy::DeployCommand,
-    external::execute_external_subcommand, login::LoginCommand, new::NewCommand,
-    plugins::PluginCommands, templates::TemplateCommands, up::UpCommand,
+    bindle::BindleCommands,
+    build::BuildCommand,
+    deploy::DeployCommand,
+    external::execute_external_subcommand,
+    login::LoginCommand,
+    new::{AddCommand, NewCommand},
+    plugins::PluginCommands,
+    templates::TemplateCommands,
+    up::UpCommand,
 };
 use spin_http::HttpTrigger;
 use spin_redis_engine::RedisTrigger;
@@ -39,6 +45,7 @@ enum SpinApp {
     #[clap(subcommand)]
     Templates(TemplateCommands),
     New(NewCommand),
+    Add(AddCommand),
     Up(UpCommand),
     #[clap(subcommand)]
     Bindle(BindleCommands),
@@ -66,6 +73,7 @@ impl SpinApp {
             Self::Templates(cmd) => cmd.run().await,
             Self::Up(cmd) => cmd.run().await,
             Self::New(cmd) => cmd.run().await,
+            Self::Add(cmd) => cmd.run().await,
             Self::Bindle(cmd) => cmd.run().await,
             Self::Deploy(cmd) => cmd.run().await,
             Self::Build(cmd) => cmd.run().await,

--- a/templates/http-empty/content/spin.toml
+++ b/templates/http-empty/content/spin.toml
@@ -1,0 +1,6 @@
+spin_version = "1"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+name = "{{project-name}}"
+trigger = { type = "http", base = "{{http-base}}" }
+version = "0.1.0"

--- a/templates/http-empty/metadata/spin-template.toml
+++ b/templates/http-empty/metadata/spin-template.toml
@@ -1,0 +1,7 @@
+manifest_version = "1"
+id = "http-empty"
+description = "HTTP application with no components"
+
+[parameters]
+project-description = { type = "string",  prompt = "Project description", default = "" }
+http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }

--- a/templates/http-go/metadata/snippets/component.txt
+++ b/templates/http-go/metadata/snippets/component.txt
@@ -1,0 +1,8 @@
+[[component]]
+id = "{{project-name | kebab_case}}"
+source = "{{ output-path }}/main.wasm"
+[component.trigger]
+route = "{{http-path}}"
+[component.build]
+command = "tinygo build -wasm-abi=generic -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+workdir = "{{ output-path }}"

--- a/templates/http-go/metadata/spin-template.toml
+++ b/templates/http-go/metadata/spin-template.toml
@@ -2,6 +2,12 @@ manifest_version = "1"
 id = "http-go"
 description = "HTTP request handler using (Tiny)Go"
 
+[add_component]
+skip_files = ["spin.toml"]
+skip_parameters = ["http-base"]
+[add_component.snippets]
+component = "component.txt"
+
 [parameters]
 project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }

--- a/templates/http-rust/metadata/snippets/component.txt
+++ b/templates/http-rust/metadata/snippets/component.txt
@@ -1,0 +1,8 @@
+[[component]]
+id = "{{project-name | kebab_case}}"
+source = "{{ output-path }}/target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
+[component.trigger]
+route = "{{http-path}}"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+workdir = "{{ output-path }}"

--- a/templates/http-rust/metadata/spin-template.toml
+++ b/templates/http-rust/metadata/spin-template.toml
@@ -2,6 +2,12 @@ manifest_version = "1"
 id = "http-rust"
 description = "HTTP request handler using Rust"
 
+[add_component]
+skip_files = ["spin.toml"]
+skip_parameters = ["http-base"]
+[add_component.snippets]
+component = "component.txt"
+
 [parameters]
 project-description = { type = "string",  prompt = "Project description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }


### PR DESCRIPTION
This updates the templates system to allow for adding a component to an existing application as well as creating a new application.

Here's how it looks in use:

```
ivan@hecate:~/testing$ spin new http-empty compytest
Project description:
HTTP base: /

ivan@hecate:~/testing$ cd compytest/

ivan@hecate:~/testing/compytest$ spin new http-rust hello
Project description:
HTTP path: /hello

ivan@hecate:~/testing/compytest$ spin new http-rust goodbye
Project description:
HTTP path: /goodbye

ivan@hecate:~/testing/compytest$ code .
# ... build spiffy application ...

ivan@hecate:~/testing/compytest$ spin build
# ... Rust compiler spew ...

ivan@hecate:~/testing/compytest$ spin up
Serving http://127.0.0.1:3000
Available Routes:
  hello: http://127.0.0.1:3000/hello
  goodbye: http://127.0.0.1:3000/goodbye
```

The template has to support the feature - so far I've only done it for `http-rust` but if we're happy with the design then I'll do it for the others.

A few things that I'd particularly keen to hear thoughts on:

1. Should we try to make it so this Just Works without requiring the incantations in the templates?  This would simplify template development and maintenance but would require much more knowledge of Spin file formats baked into the templating code.
2. Is there a simpler way to approach the structure?  I want to re-assess where various bits of code have landed but at the moment I feel l have too many things doing similar jobs or with similar names.
3. Does the "add or create new" inference look right or should I provide an explicit override a la `spin new --add`?

Thanks!

ETA: oh yeah I need to write some tests too