### PR TITLE
Enable aarch64 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,14 @@ jobs:
               target: "",
               targetDir: "target/release",
             }
-          # TODO: openssl is still a nested dep here.
-          # Re-enable when updated to use vendored openssl or cross-compile setup is updated
-          # - {
-          #     os: "ubuntu-latest",
-          #     arch: "aarch64",
-          #     extension: "",
-          #     extraArgs: "--target aarch64-unknown-linux-gnu",
-          #     target: "aarch64-unknown-linux-gnu",
-          #     targetDir: "target/aarch64-unknown-linux-gnu/release",
-          #   }
+          - {
+              os: "ubuntu-latest",
+              arch: "aarch64",
+              extension: "",
+              extraArgs: "--features openssl/vendored --target aarch64-unknown-linux-gnu",
+              target: "aarch64-unknown-linux-gnu",
+              targetDir: "target/aarch64-unknown-linux-gnu/release",
+            }
           - {
               os: "macos-latest",
               arch: "amd64",
@@ -86,13 +84,13 @@ jobs:
           default: true
           target: ${{ matrix.config.target }}
 
-      # - name: setup for cross-compiled linux aarch64 build
-      #   if: matrix.config.target == 'aarch64-unknown-linux-gnu'
-      #   run: |
-      #     sudo apt update
-      #     sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-      #     echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
-      #     echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
+      - name: setup for cross-compiled linux aarch64 build
+        if: matrix.config.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt update
+          sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
 
       - name: build release
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
I've been using the `fermyon/installer` repository to run spin applications on a raspberry pi. It looks like there isn't an official release binary for aarch64 yet but there is an open issue #901 to add support for arm64. I found the notes in the release workflow file and was able to generate a release successfully in my fork, [here's the workflow result](https://github.com/jpflueger/hippo/actions/runs/3569728099). Maybe I'm missing something but this does seem to work now.