### PR TITLE
Handle paginated responses when looking for revision and channel IDs

### DIFF
--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -273,6 +273,19 @@ impl Client {
             .await
             .map_err(format_response_error)
     }
+
+    pub async fn list_revisions_next(
+        &self,
+        previous: &RevisionItemPage,
+    ) -> anyhow::Result<RevisionItemPage> {
+        api_revisions_get(
+            &self.configuration,
+            Some(previous.page_index + 1),
+            Some(previous.page_size),
+        )
+        .await
+        .map_err(format_response_error)
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -153,6 +153,19 @@ impl Client {
         .map_err(format_response_error)
     }
 
+    pub async fn list_channels_next(&self, previous: &ChannelItemPage) -> Result<ChannelItemPage> {
+        api_channels_get(
+            &self.configuration,
+            Some(""),
+            Some(previous.page_index + 1),
+            Some(previous.page_size),
+            Some("Name"),
+            None,
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn add_channel(
         &self,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -553,15 +553,29 @@ impl DeployCommand {
         name: String,
         app_id: Uuid,
     ) -> Result<Uuid> {
-        let channels_vm = CloudClient::list_channels(cloud_client).await?;
-        let channel = channels_vm
-            .items
-            .iter()
-            .find(|&x| x.app_id == app_id && x.name == name.clone());
-        match channel {
-            Some(c) => Ok(c.id),
-            None => bail!("No channel with app_id {} and name {}", app_id, name),
+        let mut channels_vm = cloud_client.list_channels().await?;
+
+        loop {
+            if let Some(channel) = channels_vm
+                .items
+                .iter()
+                .find(|&x| x.app_id == app_id && x.name == name.clone())
+            {
+                return Ok(channel.id);
+            }
+
+            if channels_vm.is_last_page {
+                break;
+            }
+
+            channels_vm = cloud_client.list_channels_next(&channels_vm).await?;
         }
+
+        Err(anyhow!(
+            "No channel with app_id {} and name {}",
+            app_id,
+            name
+        ))
     }
 
     async fn create_and_push_bindle(


### PR DESCRIPTION
Fixes #971.

@rajatjindal This is an attempt to resolve the issue you've been seeing with the "no revision" error, but I don't have a test case to run it on.  Would you mind checking it out and seeing if it behaves correctly in all the various cases?  Thanks!

(I did it this way rather than modifying the cloud client to return all revisions so that we didn't have to hold a potentially large number of revisions in memory at once, but it does make both the client and the consumer a bit more fiddly.  Totally open to doing it the other way.)

Signed-off-by: itowlson <ivan.towlson@fermyon.com>