### PR TITLE
Introduce spin_loader::local::{absolutize, parent_dir}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,6 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "serde_json",
- "spin-loader",
- "spin-publish",
- "tempfile",
  "tokio",
  "tokio-util 0.7.4",
  "toml",
@@ -4263,7 +4260,6 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "spin-loader",
- "tempfile",
  "tokio",
  "toml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,6 @@ dependencies = [
  "itertools",
  "log",
  "mime_guess",
- "path-absolutize",
  "regex",
  "reqwest",
  "semver 1.0.14",
@@ -4039,7 +4038,6 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "futures",
- "path-absolutize",
  "spin-loader",
  "subprocess",
  "tracing",
@@ -4255,7 +4253,6 @@ dependencies = [
  "futures",
  "itertools",
  "mime_guess",
- "path-absolutize",
  "reqwest",
  "semver 1.0.14",
  "serde",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0.57"
 futures = "0.3.21"
-path-absolutize = "3.0.11"
 spin-loader = { path = "../loader" }
 subprocess = "0.2.8"
 tracing = { version = "0.1", features = [ "log" ] }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -4,17 +4,17 @@
 
 use anyhow::{bail, Context, Result};
 use spin_loader::local::{
-    absolutize,
-    config::{RawAppManifest, RawComponentManifest},
-    parent_dir,
+    config::{RawAppManifestAnyVersion, RawComponentManifest},
+    parent_dir, raw_manifest_from_file,
 };
 use std::path::{Path, PathBuf};
 use subprocess::{Exec, Redirection};
 use tracing::log;
 
 /// If present, run the build command of each component.
-pub async fn build(app: RawAppManifest, src: &Path) -> Result<()> {
-    let src = absolutize(src)?;
+pub async fn build(manifest_file: &Path) -> Result<()> {
+    let RawAppManifestAnyVersion::V1(app) = raw_manifest_from_file(&manifest_file).await?;
+    let app_dir = parent_dir(manifest_file)?;
 
     if app.components.iter().all(|c| c.build.is_none()) {
         println!("No build command found!");
@@ -24,7 +24,7 @@ pub async fn build(app: RawAppManifest, src: &Path) -> Result<()> {
     let results = futures::future::join_all(
         app.components
             .into_iter()
-            .map(|c| build_component(c, &src))
+            .map(|c| build_component(c, &app_dir))
             .collect::<Vec<_>>(),
     )
     .await;
@@ -40,14 +40,14 @@ pub async fn build(app: RawAppManifest, src: &Path) -> Result<()> {
 }
 
 /// Run the build command of the component.
-async fn build_component(raw: RawComponentManifest, src: impl AsRef<Path>) -> Result<()> {
+async fn build_component(raw: RawComponentManifest, app_dir: &Path) -> Result<()> {
     match raw.build {
         Some(b) => {
             println!(
                 "Executing the build command for component {}: {}",
                 raw.id, b.command
             );
-            let workdir = construct_workdir(src.as_ref(), b.workdir.as_ref())?;
+            let workdir = construct_workdir(app_dir, b.workdir.as_ref())?;
             if b.workdir.is_some() {
                 println!("Working directory: {:?}", workdir);
             }
@@ -83,8 +83,8 @@ async fn build_component(raw: RawComponentManifest, src: impl AsRef<Path>) -> Re
 }
 
 /// Constructs the absolute working directory in which to run the build command.
-fn construct_workdir(src: impl AsRef<Path>, workdir: Option<impl AsRef<Path>>) -> Result<PathBuf> {
-    let mut cwd = parent_dir(src)?;
+fn construct_workdir(app_dir: &Path, workdir: Option<impl AsRef<Path>>) -> Result<PathBuf> {
+    let mut cwd = app_dir.to_owned();
 
     if let Some(workdir) = workdir {
         // Using `Path::has_root` as `is_relative` and `is_absolute` have
@@ -94,7 +94,6 @@ fn construct_workdir(src: impl AsRef<Path>, workdir: Option<impl AsRef<Path>>) -
             bail!("The workdir specified in the application file must be relative.");
         }
         cwd.push(workdir);
-        cwd = absolutize(cwd)?;
     }
 
     Ok(cwd)

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -19,7 +19,6 @@ cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi" }
 itertools = "0.10.0"
 log = "0.4"
 mime_guess = { version = "2.0" }
-path-absolutize = "3.0.11"
 regex = "1.5"
 reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -25,9 +25,6 @@ reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-spin-loader = { path = "../loader" }
-spin-publish = { path = "../publish" }
-tempfile = "3.3.0"
 tokio = { version = "1.17", features = ["full"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
 tracing = { version = "0.1", features = [ "log" ] }

--- a/crates/loader/src/bindle/assets.rs
+++ b/crates/loader/src/bindle/assets.rs
@@ -14,6 +14,7 @@ use crate::digest::file_sha256_string;
 use crate::{
     assets::{create_dir, ensure_under},
     bindle::utils::BindleReader,
+    local::parent_dir,
 };
 
 pub(crate) async fn prepare_component(
@@ -88,7 +89,7 @@ impl Copier {
             p.sha256,
             to.display()
         );
-        fs::create_dir_all(to.parent().expect("Cannot copy to file '/'")).await?;
+        fs::create_dir_all(parent_dir(&to).expect("Cannot copy to file '/'")).await?;
         let mut stream = self
             .reader
             .get_parcel_stream(&p.sha256)

--- a/crates/loader/src/local/assets.rs
+++ b/crates/loader/src/local/assets.rs
@@ -1,6 +1,9 @@
 #![deny(missing_docs)]
 
-use crate::assets::{create_dir, ensure_all_under, ensure_under, to_relative};
+use crate::{
+    assets::{create_dir, ensure_all_under, ensure_under, to_relative},
+    local::parent_dir,
+};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use futures::{future, stream, StreamExt};
 use spin_manifest::DirectoryMount;
@@ -206,7 +209,7 @@ async fn copy(file: &FileMount, dir: impl AsRef<Path>) -> Result<()> {
 
     tracing::trace!("Copying asset file '{from:?}' -> '{to:?}'");
 
-    tokio::fs::create_dir_all(to.parent().context("Cannot copy to file '/'")?).await?;
+    tokio::fs::create_dir_all(parent_dir(&to).context("Cannot copy to file '/'")?).await?;
 
     let _ = tokio::fs::copy(&from, &to)
         .await

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -11,7 +11,6 @@ dunce = "1.0"
 futures = "0.3.14"
 itertools = "0.10.3"
 mime_guess = { version = "2.0" }
-path-absolutize = "3.0.11"
 reqwest = "0.11"
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -16,6 +16,5 @@ reqwest = "0.11"
 semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 spin-loader = { path = "../loader" }
-tempfile = "3.3.0"
 tokio = "1.16.1"
 toml = "0.5"

--- a/crates/publish/src/bindle_writer.rs
+++ b/crates/publish/src/bindle_writer.rs
@@ -3,6 +3,7 @@
 use crate::expander::expand_manifest;
 use anyhow::{Context, Result};
 use bindle::{Invoice, Parcel};
+use spin_loader::local::parent_dir;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
@@ -24,7 +25,7 @@ pub async fn prepare_bindle(
             )
         })?;
 
-    let source_dir = crate::app_dir(&app_file)?;
+    let source_dir = parent_dir(&app_file)?;
 
     write(&source_dir, &dest_dir, &invoice, &sources)
         .await

--- a/crates/publish/src/expander.rs
+++ b/crates/publish/src/expander.rs
@@ -13,7 +13,7 @@ use spin_loader::{
 use std::path::{Path, PathBuf};
 
 /// Expands a file-based application manifest to a Bindle invoice.
-pub async fn expand_manifest(
+pub(crate) async fn expand_manifest(
     app_file: impl AsRef<Path>,
     buildinfo: Option<BuildMetadata>,
     scratch_dir: impl AsRef<Path>,
@@ -25,7 +25,7 @@ pub async fn expand_manifest(
     let manifest = spin_loader::local::raw_manifest_from_file(&app_file).await?;
     validate_raw_app_manifest(&manifest)?;
     let local_schema::RawAppManifestAnyVersion::V1(manifest) = manifest;
-    let app_dir = app_dir(&app_file)?;
+    let app_dir = crate::app_dir(&app_file)?;
 
     // * create a new spin.toml-like document where
     //   - each component changes its `files` entry to a group name
@@ -415,20 +415,6 @@ fn bindle_id(
     };
     bindle::Id::try_from(&text)
         .with_context(|| format!("App name and version '{}' do not form a bindle ID", text))
-}
-
-fn app_dir(app_file: impl AsRef<Path>) -> Result<std::path::PathBuf> {
-    let path_buf = app_file
-        .as_ref()
-        .parent()
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Failed to get containing directory for app file '{}'",
-                app_file.as_ref().display()
-            )
-        })?
-        .to_owned();
-    Ok(path_buf)
 }
 
 struct SourcedParcel {

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -8,20 +8,3 @@ mod expander;
 
 pub use bindle_pusher::push_all;
 pub use bindle_writer::prepare_bindle;
-
-use anyhow::Result;
-use std::path::{Path, PathBuf};
-
-pub(crate) fn app_dir(app_file: impl AsRef<Path>) -> Result<PathBuf> {
-    let path_buf = app_file
-        .as_ref()
-        .parent()
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Failed to get containing directory for app file '{}'",
-                app_file.as_ref().display()
-            )
-        })?
-        .to_owned();
-    Ok(path_buf)
-}

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -7,5 +7,21 @@ mod bindle_writer;
 mod expander;
 
 pub use bindle_pusher::push_all;
-pub use bindle_writer::write;
-pub use expander::expand_manifest;
+pub use bindle_writer::prepare_bindle;
+
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn app_dir(app_file: impl AsRef<Path>) -> Result<PathBuf> {
+    let path_buf = app_file
+        .as_ref()
+        .parent()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Failed to get containing directory for app file '{}'",
+                app_file.as_ref().display()
+            )
+        })?
+        .to_owned();
+    Ok(path_buf)
+}

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -68,6 +68,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-rust"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "spin-sdk",
+ "wit-bindgen-rust",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,17 +161,6 @@ dependencies = [
  "form_urlencoded",
  "http",
  "spin-macro",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "spinhelloworld"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "spin-sdk",
  "wit-bindgen-rust",
 ]
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -3,8 +3,6 @@ use std::{ffi::OsString, path::PathBuf};
 use anyhow::Result;
 use clap::Parser;
 
-use spin_loader::local::{config::RawAppManifestAnyVersion, raw_manifest_from_file};
-
 use crate::opts::{APP_CONFIG_FILE_OPT, BUILD_UP_OPT, DEFAULT_MANIFEST_FILE};
 
 use super::up::UpCommand;
@@ -35,9 +33,8 @@ impl BuildCommand {
             .app
             .as_deref()
             .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
-        let RawAppManifestAnyVersion::V1(app) = raw_manifest_from_file(&manifest_file).await?;
 
-        spin_build::build(app, manifest_file).await?;
+        spin_build::build(manifest_file).await?;
 
         if self.up {
             let mut cmd = UpCommand::parse_from(

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -14,7 +14,7 @@ use spin_http::routes::RoutePattern;
 use spin_http::WELL_KNOWN_HEALTH_PATH;
 use spin_loader::bindle::BindleConnectionInfo;
 use spin_loader::local::config::{RawAppManifest, RawAppManifestAnyVersion};
-use spin_loader::local::{assets, config};
+use spin_loader::local::{assets, config, parent_dir};
 use spin_manifest::ApplicationTrigger;
 use spin_manifest::{HttpTriggerConfiguration, TriggerConfig};
 use tokio::fs;
@@ -425,7 +425,7 @@ impl DeployCommand {
 
     async fn compute_buildinfo(&self, cfg: &RawAppManifest) -> Result<BuildMetadata> {
         let mut sha256 = Sha256::new();
-        let app_folder = crate::app_dir(&self.app)?;
+        let app_folder = parent_dir(&self.app)?;
 
         for x in cfg.components.iter() {
             match &x.source {

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -6,9 +6,9 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
-use path_absolutize::Absolutize;
 use tokio::{fs::File, io::AsyncReadExt};
 
+use spin_loader::local::absolutize;
 use spin_templates::{RunOptions, Template, TemplateManager};
 
 /// Scaffold a new application or component based on a template.
@@ -111,17 +111,14 @@ impl FromStr for ParameterValue {
 }
 
 async fn values_from_file(file: impl AsRef<Path>) -> Result<HashMap<String, String>> {
-    let file = file
-        .as_ref()
-        .absolutize()
-        .context("Failed to resolve absolute path to values file")?;
+    let file = absolutize(file)?;
 
     let mut buf = vec![];
-    File::open(file.as_ref())
+    File::open(&file)
         .await?
         .read_to_end(&mut buf)
         .await
-        .with_context(|| anyhow!("Cannot read values file from {:?}", file.as_ref()))?;
+        .with_context(|| anyhow!("Cannot read values file from {:?}", file))?;
 
     toml::from_slice(&buf).context("Failed to deserialize values file")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,24 +2,8 @@ pub mod commands;
 pub(crate) mod opts;
 mod sloth;
 
-use std::path::{Path, PathBuf};
-
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use semver::BuildMetadata;
-
-pub(crate) fn app_dir(app_file: impl AsRef<Path>) -> Result<PathBuf> {
-    let path_buf = app_file
-        .as_ref()
-        .parent()
-        .ok_or_else(|| {
-            anyhow!(
-                "Failed to get containing directory for app file '{}'",
-                app_file.as_ref().display()
-            )
-        })?
-        .to_owned();
-    Ok(path_buf)
-}
 
 pub(crate) fn parse_buildinfo(buildinfo: &str) -> Result<BuildMetadata> {
     Ok(BuildMetadata::new(buildinfo)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,6 @@ pub(crate) fn app_dir(app_file: impl AsRef<Path>) -> Result<PathBuf> {
     Ok(path_buf)
 }
 
-pub(crate) fn write_failed_msg(bindle_id: &bindle::Id, dest_dir: &Path) -> String {
-    format!(
-        "Failed to write bindle '{}' to {}",
-        bindle_id,
-        dest_dir.display()
-    )
-}
-
 pub(crate) fn parse_buildinfo(buildinfo: &str) -> Result<BuildMetadata> {
     Ok(BuildMetadata::new(buildinfo)?)
 }


### PR DESCRIPTION
Extract repetitive patterns into fns. Probably this isn't the best
place to put them, but there is no decision about the introduction
of some util-like library.

Rebased against https://github.com/fermyon/spin/pull/887 which is approved but not merged yet
Please review these commits:
 - c0a9b8db25bb42d89311735c554a8df1c012435d
 - e51367d88b2178d2219c64c2b753e6aa138f80d8