### PR TITLE
Implement `spin plugin list`

### DIFF
--- a/crates/plugins/src/lookup.rs
+++ b/crates/plugins/src/lookup.rs
@@ -100,9 +100,13 @@ fn spin_plugins_repo_manifest_path(
     plugin_version: &Option<Version>,
     plugins_dir: &Path,
 ) -> PathBuf {
+    spin_plugins_repo_manifest_dir(plugins_dir)
+        .join(plugin_name)
+        .join(manifest_file_name_version(plugin_name, plugin_version))
+}
+
+pub fn spin_plugins_repo_manifest_dir(plugins_dir: &Path) -> PathBuf {
     plugins_dir
         .join(PLUGINS_REPO_LOCAL_DIRECTORY)
         .join(PLUGINS_REPO_MANIFESTS_DIRECTORY)
-        .join(plugin_name)
-        .join(manifest_file_name_version(plugin_name, plugin_version))
 }

--- a/crates/plugins/src/store.rs
+++ b/crates/plugins/src/store.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use flate2::read::GzDecoder;
 use std::{
+    ffi::OsStr,
     fs::{self, File},
     path::{Path, PathBuf},
 };
@@ -60,6 +61,57 @@ impl PluginStore {
             binary.set_extension("exe");
         }
         binary
+    }
+
+    pub fn installed_manifests(&self) -> Result<Vec<PluginManifest>> {
+        let manifests_dir = self.installed_manifests_directory();
+        let manifest_paths = Self::json_files_in(&manifests_dir);
+        let manifests = manifest_paths
+            .iter()
+            .filter_map(|path| Self::try_read_manifest_from(path))
+            .collect();
+        Ok(manifests)
+    }
+
+    // TODO: report errors on individuals
+    pub fn catalogue_manifests(&self) -> Result<Vec<PluginManifest>> {
+        // Structure:
+        // CATALOGUE_DIR (spin/plugins/.spin-plugins/manifests)
+        // |- foo
+        // |  |- foo@0.1.2.json
+        // |  |- foo@1.2.3.json
+        // |  |- foo.json
+        // |- bar
+        //    |- bar.json
+        let catalogue_dir =
+            crate::lookup::spin_plugins_repo_manifest_dir(self.get_plugins_directory());
+        let plugin_dirs = catalogue_dir
+            .read_dir()?
+            .filter_map(|d| d.ok())
+            .map(|d| d.path())
+            .filter(|p| p.is_dir());
+        let manifest_paths = plugin_dirs.flat_map(|path| Self::json_files_in(&path));
+        let manifests: Vec<_> = manifest_paths
+            .filter_map(|path| Self::try_read_manifest_from(&path))
+            .collect();
+        Ok(manifests)
+    }
+
+    fn try_read_manifest_from(manifest_path: &Path) -> Option<PluginManifest> {
+        let manifest_file = File::open(manifest_path).ok()?;
+        serde_json::from_reader(manifest_file).ok()
+    }
+
+    fn json_files_in(dir: &Path) -> Vec<PathBuf> {
+        let json_ext = Some(OsStr::new("json"));
+        match dir.read_dir() {
+            Err(_) => vec![],
+            Ok(rd) => rd
+                .filter_map(|de| de.ok())
+                .map(|de| de.path())
+                .filter(|p| p.is_file() && p.extension() == json_ext)
+                .collect(),
+        }
     }
 
     /// Returns the PluginManifest for an installed plugin with a given name.

--- a/crates/plugins/tests/README.md
+++ b/crates/plugins/tests/README.md
@@ -1,0 +1,8 @@
+## Fake plugin manifests
+
+These plugin manifests are fake - they exist to help exercise compatibility
+failure paths.  They are in a compatible layout for you to xcopy to your
+catalogue snapshot directory (`~/.local/share/spin/plugins/.spin-plugins/manifests/`).
+
+The actual package pointers are what we engineers call "hot garbage"; they
+cannot be installed as actual plugins.

