### PR TITLE
make `spin_publish::bindle_writer::write` public again

### DIFF
--- a/crates/publish/src/bindle_writer.rs
+++ b/crates/publish/src/bindle_writer.rs
@@ -31,7 +31,7 @@ struct BindleWriter {
 }
 
 /// Writes an invoice and supporting parcels out as a standalone bindle.
-async fn write(
+pub async fn write(
     source_dir: impl AsRef<Path>,
     dest_dir: impl AsRef<Path>,
     invoice: &Invoice,

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -8,6 +8,6 @@ mod error;
 mod expander;
 
 pub use bindle_pusher::push_all;
-pub use bindle_writer::prepare_bindle;
+pub use bindle_writer::{prepare_bindle, write};
 pub use error::{PublishError, PublishResult};
 pub use expander::expand_manifest;


### PR DESCRIPTION
This function was public in Spin 0.6.0 and should remain so to avoid breaking third-party crates unnecessarily.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>