### PR TITLE
Require raw app manifest to be valid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,7 +4258,6 @@ dependencies = [
  "futures",
  "itertools",
  "mime_guess",
- "path-absolutize",
  "reqwest",
  "semver 1.0.14",
  "serde",

--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -216,3 +216,26 @@ async fn test_invalid_url_in_allowed_http_hosts_is_rejected() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_invalid_url_in_allowed_http_hosts_is_rejected_raw() -> Result<()> {
+    let app_file = Path::new("tests/invalid-url-in-allowed-http-hosts.toml");
+    let manifest = raw_manifest_from_file(&app_file).await;
+
+    assert!(
+        manifest.is_err(),
+        "Expected allowed_http_hosts parsing error"
+    );
+
+    let e = manifest.unwrap_err().to_string();
+    assert!(
+        e.contains("ftp://some-random-api.ml"),
+        "Expected allowed_http_hosts parse error to contain `ftp://some-random-api.ml`"
+    );
+    assert!(
+        e.contains("example.com/wib/wob"),
+        "Expected allowed_http_hosts parse error to contain `example.com/wib/wob`"
+    );
+
+    Ok(())
+}

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -11,7 +11,6 @@ dunce = "1.0"
 futures = "0.3.14"
 itertools = "0.10.3"
 mime_guess = { version = "2.0" }
-path-absolutize = "3.0.11"
 reqwest = "0.11"
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/publish/src/expander.rs
+++ b/crates/publish/src/expander.rs
@@ -3,12 +3,11 @@
 use crate::bindle_writer::{self, ParcelSources};
 use anyhow::{Context, Result};
 use bindle::{BindleSpec, Condition, Group, Invoice, Label, Parcel};
-use path_absolutize::Absolutize;
 use semver::BuildMetadata;
 use spin_loader::{
     bindle::config as bindle_schema,
     digest::{bytes_sha256_string, file_sha256_string},
-    local::{config as local_schema, validate_raw_app_manifest},
+    local::config as local_schema,
 };
 use std::path::{Path, PathBuf};
 
@@ -18,13 +17,8 @@ pub async fn expand_manifest(
     buildinfo: Option<BuildMetadata>,
     scratch_dir: impl AsRef<Path>,
 ) -> Result<(Invoice, ParcelSources)> {
-    let app_file = app_file
-        .as_ref()
-        .absolutize()
-        .context("Failed to resolve absolute path to manifest file")?;
-    let manifest = spin_loader::local::raw_manifest_from_file(&app_file).await?;
-    validate_raw_app_manifest(&manifest)?;
-    let local_schema::RawAppManifestAnyVersion::V1(manifest) = manifest;
+    let local_schema::RawAppManifestAnyVersion::V1(manifest) =
+        spin_loader::local::raw_manifest_from_file(&app_file).await?;
     let app_dir = app_dir(&app_file)?;
 
     // * create a new spin.toml-like document where


### PR DESCRIPTION
Previously, raw app manifest was validated explicitly during the app publishing/load. Running validations automatically in the loader looks like a safer approach.

From the user's perspective, from now on, the invalid manifest will make the build to fail (as well as `spin up`, `spin bindle prepare/push`, `spin deploy`):

```
$ spin build
Error: One or more allowed_http_hosts entries was invalid: ftp://some-random-api.ml
isn't a valid host or host:port string example.com/wib/wob contains a path, should
be host and optional port only
```

Signed-off-by: Konstantin Shabanov <mail@etehtsea.me>