### PR TITLE
Templates for static fileserver and redirect

### DIFF
--- a/crates/templates/src/filters.rs
+++ b/crates/templates/src/filters.rs
@@ -85,3 +85,38 @@ impl Filter for SnakeCaseFilter {
         Ok(input.to_value())
     }
 }
+
+#[derive(Clone, liquid_derive::ParseFilter, liquid_derive::FilterReflection)]
+#[filter(
+    name = "http_wildcard",
+    description = "Add Spin HTTP wildcard suffix (/...) if needed.",
+    parsed(HttpWildcardFilter)
+)]
+pub(crate) struct HttpWildcardFilterParser;
+
+#[derive(Debug, Default, liquid_derive::Display_filter)]
+#[name = "http_wildcard"]
+struct HttpWildcardFilter;
+
+impl Filter for HttpWildcardFilter {
+    fn evaluate(
+        &self,
+        input: &dyn ValueView,
+        _runtime: &dyn Runtime,
+    ) -> Result<liquid::model::Value, liquid_core::error::Error> {
+        let input = input
+            .as_scalar()
+            .ok_or_else(|| liquid_core::error::Error::with_msg("String expected"))?;
+
+        let route = input.into_string().to_string();
+        let wildcard_route = if route.ends_with("/...") {
+            route
+        } else if route.ends_with('/') {
+            format!("{route}...")
+        } else {
+            format!("{route}/...")
+        };
+
+        Ok(wildcard_route.to_value())
+    }
+}

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -414,7 +414,7 @@ mod tests {
         PathBuf::from(crate_dir).join("tests")
     }
 
