### PR TITLE
Print confirmation message on plugins update

### DIFF
--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -290,7 +290,9 @@ async fn update() -> Result<()> {
     let manager = PluginManager::default()?;
     let plugins_dir = manager.store().get_plugins_directory();
     let url = plugins_repo_url()?;
-    fetch_plugins_repo(&url, plugins_dir, true).await
+    fetch_plugins_repo(&url, plugins_dir, true).await?;
+    println!("Plugin information updated successfully");
+    Ok(())
 }
 
 fn continue_to_install(


### PR DESCRIPTION
Fixes #943.

```
$ spin plugin update
Plugin information updated successfully
```

(Failures are still propagated to the output as before.)

Signed-off-by: itowlson <ivan.towlson@fermyon.com>