### PR TITLE
Templates tidying

### DIFF
--- a/crates/templates/src/cancellable.rs
+++ b/crates/templates/src/cancellable.rs
@@ -1,0 +1,50 @@
+pub(crate) enum Cancellable<T, E> {
+    Cancelled,
+    Err(E),
+    Ok(T),
+}
+
+impl<T, E> Cancellable<T, E> {
+    pub(crate) fn err(self) -> Result<(), E> {
+        match self {
+            Self::Ok(_) => Ok(()),
+            Self::Cancelled => Ok(()),
+            Self::Err(e) => Err(e),
+        }
+    }
+
+    pub(crate) fn and_then<U>(self, f: impl Fn(T) -> Result<U, E>) -> Cancellable<U, E> {
+        match self {
+            Self::Ok(value) => match f(value) {
+                Ok(r) => Cancellable::Ok(r),
+                Err(e) => Cancellable::Err(e),
+            },
+            Self::Cancelled => Cancellable::Cancelled,
+            Self::Err(e) => Cancellable::Err(e),
+        }
+    }
+
+    pub(crate) async fn and_then_async<U, Fut: std::future::Future<Output = Result<U, E>>>(
+        self,
+        f: impl Fn(T) -> Fut,
+    ) -> Cancellable<U, E> {
+        match self {
+            Self::Ok(value) => match f(value).await {
+                Ok(r) => Cancellable::Ok(r),
+                Err(e) => Cancellable::Err(e),
+            },
+            Self::Cancelled => Cancellable::Cancelled,
+            Self::Err(e) => Cancellable::Err(e),
+        }
+    }
+}
+
+impl<T, E> From<Result<Option<T>, E>> for Cancellable<T, E> {
+    fn from(ro: Result<Option<T>, E>) -> Self {
+        match ro {
+            Ok(Some(t)) => Self::Ok(t),
+            Ok(None) => Self::Cancelled,
+            Err(e) => Self::Err(e),
+        }
+    }
+}

--- a/crates/templates/src/interaction.rs
+++ b/crates/templates/src/interaction.rs
@@ -1,7 +1,105 @@
-use crate::template::{TemplateParameter, TemplateParameterDataType};
+use std::{collections::HashMap, path::Path};
 
+use crate::{
+    cancellable::Cancellable,
+    template::{TemplateParameter, TemplateParameterDataType},
+    Run,
+};
+
+use anyhow::anyhow;
 // use console::style;
 use dialoguer::{Confirm, Input};
