### PR TITLE
Skip validating unused manifest fields in spin build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,8 +4006,11 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "futures",
+ "serde",
  "spin-loader",
  "subprocess",
+ "tokio",
+ "toml",
  "tracing",
 ]
 

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -7,6 +7,9 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0.57"
 futures = "0.3.21"
+serde = { version = "1.0", features = [ "derive" ] }
 spin-loader = { path = "../loader" }
 subprocess = "0.2.8"
+tokio = { version = "1.11", features = [ "full" ] }
+toml = "0.5"
 tracing = { version = "0.1", features = [ "log" ] }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -2,18 +2,22 @@
 
 //! A library for building Spin components.
 
+mod manifest;
+
 use anyhow::{bail, Context, Result};
-use spin_loader::local::{
-    config::{RawAppManifestAnyVersion, RawComponentManifest},
-    parent_dir, raw_manifest_from_file,
-};
+use spin_loader::local::parent_dir;
 use std::path::{Path, PathBuf};
 use subprocess::{Exec, Redirection};
 use tracing::log;
 
+use crate::manifest::{BuildAppInfoAnyVersion, RawComponentManifest};
+
 /// If present, run the build command of each component.
 pub async fn build(manifest_file: &Path) -> Result<()> {
-    let RawAppManifestAnyVersion::V1(app) = raw_manifest_from_file(&manifest_file).await?;
+    let manifest_text = tokio::fs::read_to_string(manifest_file)
+        .await
+        .with_context(|| format!("Cannot read manifest file from {}", manifest_file.display()))?;
+    let BuildAppInfoAnyVersion::V1(app) = toml::from_str(&manifest_text)?;
     let app_dir = parent_dir(manifest_file)?;
 
     if app.components.iter().all(|c| c.build.is_none()) {
@@ -97,4 +101,20 @@ fn construct_workdir(app_dir: &Path, workdir: Option<impl AsRef<Path>>) -> Resul
     }
 
     Ok(cwd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_data_root() -> PathBuf {
+        let crate_dir = env!("CARGO_MANIFEST_DIR");
+        PathBuf::from(crate_dir).join("tests")
+    }
+
+    #[tokio::test]
+    async fn can_load_even_if_trigger_invalid() {
+        let bad_trigger_file = test_data_root().join("bad_trigger.toml");
+        build(&bad_trigger_file).await.unwrap();
+    }
 }

--- a/crates/build/src/manifest.rs
+++ b/crates/build/src/manifest.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "spin_version")]
+pub(crate) enum BuildAppInfoAnyVersion {
+    #[serde(rename = "1")]
+    V1(BuildAppInfoV1),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) struct BuildAppInfoV1 {
+    #[serde(rename = "component")]
+    pub components: Vec<RawComponentManifest>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) struct RawComponentManifest {
+    pub id: String,
+    pub build: Option<RawBuildConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub(crate) struct RawBuildConfig {
+    pub command: String,
+    pub workdir: Option<PathBuf>,
+}

--- a/crates/build/tests/bad_trigger.toml
+++ b/crates/build/tests/bad_trigger.toml
@@ -1,0 +1,13 @@
+spin_version = "1"
+name = "bad_trigger"
+# The trigger is missing the `base` field
+trigger = { type = "http" }
+version = "0.1.0"
+
+[[component]]
+id = "test"
+source = "does-not-exist"
+[component.trigger]
+route = "/test"
+[component.build]
+command = "echo done"


### PR DESCRIPTION
Fixes #473.

The approach taken here is that we don't care if other parts of the manifest are valid, as long as we have the info we need to do the build.  In terms of the original issue, the build won't fail because you have a missing field in your trigger.  The downside of this is that it results in some duplication of the parts of the manifest schema.

An alternative approach would be to keep the existing loader but just improve the error reporting around manifest load failures.  Despite the duplication, I prefer skipping validation, because if I'm in coding flow I don't want to have to take time out to fix some random other field.  But happy to have that discussion.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>