### PR TITLE
make `ParcelSources::source` public

### DIFF
--- a/crates/publish/src/bindle_writer.rs
+++ b/crates/publish/src/bindle_writer.rs
@@ -137,7 +137,7 @@ pub struct ParcelSources {
 }
 
 impl ParcelSources {
-    pub(crate) fn source(&self, digest: &str) -> Option<&PathBuf> {
+    pub fn source(&self, digest: &str) -> Option<&PathBuf> {
         self.sources
             .iter()
             .find(|s| s.digest == digest)


### PR DESCRIPTION
As a follow-up to 4aace0b, this makes `ParcelSources::source` public, which is needed to actually make `expand_manifest` useful.  Apologies for not including this in the earlier commit.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>