### PR TITLE
chore: Use workspace inheritence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "http",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "spin-core",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "redis",
@@ -4006,7 +4006,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-abi-conformance"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "spin-publish"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bindle",
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "http",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,21 @@
 [package]
 name = "spin-cli"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = "Apache-2.0 WITH LLVM-exception"
+rust-version = "1.64"
+
+[workspace.package]
 version = "0.6.0"
-edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
 atty = "0.2"
-bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-features = false, features = ["client"] }
+bindle = { workspace = true }
 bytes = "1.1"
 chrono = "0.4"
 clap = { version = "3.1.15", features = ["derive", "env"] }
@@ -55,7 +62,7 @@ tracing = { version = "0.1", features = [ "log" ] }
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 url = "2.2.2"
 uuid = "^1.0"
-wasmtime = "0.39.1"
+wasmtime = { workspace = true }
 webbrowser = "0.7.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -99,6 +106,23 @@ members = [
     "sdk/rust",
     "sdk/rust/macro"
 ]
+
+[workspace.dependencies]
+wasi-cap-std-sync = "0.39.1"
+wasi-common = "0.39.1"
+wasmtime = "0.39.1"
+wasmtime-wasi = { version = "0.39.1", features = ["tokio"] }
+
+[workspace.dependencies.bindle]
+git = "https://github.com/fermyon/bindle"
+tag = "v0.8.2"
+default-features = false
+features = ["client"]
+
+[workspace.dependencies.wit-bindgen-wasmtime]
+git = "https://github.com/bytecodealliance/wit-bindgen"
+rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+features = ["async"]
 
 [[bin]]
 name = "spin"

--- a/crates/abi-conformance/Cargo.toml
+++ b/crates/abi-conformance/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "spin-abi-conformance"
-version = "0.5.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0.44"
+cap-std = "0.25.2"
 clap = { version = "3.1.15", features = ["derive", "env"] }
-serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0.82"
-wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
-wasmtime = "0.39.1"
-wasmtime-wasi = "0.39.1"
-wasi-common = "0.39.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_core = "0.6.3"
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0.82"
 tempfile = "3.3.0"
-cap-std = "0.25.2"
 toml = "0.5.9"
+wasi-common = { workspace = true }
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
+wit-bindgen-wasmtime = { workspace = true }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "spin-app"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-build"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0.57"

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cloud"
-version = "0.1.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-config"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
@@ -15,11 +15,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 vaultrs = "0.6.2"
 serde = "1.0.145"
-
-[dependencies.wit-bindgen-wasmtime]
-git = "https://github.com/bytecodealliance/wit-bindgen"
-rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
-features = ["async"]
+wit-bindgen-wasmtime = { workspace = true }
 
 [dev-dependencies]
 toml = "0.5"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "spin-core"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
 tracing = "0.1"
 async-trait = "0.1"