+
+pub(crate) trait InteractionStrategy {
+    fn allow_generate_into(&self, target_dir: &Path) -> Cancellable<(), anyhow::Error>;
+    fn populate_parameters(
+        &self,
+        run: &Run,
+    ) -> Cancellable<HashMap<String, String>, anyhow::Error> {
+        let mut values = HashMap::new();
+        for parameter in run.template.parameters(&run.options.variant) {
+            match self.populate_parameter(run, parameter) {
+                Cancellable::Ok(value) => {
+                    values.insert(parameter.id().to_owned(), value);
+                }
+                Cancellable::Cancelled => return Cancellable::Cancelled,
+                Cancellable::Err(e) => return Cancellable::Err(e),
+            }
+        }
+        Cancellable::Ok(values)
+    }
+    fn populate_parameter(
+        &self,
+        run: &Run,
+        parameter: &TemplateParameter,
+    ) -> Cancellable<String, anyhow::Error>;
+}
+
+pub(crate) struct Interactive;
+pub(crate) struct Silent;
+
+impl InteractionStrategy for Interactive {
+    fn allow_generate_into(&self, target_dir: &Path) -> Cancellable<(), anyhow::Error> {
+        if !is_directory_empty(target_dir) {
+            let prompt = format!(
+                "{} already contains other files. Generate into it anyway?",
+                target_dir.display()
+            );
+            match crate::interaction::confirm(&prompt) {
+                Ok(true) => Cancellable::Ok(()),
+                Ok(false) => Cancellable::Cancelled,
+                Err(e) => Cancellable::Err(anyhow::Error::from(e)),
+            }
+        } else {
+            Cancellable::Ok(())
+        }
+    }
+
+    fn populate_parameter(
+        &self,
+        run: &Run,
+        parameter: &TemplateParameter,
+    ) -> Cancellable<String, anyhow::Error> {
+        match run.options.values.get(parameter.id()) {
+            Some(s) => Cancellable::Ok(s.clone()),
+            None => match (run.options.accept_defaults, parameter.default_value()) {
+                (true, Some(v)) => Cancellable::Ok(v.to_string()),
+                _ => match crate::interaction::prompt_parameter(parameter) {
+                    Some(v) => Cancellable::Ok(v),
+                    None => Cancellable::Cancelled,
+                },
+            },
+        }
+    }
+}
+
+impl InteractionStrategy for Silent {
+    fn allow_generate_into(&self, target_dir: &Path) -> Cancellable<(), anyhow::Error> {
+        if is_directory_empty(target_dir) {
+            Cancellable::Ok(())
+        } else {
+            let err = anyhow!(
+                "Can't generate into {} as it already contains other files",
+                target_dir.display()
+            );
+            Cancellable::Err(err)
+        }
+    }
+
+    fn populate_parameter(
+        &self,
+        run: &Run,
+        parameter: &TemplateParameter,
+    ) -> Cancellable<String, anyhow::Error> {
+        match run.options.values.get(parameter.id()) {
+            Some(s) => Cancellable::Ok(s.clone()),
+            None => match (run.options.accept_defaults, parameter.default_value()) {
+                (true, Some(v)) => Cancellable::Ok(v.to_string()),
+                _ => Cancellable::Err(anyhow!("Parameter '{}' not provided", parameter.id())),
+            },
+        }
+    }
+}
 
 pub(crate) fn confirm(text: &str) -> std::io::Result<bool> {
     Confirm::new().with_prompt(text).interact()
@@ -38,4 +136,17 @@ fn ask_free_text(prompt: &str, default_value: &Option<String>) -> anyhow::Result
     }
     let result = input.interact_text()?;
     Ok(result)
+}
+
+fn is_directory_empty(path: &Path) -> bool {
+    if !path.exists() {
+        return true;
+    }
+    if !path.is_dir() {
+        return false;
+    }
+    match path.read_dir() {
+        Err(_) => false,
+        Ok(mut read_dir) => read_dir.next().is_none(),
+    }
 }

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 
 mod app_info;
+mod cancellable;
 mod constraints;
 mod custom_filters;
 mod directory;
@@ -11,12 +12,14 @@ mod filters;
 mod interaction;
 mod manager;
 mod reader;
+mod renderer;
 mod run;
 mod source;
 mod store;
 mod template;
+mod writer;
 
 pub use manager::*;
-pub use run::{Run, RunOptions, TemplatePreparationResult};
+pub use run::{Run, RunOptions};
 pub use source::TemplateSource;
-pub use template::{Template, TemplateVariantKind};
+pub use template::{Template, TemplateVariantInfo};

