### PR TITLE
Set up a devcontainer as part of the Rust template

### DIFF
--- a/templates/http-rust/content/.devcontainer/Dockerfile
+++ b/templates/http-rust/content/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+ARG VARIANT="bullseye"
+FROM rust:1-${VARIANT}
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    && apt-get purge -y imagemagick imagemagick-6-common
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# Install additional rust components (rust-analyzer)
+ARG RUST_ANALYZER_URL="https://github.com/rust-lang/rust-analyzer/releases/download/2022-04-11/rust-analyzer-x86_64-unknown-linux-gnu.gz"
+RUN curl -sL "$RUST_ANALYZER_URL" | gunzip -c - > /usr/local/bin/rust-analyzer && chmod +x /usr/local/bin/rust-analyzer
+
+RUN rustup target add wasm32-wasi

--- a/templates/http-rust/content/.devcontainer/devcontainer.json
+++ b/templates/http-rust/content/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+    "build": {
+        "dockerfile": "./Dockerfile",
+        "context": "."
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:1": {
+            "installZsh": "true",
+            "username": "vscode",
+            "uid": "1000",
+            "gid": "1000",
+            "upgradePackages": "true"
+        },
+        "ghcr.io/devcontainers/features/rust:1": "latest",
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        },
+        "./spin": "latest"
+    },
+
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.executable": "/usr/bin/lldb",
+                "files.watcherExclude": {
+                    "**/target/**": true
+                }
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "vadimcn.vscode-lldb",
+                "rust-lang.rust-analyzer"
+            ]
+        }
+    },
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "portsAttributes": {
+        "3000": {
+            "label": "Application",
+            "onAutoForward": "openPreview"
+        }
+    },
+    "forwardPorts": [
+        3000
+    ],
+
+    // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
+}

--- a/templates/http-rust/content/.devcontainer/spin/devcontainer-feature.json
+++ b/templates/http-rust/content/.devcontainer/spin/devcontainer-feature.json
@@ -1,0 +1,14 @@
+{
+    "id": "spin",
+    "name": "spin",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "latest"
+            ],
+            "default": "latest",
+            "description": "Select or enter a version."
+        }
+    }
+}

--- a/templates/http-rust/content/.devcontainer/spin/install.sh
+++ b/templates/http-rust/content/.devcontainer/spin/install.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+VERSION="v0.6.0"
+OSARCH="linux-amd64"
+
+wget https://github.com/fermyon/spin/releases/download/${VERSION}/spin-${VERSION}-${OSARCH}.tar.gz
+tar xfv spin-${VERSION}-${OSARCH}.tar.gz
+su
+mv ./spin /usr/local/bin/


### PR DESCRIPTION
This is very closely based on the Spin codespace/devcontainer work by @craiglpeters, and it's possible that some bits could be refined (e.g. the Dockerfile uses the Rust baseline but then there is a Rust feature in the devcontainer.json as well).

With this change, when a user creates a Spin application using the `http-rust` templates, they will be able to build it in a devcontainer right off the bat, or in a GitHub codespace once they have committed it to GH.  `spin up` and `spin deploy` work fine, though `spin up` now auto-opens the browser (I assume based on the port forwarding settings) which I'm a bit doubtful about.  Also the user would need to tweak the port settings if they wanted to listen on a non-default port, but hopefully that wouldn't be an issue in a devcontainer.

With the current setup, the GH codespace takes a while to build - I do wonder if it would be faster if we created images with Spin and the appropriate tools - but that's harder to scale across multiple languages.

One thing I haven't figured out yet is how to make this play nicely with multiple components.  Like if I do a `spin new http-empty` and then add two components, I should be able to have a codespace with both of them in it.  And if one component is in Go and the other in Rust, the devcontainer declaration should be modified to include both languages' toolsets.

But anyway here's something to play with and provide feedback on.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>