### PR TITLE
Provide more context on missing import error

### DIFF
--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -196,7 +196,9 @@ impl<Executor: TriggerExecutor> TriggerAppEngine<Executor> {
         let mut component_instance_pres = HashMap::default();
         for component in app.borrowed().components() {
             let module = component.load_module(&engine).await?;
-            let instance_pre = engine.instantiate_pre(&module)?;
+            let instance_pre = engine
+                .instantiate_pre(&module)
+                .with_context(|| format!("Failed to instantiate component '{}'", component.id()))?;
             component_instance_pres.insert(component.id().to_string(), instance_pre);
         }
 

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -198,6 +198,7 @@ impl<Executor: TriggerExecutor> TriggerAppEngine<Executor> {
             let module = component.load_module(&engine).await?;
             let instance_pre = engine
                 .instantiate_pre(&module)
+                .map_err(decode_preinstantiation_error)
                 .with_context(|| format!("Failed to instantiate component '{}'", component.id()))?;
             component_instance_pres.insert(component.id().to_string(), instance_pre);
         }
@@ -311,4 +312,31 @@ pub(crate) fn parse_file_url(url: &str) -> Result<PathBuf> {
         .with_context(|| format!("Invalid URL: {url:?}"))?
         .to_file_path()
         .map_err(|_| anyhow!("Invalid file URL path: {url:?}"))
+}
+
+fn decode_preinstantiation_error(e: anyhow::Error) -> anyhow::Error {
+    let err_text = e.to_string();
+
+    if err_text.contains("unknown import") && err_text.contains("has not been defined") {
+        // TODO: how to maintain this list?
+        let sdk_imported_interfaces = &[
+            "outbound-pg",
+            "outbound-redis",
+            "spin-config",
+            "wasi_experimental_http",
+            "wasi-outbound-http",
+        ];
+
+        if sdk_imported_interfaces
+            .iter()
+            .map(|s| format!("{s}::"))
+            .any(|s| err_text.contains(&s))
+        {
+            return anyhow!(
+                "{e}. Check that the component uses a SDK version that matches the Spin runtime."
+            );
+        }
+    }
+
+    e
 }


### PR DESCRIPTION
Fixes #946.

The output for a missing import - or other instantiation failure - is now:

```
$ spin up
Error: Failed to instantiate component 'badimport'

Caused by:
    unknown import: `random-thing::get-random-thing` has not been defined
Error: exit status: 1
```

Additionally, if the module name in the 'unknown import' is recognised as one that we have built-in support for (or have once had built-in support for), it suggests a possible fix:

```
$ spin up
Error: Failed to instantiate component 'badimport'

Caused by:
    unknown import: `random-thing::get-random-thing` has not been defined. This component may be using a mismatched version of the Spin SDK. Try rebuilding it with version 0.6 of the SDK
Error: exit status: 1
```

(The above example pretends that random-thing is a Spin host component, because it was easier than trying to engineer a mismatch in a real host component.)

I am a little dubious about this latter part - it has maintenance impact, and more worryingly it could mislead people who are on canary (see the comments in the code).  It's localised to the second commit so it should be easy to back out if we don't think the risks are worth the additional guidance.