### PR TITLE
Better error if git not installed

### DIFF
--- a/crates/plugins/src/git.rs
+++ b/crates/plugins/src/git.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
+use std::{io::ErrorKind, process::ExitStatus};
 use tokio::process::Command;
 use url::Url;
 
@@ -37,13 +38,9 @@ impl GitSource {
             "--single-branch",
         ])
         .arg(&self.git_root);
-        let clone_result = git.output().await?;
-        if !clone_result.status.success() {
-            anyhow::bail!(
-                "Error cloning Git repo {}: {}",
-                self.source_url,
-                String::from_utf8_lossy(&clone_result.stderr)
-            )
+        let clone_result = git.output().await.understand_git_result();
+        if let Err(e) = clone_result {
+            anyhow::bail!("Error cloning Git repo {}: {}", self.source_url, e)
         }
         Ok(())
     }
@@ -52,14 +49,61 @@ impl GitSource {
     pub async fn pull(&self) -> Result<()> {
         let mut git = Command::new("git");
         git.arg("-C").arg(&self.git_root).arg("pull");
-        let pull_result = git.output().await?;
-        if !pull_result.status.success() {
+        let pull_result = git.output().await.understand_git_result();
+        if let Err(e) = pull_result {
             anyhow::bail!(
                 "Error updating Git repo at {}: {}",
                 self.git_root.display(),
-                String::from_utf8_lossy(&pull_result.stderr)
+                e
             )
         }
         Ok(())
+    }
+}
+
+// TODO: the following and templates/git.rs are duplicates
+
+pub(crate) enum GitError {
+    ProgramFailed(ExitStatus, Vec<u8>),
+    ProgramNotFound,
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for GitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProgramNotFound => f.write_str("`git` command not found - is git installed?"),
+            Self::Other(e) => e.fmt(f),
+            Self::ProgramFailed(_, stderr) => match std::str::from_utf8(stderr) {
+                Ok(s) => f.write_str(s),
+                Err(_) => f.write_str("(cannot get error)"),
+            },
+        }
+    }
+}
+
+pub(crate) trait UnderstandGitResult {
+    fn understand_git_result(self) -> Result<Vec<u8>, GitError>;
+}
+
+impl UnderstandGitResult for Result<std::process::Output, std::io::Error> {
+    fn understand_git_result(self) -> Result<Vec<u8>, GitError> {
+        match self {
+            Ok(output) => {
+                if output.status.success() {
+                    Ok(output.stdout)
+                } else {
+                    Err(GitError::ProgramFailed(output.status, output.stderr))
+                }
+            }
+            Err(e) => match e.kind() {
+                // TODO: consider cases like insufficient permission?
+                ErrorKind::NotFound => Err(GitError::ProgramNotFound),
+                _ => {
+                    let err = anyhow::Error::from(e).context("Failed to run `git` command");
+                    Err(GitError::Other(err))
+                }
+            },
+        }
     }
 }

--- a/crates/templates/src/environment.rs
+++ b/crates/templates/src/environment.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use anyhow::Result;
 use tokio::process::Command;
 
+use crate::git::UnderstandGitResult;
+
 #[derive(Debug, Default)]
 pub(crate) struct Authors {
     pub author: String,
@@ -67,13 +69,14 @@ pub(crate) async fn get_authors() -> Result<Authors> {
     }
 
     async fn find_real_git_config_inner() -> Option<GitConfig> {
-        let mut git = Command::new("git");
-
-        let config_result = git.arg("config").arg("--list").output().await.ok()?;
-        match config_result.status.success() {
-            true => try_parse_git_config(&config_result.stdout),
-            false => None,
-        }
+        Command::new("git")
+            .arg("config")
+            .arg("--list")
+            .output()
+            .await
+            .understand_git_result()
+            .ok()
+            .and_then(|stdout| try_parse_git_config(&stdout))
     }
 
     let author = match discover_author().await? {

--- a/crates/templates/src/git.rs
+++ b/crates/templates/src/git.rs
@@ -1,0 +1,48 @@
+use std::{io::ErrorKind, process::ExitStatus};
+
+// TODO: the following and the second half of plugins/git.rs are duplicates
+
+pub(crate) enum GitError {
+    ProgramFailed(ExitStatus, Vec<u8>),
+    ProgramNotFound,
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for GitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProgramNotFound => f.write_str("`git` command not found - is git installed?"),
+            Self::Other(e) => e.fmt(f),
+            Self::ProgramFailed(_, stderr) => match std::str::from_utf8(stderr) {
+                Ok(s) => f.write_str(s),
+                Err(_) => f.write_str("(cannot get error)"),
+            },
+        }
+    }
+}
+
+pub(crate) trait UnderstandGitResult {
+    fn understand_git_result(self) -> Result<Vec<u8>, GitError>;
+}
+
+impl UnderstandGitResult for Result<std::process::Output, std::io::Error> {
+    fn understand_git_result(self) -> Result<Vec<u8>, GitError> {
+        match self {
+            Ok(output) => {
+                if output.status.success() {
+                    Ok(output.stdout)
+                } else {
+                    Err(GitError::ProgramFailed(output.status, output.stderr))
+                }
+            }
+            Err(e) => match e.kind() {
+                // TODO: consider cases like insufficient permission?
+                ErrorKind::NotFound => Err(GitError::ProgramNotFound),
+                _ => {
+                    let err = anyhow::Error::from(e).context("Failed to run `git` command");
+                    Err(GitError::Other(err))
+                }
+            },
+        }
+    }
+}

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -9,6 +9,7 @@ mod custom_filters;
 mod directory;
 mod environment;
 mod filters;
+mod git;
 mod interaction;
 mod manager;
 mod reader;


### PR DESCRIPTION
Fixes #953.

The output when `git` is not installed is still not 100% crisp, and we could do with bypassing the context stack for these "known" cases.  But this at least gives the specific message pointing the finger at `git`:

```
# --- Template case ---
$ spin templates install --git https://github.com/fermyon/spin
Copying remote template source
Error: Failed to install one or more templates

Caused by:
    0: Failed to get template source
    1: Error cloning Git repo https://github.com/fermyon/spin: `git` command not found - is git installed?

# --- Plugin case ---
$ spin plugin install js2wasm
Error: failed to connect to endpoint https://github.com/fermyon/spin-plugins/: Error cloning Git repo https://github.com/fermyon/spin-plugins/: `git` command not found - is git installed?
```

I'm not sure there is a sensible way to deduplicate this with the current cratification of the Spin CLI, bar lots of micro-crates or the `spin-util` crate of shame, but I'm open to ideas!

Signed-off-by: itowlson <ivan.towlson@fermyon.com>