-    const TPLS_IN_THIS: usize = 9;
+    const TPLS_IN_THIS: usize = 11;
 
     #[tokio::test]
     async fn can_install_into_new_directory() {

--- a/crates/templates/src/reader.rs
+++ b/crates/templates/src/reader.rs
@@ -18,6 +18,7 @@ pub(crate) struct RawTemplateManifestV1 {
     pub id: String,
     pub description: Option<String>,
     pub trigger_type: Option<String>,
+    pub new_application: Option<RawTemplateVariant>,
     pub add_component: Option<RawTemplateVariant>,
     pub parameters: Option<IndexMap<String, RawParameter>>,
     pub custom_filters: Option<Vec<RawCustomFilter>>,
@@ -26,6 +27,7 @@ pub(crate) struct RawTemplateManifestV1 {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) struct RawTemplateVariant {
+    pub supported: Option<bool>,
     pub skip_files: Option<Vec<String>>,
     pub skip_parameters: Option<Vec<String>>,
     pub snippets: Option<HashMap<String, String>>,

--- a/crates/templates/src/run.rs
+++ b/crates/templates/src/run.rs
@@ -415,7 +415,8 @@ impl Run {
         let mut builder = liquid::ParserBuilder::with_stdlib()
             .filter(crate::filters::KebabCaseFilterParser)
             .filter(crate::filters::PascalCaseFilterParser)
-            .filter(crate::filters::SnakeCaseFilterParser);
+            .filter(crate::filters::SnakeCaseFilterParser)
+            .filter(crate::filters::HttpWildcardFilterParser);
         for filter in self.template.custom_filters() {
             builder = builder.filter(filter);
         }

--- a/crates/templates/src/run.rs
+++ b/crates/templates/src/run.rs
@@ -471,13 +471,18 @@ impl PreparedTemplate {
             .into_iter()
             .map(|(path, content)| Self::render_one(path, content, &globals))
             .collect::<anyhow::Result<Vec<_>>>()?;
-        let outputs = HashMap::from_iter(rendered);
 
         let deltas = self
             .snippets
             .into_iter()
             .map(|so| Self::render_snippet(so, &globals))
             .collect::<anyhow::Result<Vec<_>>>()?;
+
+        if rendered.is_empty() && deltas.is_empty() {
+            return Err(anyhow!("Nothing to create"));
+        }
+
+        let outputs = HashMap::from_iter(rendered);
         Ok(TemplateOutputs {
             files: outputs,
             deltas,

--- a/templates/redirect/metadata/snippets/component.txt
+++ b/templates/redirect/metadata/snippets/component.txt
@@ -1,0 +1,7 @@
+[[component]]
+source = { url = "https://github.com/fermyon/spin-redirect/releases/download/v0.0.1/redirect.wasm", digest = "sha256:d57c3d91e9b62a6b628516c6d11daf6681e1ca2355251a3672074cddefd7f391" }
+id = "{{ project-name }}"
+environment = { DESTINATION = "{{ redirect-to }}" }
+[component.trigger]
+route = "{{ redirect-from }}"
+executor = { type = "wagi" }

--- a/templates/redirect/metadata/spin-template.toml
+++ b/templates/redirect/metadata/spin-template.toml
@@ -1,0 +1,12 @@
+manifest_version = "1"
+id = "redirect"
+description = "Redirects a HTTP route"
+trigger_type = "http"
+
+[add_component]
+[add_component.snippets]
+component = "component.txt"
+
+[parameters]
+redirect-from = { type = "string", prompt = "Redirect from", pattern = "^/\\S*$" }
+redirect-to = { type = "string", prompt = "Redirect to", pattern = "^/\\S*$" }

--- a/templates/redirect/metadata/spin-template.toml
+++ b/templates/redirect/metadata/spin-template.toml
@@ -3,6 +3,9 @@ id = "redirect"
 description = "Redirects a HTTP route"
 trigger_type = "http"
 
+[new_application]
+supported = false
+
 [add_component]
 [add_component.snippets]
 component = "component.txt"

--- a/templates/static-fileserver/metadata/snippets/component.txt
+++ b/templates/static-fileserver/metadata/snippets/component.txt
@@ -1,0 +1,6 @@
+[[component]]
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+id = "{{ project-name }}"
+files = [ { source = "{{ files-path }}", destination = "/" } ]
+[component.trigger]
+route = "{{ http-path | http_wildcard }}"

--- a/templates/static-fileserver/metadata/spin-template.toml
+++ b/templates/static-fileserver/metadata/spin-template.toml
@@ -1,0 +1,12 @@
+manifest_version = "1"
+id = "static-fileserver"
+description = "Serves static files from an asset directory"
+trigger_type = "http"
+
+[add_component]
+[add_component.snippets]
+component = "component.txt"
+
+[parameters]
+http-path = { type = "string", prompt = "HTTP path", default = "/static/...", pattern = "^/\\S*$" }
+files-path = { type = "string", prompt = "Directory containing the files to serve", default = "assets", pattern = "^\\S+$" }

--- a/templates/static-fileserver/metadata/spin-template.toml
+++ b/templates/static-fileserver/metadata/spin-template.toml
@@ -3,6 +3,9 @@ id = "static-fileserver"
 description = "Serves static files from an asset directory"
 trigger_type = "http"
 
+[new_application]
+supported = false
+
 [add_component]
 [add_component.snippets]
 component = "component.txt"


### PR DESCRIPTION
This depends on #889 (and currently includes it; I'll rebase once we've agreed whether that's the way to go and have merged whatever comes out of the discussion).

At the moment the component references refer to test releases in my forks.  I will update these when we do formal releases.

```
ivan@hecate:~/testing/compytest$ spin add static-fileserver statto
HTTP path: /assets
Directory containing static assets to serve: assets

ivan@hecate:~/testing/compytest$ spin add redirect au-revoir
Redirect from: /au-revoir
Redirect to: /goodbye

ivan@hecate:~/testing/compytest$ spin up
Serving http://127.0.0.1:3000
Available Routes:
  hello: http://127.0.0.1:3000/hello
  goodbye: http://127.0.0.1:3000/goodbye
  statto: http://127.0.0.1:3000/assets (wildcard)
  au-revoir: http://127.0.0.1:3000/au-revoir
```
