### PR TITLE
add `--direct-mounts` option to `spin up`

### DIFF
--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -11,7 +11,7 @@ async fn test_from_local_source() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir, &None).await?;
+    let app = from_file(MANIFEST, Some(dir), &None).await?;
 
     assert_eq!(app.info.name, "spin-local-source-test");
     assert_eq!(app.info.version, "1.0.0");
@@ -157,7 +157,7 @@ async fn test_invalid_manifest() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir, &None).await;
+    let app = from_file(MANIFEST, Some(dir), &None).await;
 
     let e = app.unwrap_err().to_string();
     assert!(
@@ -214,7 +214,7 @@ async fn test_duplicate_component_id_is_rejected() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir, &None).await;
+    let app = from_file(MANIFEST, Some(dir), &None).await;
 
     assert!(
         app.is_err(),
@@ -236,7 +236,7 @@ async fn test_insecure_allow_all_with_invalid_url() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir, &None).await;
+    let app = from_file(MANIFEST, Some(dir), &None).await;
 
     assert!(
         app.is_ok(),
@@ -252,7 +252,7 @@ async fn test_invalid_url_in_allowed_http_hosts_is_rejected() -> Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let dir = temp_dir.path();
-    let app = from_file(MANIFEST, dir, &None).await;
+    let app = from_file(MANIFEST, Some(dir), &None).await;
 
     assert!(app.is_err(), "Expected allowed_http_hosts parsing error");
 

--- a/crates/trigger/src/locked.rs
+++ b/crates/trigger/src/locked.rs
@@ -235,7 +235,7 @@ mod tests {
         std::fs::write("spin.toml", TEST_MANIFEST).expect("write manifest");
         std::fs::write("test-source.wasm", "not actual wasm").expect("write source");
         std::fs::write("static.txt", "content").expect("write static");
-        let app = spin_loader::local::from_file("spin.toml", &tempdir, &None)
+        let app = spin_loader::local::from_file("spin.toml", Some(&tempdir), &None)
             .await
             .expect("load app");
         (app, tempdir)

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -87,6 +87,14 @@ pub struct UpCommand {
     #[clap(long = "temp")]
     pub tmp: Option<PathBuf>,
 
+    /// For local apps with directory mounts and no excluded files, mount them directly instead of using a temporary
+    /// directory.
+    ///
+    /// This allows you to update the assets on the host filesystem such that the updates are visible to the guest
+    /// without a restart.  This will raise an error if used with bindle apps or apps using file patterns.
+    #[clap(long, takes_value = false)]
+    pub direct_mounts: bool,
+
     /// All other args, to be passed through to the trigger
     #[clap(hide = true)]
     pub trigger_args: Vec<OsString>,
@@ -127,10 +135,25 @@ impl UpCommand {
                     .as_deref()
                     .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
                 let bindle_connection = self.bindle_connection();
-                spin_loader::from_file(manifest_file, &working_dir, &bindle_connection).await?
+                spin_loader::from_file(
+                    manifest_file,
+                    if self.direct_mounts {
+                        None
+                    } else {
+                        Some(&working_dir)
+                    },
+                    &bindle_connection,
+                )
+                .await?
             }
             (None, Some(bindle)) => match &self.server {
-                Some(server) => spin_loader::from_bindle(bindle, server, &working_dir).await?,
+                Some(server) => {
+                    if self.direct_mounts {
+                        bail!("direct mounts not supported for apps loaded from bindles")
+                    } else {
+                        spin_loader::from_bindle(bindle, server, &working_dir).await?
+                    }
+                }
                 _ => bail!("Loading from a bindle requires a Bindle server URL"),
             },
             (Some(_), Some(_)) => bail!("Specify only one of app file or bindle ID"),

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -91,8 +91,8 @@ pub struct UpCommand {
     /// directory.
     ///
     /// This allows you to update the assets on the host filesystem such that the updates are visible to the guest
-    /// without a restart.  This will raise an error if used with bindle apps or apps using file patterns.
-    #[clap(long, takes_value = false)]
+    /// without a restart.  This cannot be used with bindle apps or apps which use file patterns and/or exclusions.
+    #[clap(long, takes_value = false, conflicts_with = BINDLE_ID_OPT)]
     pub direct_mounts: bool,
 
     /// All other args, to be passed through to the trigger

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -135,24 +135,18 @@ impl UpCommand {
                     .as_deref()
                     .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
                 let bindle_connection = self.bindle_connection();
-                spin_loader::from_file(
-                    manifest_file,
-                    if self.direct_mounts {
-                        None
-                    } else {
-                        Some(&working_dir)
-                    },
-                    &bindle_connection,
-                )
-                .await?
+                let asset_dst = if self.direct_mounts {
+                    None
+                } else {
+                    Some(&working_dir)
+                };
+                spin_loader::from_file(manifest_file, asset_dst, &bindle_connection).await?
             }
             (None, Some(bindle)) => match &self.server {
                 Some(server) => {
-                    if self.direct_mounts {
-                        bail!("direct mounts not supported for apps loaded from bindles")
-                    } else {
-                        spin_loader::from_bindle(bindle, server, &working_dir).await?
-                    }
+                    assert!(!self.direct_mounts);
+
+                    spin_loader::from_bindle(bindle, server, &working_dir).await?
                 }
                 _ => bail!("Loading from a bindle requires a Bindle server URL"),
             },


### PR DESCRIPTION
This option tells `spin up` to directly mount any asset directories specified in the manifest file instead of copying the contents to a temporary directory and mounting that.  This is useful when iteratively developing the static assets in the app, since any modifications to assets are immediately visible to subsequent invocations -- no restart required.

Closes #964.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>