### PR TITLE
If config key isn't in Vault, try other providers or default

### DIFF
--- a/tests/http/vault-config-test/spin.toml
+++ b/tests/http/vault-config-test/spin.toml
@@ -7,13 +7,15 @@ version = "0.1.0"
 
 [variables]
 password = { required = true }
+greeting = { default = "Hello!" }
 
 [[component]]
 id = "config-test"
-source = "target/wasm32-wasi/release/config_test.wasm"
+source = "target/wasm32-wasi/release/vault_config_test.wasm"
 [component.trigger]
 route = "/..."
 [component.build]
 command = "cargo build --target wasm32-wasi --release"
 [component.config]
 password = "{{ password }}"
+greeting = "{{ greeting }}"

--- a/tests/http/vault-config-test/src/lib.rs
+++ b/tests/http/vault-config-test/src/lib.rs
@@ -8,8 +8,11 @@ use spin_sdk::{
 /// A simple Spin HTTP component.
 #[http_component]
 fn config_test(_req: Request) -> Result<Response> {
+    // Ensure we can get a value from Vault
     let password = config::get("password").expect("Failed to acquire password from vault");
+    // Ensure we can get a defaulted value
+    let greeting = config::get("greeting").expect("Failed to acquire greeting from default");
     Ok(http::Response::builder()
         .status(200)
-        .body(Some(format!("Got password {}", password).into()))?)
+        .body(Some(format!("{} Got password {}", greeting, password).into()))?)
 }


### PR DESCRIPTION
Fixes #983.

cc @FrankYang0529 (can't add you as a reviewer, sorry)

This was manually tested by modifying `examples/config-rust` with a runtime-config file.  If we have an automated test for Vault then I can add it to that.

For the time being I have replicated the current error behaviour when the error is anything other than "not found."  This will mean that if, say, Vault is down, then _all_ config lookups will fail (including ones with defaults).  This seems reasonable because we don't know if it's important to security that a value come from Vault - but the same argument applies to the 404 case.  So we might need to have think about whether we need some finer granularity longer term.