### PR TITLE
add support for outbound Redis set operations

### DIFF
--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -47,6 +47,24 @@ impl outbound_redis::OutboundRedis for OutboundRedis {
         let value = conn.del(keys).await.map_err(log_error)?;
         Ok(value)
     }
+
+    async fn sadd(&mut self, address: &str, key: &str, values: Vec<&str>) -> Result<i64, Error> {
+        let conn = self.get_conn(address).await.map_err(log_error)?;
+        let value = conn.sadd(key, values).await.map_err(log_error)?;
+        Ok(value)
+    }
+
+    async fn smembers(&mut self, address: &str, key: &str) -> Result<Vec<String>, Error> {
+        let conn = self.get_conn(address).await.map_err(log_error)?;
+        let value = conn.smembers(key).await.map_err(log_error)?;
+        Ok(value)
+    }
+
+    async fn srem(&mut self, address: &str, key: &str, values: Vec<&str>) -> Result<i64, Error> {
+        let conn = self.get_conn(address).await.map_err(log_error)?;
+        let value = conn.srem(key, values).await.map_err(log_error)?;
+        Ok(value)
+    }
 }
 
 impl OutboundRedis {

--- a/wit/ephemeral/outbound-redis.wit
+++ b/wit/ephemeral/outbound-redis.wit
@@ -15,3 +15,12 @@ incr: func(address: string, key: string) -> expected<s64, error>
 
 // Removes the specified keys. A key is ignored if it does not exist.
 del: func(address: string, keys: list<string>) -> expected<s64, error>
+
+// Add the specified `values` to the set named `key`, returning the number of newly-added values.
+sadd: func(address: string, key: string, values: list<string>) -> expected<s64, error>
+
+// Retrieve the contents of the set named `key`.
+smembers: func(address: string, key: string) -> expected<list<string>, error>
+
+// Remove the specified `values` from the set named `key`, returning the number of newly-removed values.
+srem: func(address: string, key: string, values: list<string>) -> expected<s64, error>


### PR DESCRIPTION
This adds support for the SADD, SREM, and SMEMBERS Redis commands, useful for apps which need to manage groups of unique identifiers (e.g. chat apps).

Signed-off-by: Joel Dice <joel.dice@fermyon.com>