### PR TITLE
They said Stonehenge would stand forever

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-18.04",
+              os: "ubuntu-20.04",
               arch: "amd64",
               extension: "",
               # Ubuntu 22.04 no longer ships libssl1.1, so we statically


### PR DESCRIPTION
The Ubuntu 18.04 GitHub runner image is being deprecated and is being randomly browned out.  Including today.  This ~~removes it from~~ replaces it with 20.04 in the release action.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>