### PR TITLE
Bartholomew template

### DIFF
--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -414,7 +414,7 @@ mod tests {
         PathBuf::from(crate_dir).join("tests")
     }
 
-    const TPLS_IN_THIS: usize = 9;
+    const TPLS_IN_THIS: usize = 10;
 
     #[tokio::test]
     async fn can_install_into_new_directory() {

--- a/templates/bartholomew/content/README.md
+++ b/templates/bartholomew/content/README.md
@@ -1,0 +1,31 @@
+# {{ site-title }}
+
+_Built with (Bartholomew)[https://bartholomew.fermyon.dev/], (Fermyon)[https://www.fermyon.com]'s open source micro-CMS._
+
+## Directory Structure:
+
+- `config/site.toml`: The main configuration file for the site. You should edit this.
+- `content/`: Your markdown files go in here.
+- `scripts/` (advanced): If you want to write your owh Rhai scripts, they go here.
+- `spin.toml`: The configuration file for the Spin application.
+- `static/`: Static assets like images, CSS, and downloads go in here.
+- `templates/`: Your handlebars templates go here. 
+
+## Running the site
+
+To start this site, run `spin up`` from this directory.  (If you don't have Spin, you can install it from (here)[https://developer.fermyon.com/spin/install].)
+
+```console
+$ spin up --follow-all
+spin up --follow-all
+Serving HTTP on address http://127.0.0.1:3000
+Available Routes:
+  bartholomew: http://127.0.0.1:3000 (wildcard)
+  fileserver: http://127.0.0.1:3000/static (wildcard)
+```
+
+Now you can point your web browser to `http://localhost:3000/` and see your Bartholomew site.
+
+## Publishing this site
+
+You can publish this site to (Fermyon Cloud)[https://developer.fermyon.com/cloud/index] by running `spin deploy`.

--- a/templates/bartholomew/content/config/site.toml
+++ b/templates/bartholomew/content/config/site.toml
@@ -1,0 +1,13 @@
+title = "{{ site-title }}"
+# logo = "URL to logo"
+base_url = "http://localhost:3000{{ http-base }}"
+about = "This site is generated with Bartholomew, the WebAssembly micro-CMS. And this message is in site.toml."
+index_site_pages = ["blog"]
+
+[extra]
+copyright = "{{ authors }}"
+# Add or edit site metadata
+# github = "https://github.com/fermyon"
+# twitter = "https://twitter.com/fermyontech"
+
+date_style = "%B %e, %Y"

--- a/templates/bartholomew/content/content/blog.md
+++ b/templates/bartholomew/content/content/blog.md
@@ -1,0 +1,6 @@
+title = "Your new blog"
+description = "All you need to know to get started with Bartholomew"
+template = "blog"
+date = "2021-12-23T17:05:19Z"
+---
+An example page for setting up a blog.  See https://bartholomew.fermyon.dev/ for more about how this works.

--- a/templates/bartholomew/content/content/index.md
+++ b/templates/bartholomew/content/content/index.md
@@ -1,0 +1,29 @@
+# This is the preamble, and it is written in TOML format.
+# In this section, you set information about the page, like title, description, and the template
+# that should be used to render the content.
+
+# REQUIRED
+
+# The title of the document
+title = "{{ site-title }}"
+
+# OPTIONAL
+
+# The description of the page.
+description = "Built using Bartholomew, the Micro-CMS for WebAssembly and Spin"
+
+# The name of the template to use. `templates/` is automatically prepended, and `.hbs` is appended.
+# So if you set this to `blog`, it becomes `templates/blog.hbs`.
+template = "main"
+
+# These fields are user-definable. You can create whatever values you want
+# here. The format must be `string` keys with `string` values, though.
+[extra]
+date = "Nov. 15, 2021"
+
+# Anything after this line is considered Markdown content
+---
+
+This is an example home page written in _Markdown_.
+
+You can find this text in `content/index.md`.

--- a/templates/bartholomew/content/modules/LICENSE.bartholomew
+++ b/templates/bartholomew/content/modules/LICENSE.bartholomew
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/templates/bartholomew/content/modules/LICENSE.spin_static_fs
+++ b/templates/bartholomew/content/modules/LICENSE.spin_static_fs
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright (c) Fermyon Technologies. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/templates/bartholomew/content/scripts/blogs.rhai
+++ b/templates/bartholomew/content/scripts/blogs.rhai
@@ -1,0 +1,35 @@
+// This function lists all of the blog posts, subject to the constraints.
+// It assumes you have a `content/blog` subdirectory, and every file in there
+// is treated like a blog post.
+//
+// It returns an array of objects of the form:
+//  [
+//    #{ uri: "path/to/page", page: PageObject }
+// ]
+
+// Param 1 should be `site.pages`
+let pages = params[0];
+
+// Loop through them and return all of the page objects that are in
+// the blog path.
+
+let blog_pages = [];
+
+// Get each blog post, assigning it to {path: object}.
+let keys = pages.keys();
+for item in keys {
+    if item.index_of("/content/blog/") == 0 {
+        // Remove /content and .md
+        let path = item.sub_string(8);
+        path = path.sub_string(0, path.index_of(".md"));
+        blog_pages.push(#{
+            uri: path,
+            page: pages[item],
+        });
+        //blog_pages[path] = pages[item];
+    }
+   
+}
+// Newest to oldest, assuming you put the date in the URI
+blog_pages.reverse();
+blog_pages

--- a/templates/bartholomew/content/scripts/get_page.rhai
+++ b/templates/bartholomew/content/scripts/get_page.rhai
@@ -1,0 +1,19 @@
+// This gets a page path from its `md`  filename.
+// `page /content/index.md site.pages` will return the path to the index file. 
+let target = params[0];
+let pages = params[1];
+
+let page = #{};
+
+for item in pages.keys() {
+    if item == target {
+        let path = item.sub_string(8);
+        path = path.sub_string(0, path.index_of(".md"));
+        page = #{
+            uri: path,
+            page: pages[item],
+        };
+    }
+}
+
+page;

--- a/templates/bartholomew/content/spin.toml
+++ b/templates/bartholomew/content/spin.toml
@@ -1,0 +1,21 @@
+spin_version = "1"
+authors = ["{{authors}}"]
+description = "{{site-title}}"
+name = "{{project-name}}"
+trigger = { type = "http", base = "{{http-base}}" }
+version = "0.1.0"
+
+[[component]]
+source = { url = "https://github.com/fermyon/bartholomew/releases/download/v0.6.0/bartholomew.wasm", digest = "sha256:b64bc17da4484ff7fee619ba543f077be69b3a1f037506e0eeee1fb020d42786" }
+id = "bartholomew"
+files = [ "content/**/*" , "templates/*", "scripts/*", "config/*"]
+[component.trigger]
+route = "/..."
+
+[[component]]
+# TODO: proper release
+source = { url = "https://github.com/itowlson/spin-fileserver/releases/download/v0.0.1-test2/spin_static_fs.wasm", digest = "sha256:731c95d2e80ab898da2fe7efabb3f2115a540f62df730223cdae194874b7d9cf" }
+id = "fileserver"
+files = [ { source = "static/", destination = "/" } ]
+[component.trigger]
+route = "/static/..."

--- a/templates/bartholomew/content/static/example.txt
+++ b/templates/bartholomew/content/static/example.txt
@@ -1,0 +1,4 @@
+This is an example of a static text file.
+
+If you can see this in your browser at `http://localhost:3000/static/example.txt`, then you have
+correctly configured the fileserver.

--- a/templates/bartholomew/content/templates/blog.hbs
+++ b/templates/bartholomew/content/templates/blog.hbs
@@ -1,0 +1,21 @@
+{{> content_top }}
+
+<div class="col-md-8">
+
+    {{#each (blogs site.pages)}}
+    <article class="blog-post">
+        <h1 class="blog-post-title border-bottom">{{page.head.title}}</h1>
+            <p class="blog-post-meta">
+                {{#if page.head.date }}{{date_format ../site.info.extra.date_style page.head.date}} {{/if}}
+                {{#if page.head.extra.author}} by <a
+                    href="{{page.head.extra.author_page}}">{{page.head.extra.author}}</a>{{/if}}
+            </p>
+            {{! Since this is HTML, we use the triple-curly }}
+            {{{page.body}}}
+            <p><a href="{{this.uri}}">View the Post</a></p>
+    </article>
+    {{/each}}
+
+</div><!-- end col -->
+{{> content_sidebar }}
+{{> content_bottom }}

--- a/templates/bartholomew/content/templates/content_bottom.hbs
+++ b/templates/bartholomew/content/templates/content_bottom.hbs
@@ -1,0 +1,12 @@
+{{! See content_top.hbs }}
+</div>
+</main>
+<footer>
+    {{#if site.info.extra.copyright }}
+    <p>&copy; {{site.info.extra.copyright}}</p>
+    {{/if}}
+</footer>
+</div><!-- End main container -->
+</body>
+
+</html>

--- a/templates/bartholomew/content/templates/content_sidebar.hbs
+++ b/templates/bartholomew/content/templates/content_sidebar.hbs
@@ -1,0 +1,19 @@
+<div class="col-md-4">
+    <div class="position-sticky" style="top: 2rem;">
+        <div class="p-4 mb-3 bg-light rounded">
+            <h4 class="fst-italic">About</h4>
+            <p class="mb-0">{{site.info.about}}</p>
+        </div>
+
+        <div class="p-4">
+            <h4 class="fst-italic">Elsewhere</h4>
+            <ol class="list-unstyled">
+                {{#with site.info.extra}}
+                {{#if github }}<li><a href="{{github}}">GitHub</a></li>{{/if}}
+                {{#if twitter }}<li><a href="{{twitter}}">Twitter</a></li>{{/if}}
+                {{#if facebook }}<li><a href="{{facebook}}">Facebook</a></li>{{/if}}
+                {{/with}}
+            </ol>
+        </div>
+    </div>
+</div>

--- a/templates/bartholomew/content/templates/content_top.hbs
+++ b/templates/bartholomew/content/templates/content_top.hbs
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    {{! Use the formatter.title and formatter.description in the head }}
+    <title>{{page.head.title}} | {{site.info.title}}</title>
+    {{#if page.head.description}}
+    {{! Only render the description if it exists }}
+    <meta name="description" content="{{page.head.description}}">
+    {{/if}}
+    <!-- Twitter Bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+    <!-- JavaScript Bundle with Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-U1DAWAznBHeqEIlVSCgzq+c9gqGAJn5c/t99JyeKa9xxaYpSvHU5awsuZVVFIhvj"
+        crossorigin="anonymous"></script>
+
+    <style>
+        /* pretend we have some style */
+        body {
+            margin-top: 1em;
+            margin-left: 5em;
+        }
+
+        nav {
+            margin-bottom: 1em;
+        }
+
+        .learn-more-card-group {
+            margin-top: 2em;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container" id="main-container">
+        {{> navbar }}
+        <main>
+            <div class="row">

--- a/templates/bartholomew/content/templates/main.hbs
+++ b/templates/bartholomew/content/templates/main.hbs
@@ -1,0 +1,21 @@
+{{! This adds the HTML head section and the beginning of the body. See content_top.hbs. }}
+{{> content_top }}
+
+<div class="col-md-8">
+    <article class="blog-post">
+        {{#with page.head}}
+        <h1 class="blog-post-title border-bottom">{{title}}</h2>
+            <p class="blog-post-meta">{{#if extra.date}}Published: {{extra.date}}{{/if}}</p>
+            {{/with}}
+            {{! Since this is HTML, we use the triple-curly }}
+            {{{page.body}}}
+            {{! Remove the `!` on the line below to see how to call a Rhai script }}
+            {{! echo "world" }}
+    </article>
+</div><!-- end col -->
+
+{{! This adds the sidebar }}
+{{> content_sidebar }}
+
+{{! This closes the body. See content_bottom.hbs. }}
+{{> content_bottom }}

--- a/templates/bartholomew/metadata/spin-template.toml
+++ b/templates/bartholomew/metadata/spin-template.toml
@@ -1,0 +1,7 @@
+manifest_version = "1"
+id = "bartholomew"
+description = "Web site using Bartholomew micro-CMS"
+
+[parameters]
+site-title = { type = "string",  prompt = "Title for the site", default = "Unnamed Site" }
+http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }


### PR DESCRIPTION
My thought here is to provide an "add component" version of this so that people can easily add a content-managed component to their Spin applications.  This will hopefully make a nice demo of how Spin facilitates composing applications out of Wasm modules, whether custom or off-the-shelf.

Known issues:

* Does not play nicely with HTTP bases other than root.
* The static fileserver URL currently points to a test release in my fork.

Open question:

* Does this even belong in the Spin default template set, or should it go in the Bartholomew repo and require separate installation?  Or should we avoid having a Spin template that would need to be maintained alongside the GitHub template?  (If we don't want this here or at all, I would at least like to offer a static file server component in the default set - it's a widely useful thing.)

Signed-off-by: itowlson <ivan.towlson@fermyon.com>