### PR TITLE
make `spin_publish::expander::expand_manifest` public again

### DIFF
--- a/crates/publish/src/bindle_writer.rs
+++ b/crates/publish/src/bindle_writer.rs
@@ -132,7 +132,7 @@ pub(crate) struct ParcelSource {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ParcelSources {
+pub struct ParcelSources {
     sources: Vec<ParcelSource>,
 }
 

--- a/crates/publish/src/expander.rs
+++ b/crates/publish/src/expander.rs
@@ -12,7 +12,7 @@ use spin_loader::{
 use std::path::{Path, PathBuf};
 
 /// Expands a file-based application manifest to a Bindle invoice.
-pub(crate) async fn expand_manifest(
+pub async fn expand_manifest(
     app_file: impl AsRef<Path>,
     buildinfo: Option<BuildMetadata>,
     scratch_dir: impl AsRef<Path>,

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -10,3 +10,4 @@ mod expander;
 pub use bindle_pusher::push_all;
 pub use bindle_writer::prepare_bindle;
 pub use error::{PublishError, PublishResult};
+pub use expander::expand_manifest;


### PR DESCRIPTION
An earlier commit changed this from `pub` to `pub(crate)`, making it inaccessible to third-party crates.  This makes it public again.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>