### PR TITLE
Build is not async

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -25,13 +25,10 @@ pub async fn build(manifest_file: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let results = futures::future::join_all(
-        app.components
-            .into_iter()
-            .map(|c| build_component(c, &app_dir))
-            .collect::<Vec<_>>(),
-    )
-    .await;
+    let results = app
+        .components
+        .into_iter()
+        .map(|c| build_component(c, &app_dir));
 
     for r in results {
         if r.is_err() {
@@ -44,7 +41,7 @@ pub async fn build(manifest_file: &Path) -> Result<()> {
 }
 
 /// Run the build command of the component.
-async fn build_component(raw: RawComponentManifest, app_dir: &Path) -> Result<()> {
+fn build_component(raw: RawComponentManifest, app_dir: &Path) -> Result<()> {
     match raw.build {
         Some(b) => {
             println!(


### PR DESCRIPTION
Some internals of the `build` crate were declared as async and had machinery to run in parallel.  From what I can tell, they never have been async, so the parallelism/join stuff wasn't doing anything - the builds have always been sequential.  The presence of `async` may be a hangover from during initial development (perhaps the author started out by using `tokio::process::Command`?).

This PR removes the `async` modifier and strips out the machinery for joining after parallel builds.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>