### PR TITLE
feat!: Make log output to stdout default

### DIFF
--- a/crates/trigger/src/stdio.rs
+++ b/crates/trigger/src/stdio.rs
@@ -1,18 +1,12 @@
-use std::{
-    collections::HashSet,
-    fs::File,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashSet, fs::File, path::PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::Context;
 
 use crate::{TriggerHooks, SPIN_HOME};
 
 /// Which components should have their logs followed on stdout/stderr.
 #[derive(Clone, Debug)]
 pub enum FollowComponents {
-    /// No components should have their logs followed.
-    None,
     /// Only the specified components should have their logs followed.
     Named(HashSet<String>),
     /// All components should have their logs followed.
@@ -23,7 +17,6 @@ impl FollowComponents {
     /// Whether a given component should have its logs followed on stdout/stderr.
     pub fn should_follow(&self, component_id: &str) -> bool {
         match self {
-            Self::None => false,
             Self::All => true,
             Self::Named(ids) => ids.contains(component_id),
         }
@@ -32,47 +25,73 @@ impl FollowComponents {
 
 impl Default for FollowComponents {
     fn default() -> Self {
-        Self::None
+        Self::All
     }
 }
 
-/// Implements TriggerHooks, writing logs to a log file and (optionally) stderr
+/// Defines where to write logs
+pub enum LogDestination {
+    /// Write logs to stdout/stderr
+    Std,
+    /// Write logs to files in the directory
+    Dir(Option<PathBuf>),
+}
+
+/// Implements TriggerHooks, writing logs to a log file or stdout/stderr
 pub struct StdioLoggingTriggerHooks {
     follow_components: FollowComponents,
-    log_dir: Option<PathBuf>,
+    log: LogDestination,
 }
 
 impl StdioLoggingTriggerHooks {
-    pub fn new(follow_components: FollowComponents, log_dir: Option<PathBuf>) -> Self {
+    pub fn new(follow_components: FollowComponents, log: LogDestination) -> Self {
         Self {
             follow_components,
-            log_dir,
+            log,
         }
     }
 
-    fn component_stdio_writer(
+    fn component_log_writer(
         &self,
+        builder: &mut spin_core::StoreBuilder,
         component_id: &str,
-        log_suffix: &str,
-    ) -> Result<ComponentStdioWriter> {
-        let sanitized_component_id = sanitize_filename::sanitize(component_id);
-        let log_path = self
-            .log_dir
-            .as_deref()
-            .expect("log_dir should have been initialized in app_loaded")
-            .join(format!("{sanitized_component_id}_{log_suffix}.txt"));
-        let follow = self.follow_components.should_follow(component_id);
-        ComponentStdioWriter::new(&log_path, follow)
-            .with_context(|| format!("Failed to open log file {log_path:?}"))
+    ) -> anyhow::Result<()> {
+        if self.follow_components.should_follow(component_id) {
+            match &self.log {
+                LogDestination::Std => {
+                    builder.stdout_pipe(std::io::stdout());
+                    builder.stderr_pipe(std::io::stderr());
+                }
+                LogDestination::Dir(log_path) => {
+                    let log_path = log_path
+                        .as_deref()
+                        .expect("log should have been initialized in app_loaded");
+
+                    let sanitized_component_id = sanitize_filename::sanitize(component_id);
+                    let out_path = log_path.join(format!("{sanitized_component_id}_stdout.txt"));
+                    let err_path = log_path.join(format!("{sanitized_component_id}_stderr.txt"));
+
+                    builder.stdout_pipe(log_file(&out_path)?);
+                    builder.stderr_pipe(log_file(&err_path)?);
+                }
+            };
+        }
+
+        Ok(())
     }
 
     fn create_log_dir(&mut self, app: &spin_app::App) -> anyhow::Result<()> {
         let app_name: &str = app.require_metadata("name")?;
 
         // Set default log_dir (if not explicitly passed)
-        let log_dir = self
-            .log_dir
-            .get_or_insert_with(|| default_log_dir(app_name));
+        let log_dir = match self.log {
+            LogDestination::Std => {
+                panic!("Log dir creation shouldn't be called when destination is stdout/stderr")
+            }
+            LogDestination::Dir(ref mut dir) => {
+                dir.get_or_insert_with(|| default_log_dir(app_name))
+            }
+        };
 
         // Ensure log dir exists
         std::fs::create_dir_all(&log_dir)
@@ -84,7 +103,9 @@ impl StdioLoggingTriggerHooks {
 
 impl TriggerHooks for StdioLoggingTriggerHooks {
     fn app_loaded(&mut self, app: &spin_app::App) -> anyhow::Result<()> {
-        self.create_log_dir(app)?;
+        if let LogDestination::Dir(_dir) = &self.log {
+            self.create_log_dir(app)?;
+        }
 
         Ok(())
     }
@@ -94,40 +115,7 @@ impl TriggerHooks for StdioLoggingTriggerHooks {
         component: spin_app::AppComponent,
         builder: &mut spin_core::StoreBuilder,
     ) -> anyhow::Result<()> {
-        builder.stdout_pipe(self.component_stdio_writer(component.id(), "stdout")?);
-        builder.stderr_pipe(self.component_stdio_writer(component.id(), "stderr")?);
-        Ok(())
-    }
-}
-
-/// ComponentStdioWriter forwards output to a log file and (optionally) stderr
-pub struct ComponentStdioWriter {
-    log_file: File,
-    follow: bool,
-}
-
-impl ComponentStdioWriter {
-    pub fn new(log_path: &Path, follow: bool) -> anyhow::Result<Self> {
-        let log_file = File::options().create(true).append(true).open(log_path)?;
-        Ok(Self { log_file, follow })
-    }
-}
-
-impl std::io::Write for ComponentStdioWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let written = self.log_file.write(buf)?;
-        if self.follow {
-            std::io::stderr().write_all(&buf[..written])?;
-        }
-        Ok(written)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.log_file.flush()?;
-        if self.follow {
-            std::io::stderr().flush()?;
-        }
-        Ok(())
+        self.component_log_writer(builder, component.id())
     }
 }
 
@@ -139,4 +127,12 @@ fn default_log_dir(app_name: &str) -> PathBuf {
     let sanitized_app = sanitize_filename::sanitize(app_name);
 
     parent_dir.join(sanitized_app).join("logs")
+}
+
+fn log_file(file_path: &PathBuf) -> anyhow::Result<File> {
+    File::options()
+        .create(true)
+        .append(true)
+        .open(file_path)
+        .with_context(|| format!("Failed to open log file {file_path:?}"))
 }


### PR DESCRIPTION
- spin writes to stdout/stderr by default (only)
- Drops `--follow-all` cmd arg is it no longer needed.
- `--follow` logs only the output for the provided components list
- `-L/--log-dir` w/o value makes spin to log in the default directory
- `-L/--log-dir <dir>` logs into the provided directory
- spin prints output to both stdout/stderr instead of stderr only
- Update `--follow <FOLLOW_ID>` to `--follow <COMPONENT_ID>`

```
  --follow <COMPONENT_ID>
        Print output for given component(s) to stdout/stderr. Can be provided multiple times to
        follow several components
```

- Mention default log location in `-L/--log-dir` help output.

Fixes #928.