### PR TITLE
Get Wasm modules from Web URLs

### DIFF
--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -137,6 +137,8 @@ pub enum RawModuleSource {
     FileReference(PathBuf),
     /// Reference to a remote bindle
     Bindle(FileComponentBindleSource),
+    /// Reference to a Wasm file at a URL
+    Url(FileComponentUrlSource),
 }
 
 /// A component source from Bindle.
@@ -150,4 +152,14 @@ pub struct FileComponentBindleSource {
     pub reference: String,
     /// Parcel to use from the bindle.
     pub parcel: String,
+}
+/// A component source from a URL.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct FileComponentUrlSource {
+    /// The URL of the Wasm binary.
+    pub url: String,
+    /// The digest of the Wasm binary, used for integrity checking. This must be a
+    /// SHA256 digest, in the form `sha256:...`
+    pub digest: String,
 }

--- a/crates/loader/tests/valid-manifest.toml
+++ b/crates/loader/tests/valid-manifest.toml
@@ -23,3 +23,11 @@ parcel = "parcel"
 reference = "bindle reference"
 [component.trigger]
 route = "/test"
+
+[[component]]
+id = "web"
+[component.source]
+url = "https://example.com/wasm.wasm.wasm"
+digest = "sha256:12345"
+[component.trigger]
+route = "/dont/test"

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -441,6 +441,7 @@ impl DeployCommand {
                     copy(&mut r, &mut sha256)?;
                 }
                 config::RawModuleSource::Bindle(_b) => {}
+                config::RawModuleSource::Url(us) => sha256.update(us.digest.as_bytes()),
             }
             if let Some(files) = &x.wasm.files {
                 let source_dir = crate::app_dir(&self.app)?;

--- a/tests/http/assets-test/config/site.toml
+++ b/tests/http/assets-test/config/site.toml
@@ -1,0 +1,9 @@
+title = "Test"
+base_url = "http://localhost:3000"
+about = "This site is generated with Bartholomew, the Spin micro-CMS. And this message is in site.toml."
+theme = "fermyon"
+index_site_pages = ["main"]
+enable_shortcodes = false
+
+[extra]
+copyright = "The Site Authors"

--- a/tests/http/assets-test/content/index.md
+++ b/tests/http/assets-test/content/index.md
@@ -1,0 +1,4 @@
+title = "Test"
+template = "home"
+date = "2022-10-15T00:22:56Z"
+---

--- a/tests/http/assets-test/spin.toml
+++ b/tests/http/assets-test/spin.toml
@@ -5,6 +5,13 @@ trigger = {type = "http", base = "/"}
 version = "1.0.0"
 
 [[component]]
+source = { url = "https://github.com/fermyon/bartholomew/releases/download/v0.6.0/bartholomew.wasm", digest = "sha256:b64bc17da4484ff7fee619ba543f077be69b3a1f037506e0eeee1fb020d42786" }
+id = "bartholomew"
+files = [ "content/**/*" , "templates/*", "config/*"]
+[component.trigger]
+route = "/..."
+
+[[component]]
 id = "fs"
 # should we just use git submodules to avoid having binary test files here?
 source = "spin_static_fs.wasm"

--- a/tests/http/assets-test/templates/home.hbs
+++ b/tests/http/assets-test/templates/home.hbs
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <div>
+      <h1>Hello</h1>
+    </div>
+  </body>
+</html>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -175,6 +175,9 @@ mod integration_tests {
             let s = SpinTestController::with_bindle(RUST_HTTP_STATIC_ASSETS_REST_REF, &b.url, &[])
                 .await?;
 
+            assert_status(&s, "/", 200).await?;
+            assert_response_contains(&s, "/", "<h1>Hello</h1>").await?;
+
             assert_status(&s, "/static/thisshouldbemounted/1", 200).await?;
             assert_status(&s, "/static/thisshouldbemounted/2", 200).await?;
             assert_status(&s, "/static/thisshouldbemounted/3", 200).await?;
@@ -662,6 +665,9 @@ mod integration_tests {
         )
         .await?;
 
+        assert_status(&s, "/", 200).await?;
+        assert_response_contains(&s, "/", "<h1>Hello</h1>").await?;
+
         assert_status(&s, "/static/thisshouldbemounted/1", 200).await?;
         assert_status(&s, "/static/thisshouldbemounted/2", 200).await?;
         assert_status(&s, "/static/thisshouldbemounted/3", 200).await?;
@@ -802,6 +808,27 @@ mod integration_tests {
             .await
             .expect("read body");
         assert_eq!(status, expected, "{}", String::from_utf8_lossy(&body));
+
+        Ok(())
+    }
+
+    async fn assert_response_contains(
+        s: &SpinTestController,
+        absolute_uri: &str,
+        expected: &str,
+    ) -> Result<()> {
+        let res = req(s, absolute_uri).await?;
+        let body = hyper::body::to_bytes(res.into_body())
+            .await
+            .expect("read body");
+        let body_text =
+            String::from_utf8(body.into_iter().collect()).expect("convert body to string");
+        assert!(
+            body_text.contains(expected),
+            "expected to contain {}, got {}",
+            expected,
+            body_text
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #393.

Currently a proof of concept, needs tidying, testing and error handling, plus re-assessing against the requirements in #610 (e.g. should support SHA512, redirects, caching, `file:` URL support, making the digest optional).

Also note this uses a `url/digest` object instead of overloading the string form of `component.source` as proposed in #610.  This isn't a breaking change and is similar to the way we specify parcel sources.

I ported the `bartholomew` component of `fermyon/developer` to exercise it and this is what it ends up looking like:

```
[[component]]
source = { url = "https://github.com/fermyon/bartholomew/releases/download/v0.6.0/bartholomew.wasm", digest = "sha256:b64bc17da4484ff7fee619ba543f077be69b3a1f037506e0eeee1fb020d42786" }
id = "bartholomew"
files = [ "content/**/*" , "templates/*", "scripts/*", "config/*", "shortcodes/*"]
[component.trigger]
route = "/..."
```

I also deployed it to cloud so it looks like it works correctly with bindling, but again, that needs more (and more methodical) testing.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>