### PR TITLE
Initial add of http-php template

### DIFF
--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -414,7 +414,7 @@ mod tests {
         PathBuf::from(crate_dir).join("tests")
     }
 
-    const TPLS_IN_THIS: usize = 11;
+    const TPLS_IN_THIS: usize = 12;
 
     #[tokio::test]
     async fn can_install_into_new_directory() {

--- a/templates/http-php/content/spin.toml
+++ b/templates/http-php/content/spin.toml
@@ -1,0 +1,16 @@
+spin_version = "1"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+name = "{{project-name}}"
+trigger = { type = "http", base = "{{http-base}}" }
+version = "0.1.0"
+
+[[component]]
+id = "{{project-name | kebab_case}}"
+files = [ { source = "./src", destination = "/" } ]
+[component.source]
+url = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/php%2F7.4.32%2B20221124-2159d1c/php-cgi-7.4.32.speed-optimized.wasm"
+digest = "sha256:511720698dee56134ed8a08a87131d33c3ea8a64b6726cd6710d624bca4ceb6c"
+[component.trigger]
+executor = { type = "wagi"}
+route = "{{http-path}}"

--- a/templates/http-php/content/src/index.php
+++ b/templates/http-php/content/src/index.php
@@ -1,0 +1,1 @@
+<?php echo "Hello Fermyon Spin"; ?>

--- a/templates/http-php/metadata/spin-template.toml
+++ b/templates/http-php/metadata/spin-template.toml
@@ -1,6 +1,6 @@
 manifest_version = "1"
 id = "http-php"
-description = "HTTP PHP environment"
+description = "HTTP request handler using PHP"
 
 [parameters]
 project-description = { type = "string",  prompt = "Project description", default = "" }

--- a/templates/http-php/metadata/spin-template.toml
+++ b/templates/http-php/metadata/spin-template.toml
@@ -1,0 +1,8 @@
+manifest_version = "1"
+id = "http-php"
+description = "HTTP PHP environment"
+
+[parameters]
+project-description = { type = "string",  prompt = "Project description", default = "" }
+http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
+http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }


### PR DESCRIPTION
This adds a PHP template that uses the Wagi executor.

It uses the latest PHP build from VMware Wasm Labs: https://github.com/vmware-labs/webassembly-language-runtimes/releases

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>