--- a/crates/plugins/tests/arm-only/arm-only.json
+++ b/crates/plugins/tests/arm-only/arm-only.json
@@ -1,0 +1,15 @@
+{
+    "name": "arm-only",
+    "description": "A plugin which only works on ARM Linux.",
+    "version": "0.1.0",
+    "spinCompatibility": ">=0.4",
+    "license": "Apache-2.0",
+    "packages": [
+        {
+            "os": "linux",
+            "arch": "arm",
+            "url": "https://example.com/doesnt-exist",
+            "sha256": "11111111"
+        }
+    ]
+}

--- a/crates/plugins/tests/not-spin-ver/not-spin-ver.json
+++ b/crates/plugins/tests/not-spin-ver/not-spin-ver.json
@@ -1,0 +1,21 @@
+{
+    "name": "not-spin-ver",
+    "description": "A plugin which doesn't work with your current version of Spin.",
+    "version": "10.2.0",
+    "spinCompatibility": "=999.999.999",
+    "license": "Apache-2.0",
+    "packages": [
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "url": "https://example.com/doesnt-exist",
+            "sha256": "11111111"
+        },
+        {
+            "os": "macos",
+            "arch": "aarch64",
+            "url": "https://example.com/doesnt-exist",
+            "sha256": "11111111"
+        }
+    ]
+}

--- a/crates/plugins/tests/not-spin-ver/not-spin-ver@9.1.0.json
+++ b/crates/plugins/tests/not-spin-ver/not-spin-ver@9.1.0.json
@@ -1,0 +1,15 @@
+{
+    "name": "not-spin-ver",
+    "description": "A plugin which doesn't work with your current version of Spin - Mac only build.",
+    "version": "9.1.0",
+    "spinCompatibility": "=999.999.999",
+    "license": "Apache-2.0",
+    "packages": [
+        {
+            "os": "macos",
+            "arch": "aarch64",
+            "url": "https://example.com/doesnt-exist",
+            "sha256": "11111111"
+        }
+    ]
+}

--- a/crates/plugins/tests/windows-only/windows-only.json
+++ b/crates/plugins/tests/windows-only/windows-only.json
@@ -1,0 +1,15 @@
+{
+    "name": "windows-only",
+    "description": "A plugin which only works on Windows.",
+    "version": "0.1.0",
+    "spinCompatibility": ">=0.4",
+    "license": "Apache-2.0",
+    "packages": [
+        {
+            "os": "windows",
+            "arch": "amd64",
+            "url": "https://example.com/doesnt-exist",
+            "sha256": "11111111"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #937.

I'd really value comments on the structure of this - even more than usual, because I kind of felt that a bunch of this must already be in there but I wasn't sure where to find it.  So please do flag up if logic is in the wrong places or are already done somewhere else.

The output with this code is loosely based on how `apt` looks on my WSL Ubuntu system, and looks like this:

```
$ spin plugin list
arm-only 0.1.0 [incompatible]
example 0.1.0
example 0.2.0
js2wasm 0.1.0 [installed]
not-spin-ver 9.1.0 [incompatible]
not-spin-ver 10.2.0 [requires other Spin version]
windows-only 0.1.0 [incompatible]

$ spin plugin list --installed
js2wasm 0.1.0 [installed]
```

It could alternatively be printed in tabular format, and/or with colour highlighting, and/or with emoticons - the `PluginDescriptor` hopefully decouples the printing logic enough that this would be easy to fiddle with.

At the moment, this glides silently over plugins that are in such a corrupted state that we can't even load them.  This is preferable to being unable to list plugins _at all_ just because one got mangled while I was trying to exit `vi`.  It would be nice to print a warning if any were skipped, but it's a bit fiddly to do without losing the friendly `?` syntax - I can have a noodle on it if people think it's worth it though.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>