### PR TITLE
Fail if template references unknown filter

### DIFF
--- a/crates/templates/tests/templates/bad-non-existent-filter/content/test.txt
+++ b/crates/templates/tests/templates/bad-non-existent-filter/content/test.txt
@@ -1,0 +1,1 @@
+p1/lolsnort = {{p1 | lol_snort }}

--- a/crates/templates/tests/templates/bad-non-existent-filter/metadata/spin-template.toml
+++ b/crates/templates/tests/templates/bad-non-existent-filter/metadata/spin-template.toml
@@ -1,0 +1,6 @@
+manifest_version = "1"
+id = "bad-non-existent-filter"
+description = "TEST - INTENTIONALLY FAILS - do not use"
+
+[parameters]
+p1 = { type = "string", prompt = "P1" }


### PR DESCRIPTION
The template system is intentionally forgiving of parse errors, because a template might contain text that confuses the Liquid parser but which an author wants to be included anyway.  However, this can disguise genuine authoring errors.  This particular one bit me when accidentally using the redirect template with a previous version of Spin - it appeared to succeed but actually failed on a new filter and dumped the unsubstituted template into my project.  With this fix, I need never be confused again.

Longer term, we perhaps need more robust mechanisms for template authors to exclude files from parsing, after which we can banhammer actual parse failures.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>