### PR TITLE
 chore(GitHub): Refactor build/test workflow 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,82 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  build:
+  lint-rust:
+    name: Lint Rust
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-lint-${{ hashFiles('./Cargo.lock') }}"
+
+      - name: Cargo Format
+        run:
+          BUILD_SPIN_EXAMPLES=0 cargo fmt --all -- --check
+
+      - name: Cargo Clippy
+        run:
+          BUILD_SPIN_EXAMPLES=0 cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  build-rust:
     name: Build Spin
     runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - {
+              os: "ubuntu-latest",
+              extension: "",
+              # We have this enabled for releases, so we should test it.
+              extraArgs: "--features openssl/vendored",
+            }
+          - {
+              os: "macos-latest",
+              extension: "",
+              extraArgs: "",
+            }
+          - {
+              os: "windows-latest",
+              extension: ".exe",
+              extraArgs: "",
+            }
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+
+      - name: "Install Wasm Rust target"
+        run: rustup target add wasm32-wasi
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+
+      - name: Cargo Build
+        run: cargo build --workspace --all-targets --all-features ${{ matrix.config.extraArgs }}
+
+      - name: "Archive executable artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: spin-${{ matrix.config.os }}
+          path: target/debug/spin${{ matrix.config.extension }}
+
+
+  test-rust:
+    name: Test Spin SDK - Rust
+    runs-on: ${{ matrix.config.os }}
+    needs: build-rust
     strategy:
       matrix:
         config:
@@ -69,7 +142,6 @@ jobs:
         with:
           toolchain: stable
           default: true
-          components: clippy, rustfmt
 
       - name: "Install Wasm Rust target"
         run: rustup target add wasm32-wasi
@@ -107,35 +179,63 @@ jobs:
           echo "$((Get-Item .\hippo-server-output).FullName)\win-x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append;
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
 
-      - name: Cargo Format
-        if: ${{ matrix.config.platformAgnosticChecks }}
-        run:
-          cargo fmt --all -- --check
-
-      - name: Cargo Clippy
-        if: ${{ matrix.config.platformAgnosticChecks }}
-        run:
-          cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-      - name: Cargo Build
-        run: cargo build --workspace --all-targets --all-features ${{ matrix.config.extraArgs }}
-
-      - name: Cargo Test
+      - name: Cargo Unit Tests
         run: |
           make test-unit
+
+      - name: Cargo E2E Tests
+        run: |
           make test-e2e
         env:
           RUST_LOG: spin=trace
 
+  test-go:
+    name: Test Spin SDK - Go
+    runs-on: ${{ matrix.config.os }}
+    needs: build-rust
+    strategy:
+      matrix:
+        config:
+          - {
+              os: "ubuntu-latest",
+              bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-linux-amd64.tar.gz",
+              bindleBinary: "bindle-server",
+              pathInBindleArchive: "bindle-server",
+              wasmtimeUrl: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.36.0/wasmtime-v0.36.0-x86_64-linux.tar.xz",
+              wasmtimeBinary: "wasmtime",
+              pathInWasmtimeArchive: "wasmtime-v0.36.0-x86_64-linux/wasmtime",
+            }
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Retrieve saved Spin Binary
+        uses: actions/download-artifact@v3
+        with:
+          name: spin-ubuntu-latest
+          path: target/debug/
+
+      - name: Fix Spin Binary permissions
+        run: |
+          ls -lah target/
+          ls -lah target/debug
+          chmod +x target/debug/spin
+
+      - name: Install bindle
+        uses: engineerd/configurator@v0.0.8
+        with:
+          name: ${{ matrix.config.bindleBinary }}
+          url: ${{ matrix.config.bindleUrl }}
+          pathInArchive: ${{ matrix.config.pathInBindleArchive }}
+
       - name: "Install Go"
-        if: ${{ matrix.config.platformAgnosticChecks }}
         uses: actions/setup-go@v3
         with:
           go-version: '1.17'
 
       - name: "Install TinyGo"
-        if: ${{ matrix.config.platformAgnosticChecks }}
         run: |
           wget https://github.com/tinygo-org/tinygo/releases/download/v0.22.0/tinygo_0.22.0_amd64.deb
           sudo dpkg -i tinygo_0.22.0_amd64.deb
@@ -143,18 +243,10 @@ jobs:
 
       - name: "Install Wasmtime"
         uses: engineerd/configurator@v0.0.8
-        if: ${{ matrix.config.platformAgnosticChecks }}
         with:
           name: ${{ matrix.config.wasmtimeBinary }}
           url: ${{ matrix.config.wasmtimeUrl }}
           pathInArchive: ${{ matrix.config.pathInWasmtimeArchive }}
 
       - name: "Test Go SDK"
-        if: ${{ matrix.config.platformAgnosticChecks }}
         run: make test-sdk-go
-
-      - name: "Archive executable artifact"
-        uses: actions/upload-artifact@v3
-        with:
-          name: spin-${{ matrix.config.os }}
-          path: target/debug/spin${{ matrix.config.extension }}


### PR DESCRIPTION
Our current builds are currently unstable because we run out of disk
space on the default GitHub Actions builders.

While we could start trying to be clever and purge various resources
between steps - it's simpler to refactor the build into mutliple
independent steps.

For now we're going to use a "shared-for-the-platform" cache based on
the hash of the Cargo.lock. I plan to follow up with a little more
rigerous of a cache-key system that can also naturally expire a little
sooner to ensure everything is still buildable - but for now, lets get
spin building consistently again.