--- a/crates/templates/src/renderer.rs
+++ b/crates/templates/src/renderer.rs
@@ -1,0 +1,101 @@
+use anyhow::anyhow;
+use std::{collections::HashMap, path::PathBuf};
+
+use crate::writer::{TemplateOutput, TemplateOutputs};
+
+// A template that has been evaluated and parsed, with all the values
+// it needs to render.
+pub(crate) struct TemplateRenderer {
+    pub render_operations: Vec<RenderOperation>,
+    pub parameter_values: HashMap<String, String>,
+}
+
+pub(crate) enum TemplateContent {
+    Template(liquid::Template),
+    Binary(Vec<u8>),
+}
+
+pub(crate) enum RenderOperation {
+    AppendToml(PathBuf, TemplateContent),
+    WriteFile(PathBuf, TemplateContent),
+}
+
+impl TemplateRenderer {
+    pub(crate) fn render(self) -> anyhow::Result<TemplateOutputs> {
+        let globals = self.renderer_globals();
+
+        let outputs = self
+            .render_operations
+            .into_iter()
+            .map(|so| so.render(&globals))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        if outputs.is_empty() {
+            return Err(anyhow!("Nothing to create"));
+        }
+
+        Ok(TemplateOutputs::new(outputs))
+    }
+
+    fn renderer_globals(&self) -> liquid::Object {
+        let mut object = liquid::Object::new();
+
+        for (k, v) in &self.parameter_values {
+            object.insert(
+                k.to_owned().into(),
+                liquid_core::Value::Scalar(v.to_owned().into()),
+            );
+        }
+
+        object
+    }
+}
+
+impl RenderOperation {
+    fn render(self, globals: &liquid::Object) -> anyhow::Result<TemplateOutput> {
+        match self {
+            Self::WriteFile(path, content) => {
+                let rendered = content.render(globals)?;
+                Ok(TemplateOutput::WriteFile(path, rendered))
+            }
+            Self::AppendToml(path, content) => {
+                let rendered = content.render(globals)?;
+                let rendered_text = String::from_utf8(rendered)?;
+                Ok(TemplateOutput::AppendToml(path, rendered_text))
+            }
+        }
+    }
+}
+
+impl TemplateContent {
+    pub(crate) fn infer_from_bytes(raw: Vec<u8>, parser: &liquid::Parser) -> TemplateContent {
+        match string_from_bytes(&raw) {
+            None => TemplateContent::Binary(raw),
+            Some(s) => {
+                match parser.parse(&s) {
+                    Ok(t) => TemplateContent::Template(t),
+                    Err(_) => TemplateContent::Binary(raw), // TODO: detect legit broken templates and error on them
+                }
+            }
+        }
+    }
+
+    fn render(self, globals: &liquid::Object) -> anyhow::Result<Vec<u8>> {
+        match self {
+            Self::Template(t) => {
+                let text = t.render(globals)?;
+                Ok(text.bytes().collect())
+            }
+            Self::Binary(v) => Ok(v),
+        }
+    }
+}
+
+// TODO: this doesn't truly belong in a module that claims to be about
+// rendering but the only thing that uses it is the TemplateContent ctor
+fn string_from_bytes(bytes: &[u8]) -> Option<String> {
+    match std::str::from_utf8(bytes) {
+        Ok(s) => Some(s.to_owned()),
+        Err(_) => None, // TODO: try other encodings!
+    }
+}

--- a/crates/templates/src/writer.rs
+++ b/crates/templates/src/writer.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+
+pub(crate) struct TemplateOutputs {
+    outputs: Vec<TemplateOutput>,
+}
+
+pub(crate) enum TemplateOutput {
+    WriteFile(PathBuf, Vec<u8>),
+    AppendToml(PathBuf, String),
+}
+
+impl TemplateOutputs {
+    pub fn new(outputs: Vec<TemplateOutput>) -> Self {
+        Self { outputs }
+    }
+
+    pub async fn write(&self) -> anyhow::Result<()> {
+        for output in &self.outputs {
+            output.write().await?;
+        }
+        Ok(())
+    }
+}
+
+impl TemplateOutput {
+    pub async fn write(&self) -> anyhow::Result<()> {
+        match &self {
+            TemplateOutput::WriteFile(path, contents) => {
+                let dir = path.parent().with_context(|| {
+                    format!("Can't get directory containing {}", path.display())
+                })?;
+                tokio::fs::create_dir_all(&dir)
+                    .await
+                    .with_context(|| format!("Failed to create directory {}", dir.display()))?;
+                tokio::fs::write(&path, &contents)
+                    .await
+                    .with_context(|| format!("Failed to write file {}", path.display()))?;
+            }
+            TemplateOutput::AppendToml(path, text) => {
+                let existing_toml = tokio::fs::read_to_string(path)
+                    .await
+                    .with_context(|| format!("Can't open {} to append", path.display()))?;
+                let new_toml = format!("{}\n\n{}", existing_toml.trim_end(), text);
+                tokio::fs::write(path, new_toml)
+                    .await
+                    .with_context(|| format!("Can't save changes to {}", path.display()))?;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Reorganising the templates crate so that:

* Modules are less bulky and the code overall is easier to navigate
* Things are more distinctively and specifically named
* The core run flow is clearer
* It is harder to express invalid states

Leaving the individual commits for now in case some of it is deemed unwelcome and we need to cherry-pick the good bits, but should be squashed before merging.