-wasi-cap-std-sync = "0.39"
-wasi-common = "0.39"
-wasmtime = "0.39"
-wasmtime-wasi = { version = "0.39", features = ["tokio"] }
+wasi-cap-std-sync = { workspace = true }
+wasi-common = { workspace = true }
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-http"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false
@@ -30,11 +30,7 @@ tls-listener = { version = "0.4.0", features = [
 tokio = { version = "1.10", features = ["full"] }
 tokio-rustls = { version = "0.23.2" }
 tracing = { version = "0.1", features = ["log"] }
-
-[dependencies.wit-bindgen-wasmtime]
-git = "https://github.com/bytecodealliance/wit-bindgen"
-rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
-features = ["async"]
+wit-bindgen-wasmtime = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio"] }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "spin-loader"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.52"
-bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-features = false, features = ["client"] }
+bindle = { workspace = true }
 bytes = "1.1.0"
 futures = "0.3.17"
 glob = "0.3.0"

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-manifest"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "outbound-http"
-version = "0.2.0"
-edition = "2021"
-authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false
@@ -15,9 +15,4 @@ spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 tracing = { version = "0.1", features = [ "log" ] }
 url = "2.2.1"
-
-[dependencies.wit-bindgen-wasmtime]
-git = "https://github.com/bytecodealliance/wit-bindgen"
-rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
-features = ["async"]
-
+wit-bindgen-wasmtime = { workspace = true }

--- a/crates/outbound-pg/Cargo.toml
+++ b/crates/outbound-pg/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "outbound-pg"
-version = "0.2.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false
@@ -12,8 +13,4 @@ spin-core = { path = "../core" }
 tokio = { version = "1", features = [ "rt-multi-thread" ] }
 tokio-postgres = { version = "0.7.7" }
 tracing = { version = "0.1", features = [ "log" ] }
-
-[dependencies.wit-bindgen-wasmtime]
-git = "https://github.com/bytecodealliance/wit-bindgen"
-rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
-features = ["async"]
+wit-bindgen-wasmtime = { workspace = true }

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "outbound-redis"
-version = "0.2.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false
@@ -12,8 +13,4 @@ redis = { version = "0.21", features = ["tokio-comp"] }
 spin-core = { path = "../core" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["log"] }
-
-[dependencies.wit-bindgen-wasmtime]
-git = "https://github.com/bytecodealliance/wit-bindgen"
-rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
-features = ["async"]
+wit-bindgen-wasmtime = { workspace = true }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "spin-plugins"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "spin-publish"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
-bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-features = false, features = ["client"] }
+bindle = { workspace = true }
 dunce = "1.0"
 futures = "0.3.14"
 itertools = "0.10.3"

--- a/crates/redis/Cargo.toml
+++ b/crates/redis/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-redis-engine"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 doctest = false
@@ -17,11 +17,7 @@ spin-core = { path = "../core" }
 spin-trigger = { path = "../trigger" }
 redis = { version = "0.21", features = [ "tokio-comp" ] }
 tracing = { version = "0.1", features = [ "log" ] }
-
-[dependencies.wit-bindgen-wasmtime]
-git = "https://github.com/bytecodealliance/wit-bindgen"
-rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
-features = ["async"]
+wit-bindgen-wasmtime = { workspace = true }
 
 [dev-dependencies]
 spin-testing = { path = "../testing" }

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-templates"
-version = "0.2.0"
-edition = "2021"
-authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
@@ -35,10 +35,6 @@ tokio = { version = "1.10", features = [ "fs", "process", "rt", "macros" ] }
 toml = "0.5"
 url = "2.2.2"
 walkdir = "2"
-wasmtime = { version = "0.39.1", features = [ "async" ] }
-wasmtime-wasi = "0.39.1"
-
-[dependencies.wit-bindgen-wasmtime]
-git = "https://github.com/bytecodealliance/wit-bindgen"
-rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
-features = ["async"]
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
+wit-bindgen-wasmtime = { workspace = true }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-testing"
-version = "0.2.0"
-edition = "2021"
-authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spin-trigger"
-version = "0.2.0"
-edition = "2021"
-authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
@@ -25,7 +25,7 @@ spin-manifest = { path = "../manifest" }
 toml = "0.5.9"
 tracing = { version = "0.1", features = [ "log" ] }
 url = "2"
-wasmtime = "0.39.1"
+wasmtime = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2021"
 name = "spin-sdk"
-version = "0.6.0"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 name = "spin_sdk"
@@ -11,5 +12,5 @@ anyhow = "1"
 bytes = "1"
 form_urlencoded = "1.0"
 http = "0.2"
-spin-macro = {path = "macro"}
+spin-macro = { path = "macro" }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }


### PR DESCRIPTION
This uses the "workspace inheretance" features introduced in Cargo 1.64 to deduplicate dependency specifications and package info across the workspace.
    
Add package 'license' and 'rust-version' to the workspace root.