### PR TITLE
chore(*): v0.7.1 version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "http",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "spin-core",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "redis",
@@ -3971,7 +3971,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-abi-conformance"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "indexmap",
  "serde",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "spin-publish"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bindle",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "http",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 rust-version = "1.64"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 edition = "2021"
 

--- a/docs/content/release-process.md
+++ b/docs/content/release-process.md
@@ -9,7 +9,7 @@ url = "https://github.com/fermyon/spin/blob/main/docs/content/release-process.md
 To cut a release of Spin, you will need to do the following:
 
 1. Create a pull request that changes the version number for your new version
-   (e.g. `0.7.0` becomes `0.7.1`)
+   (e.g. `0.7.1` becomes `0.7.2`)
    - Bump the version in Spin's `Cargo.toml`
    - Update SDK_VERSION in `templates/Makefile`
    - Check the docs for hard-coded version strings
@@ -17,8 +17,8 @@ To cut a release of Spin, you will need to do the following:
    make sure you get signoff on the PR)
 1. Before proceeding, verify that the merge commit on `main` intended to be
    tagged is green, i.e. CI is successful
-1. Create a new tag with a `v` and then the version number (`v0.7.1`)
-1. The Go SDK tag `sdk/go/v0.7.1` will be created in the [release action].
+1. Create a new tag with a `v` and then the version number (`v0.7.2`)
+1. The Go SDK tag `sdk/go/v0.7.2` will be created in the [release action].
 1. When the [release action] completes, binary artifacts and checksums will be
    automatically uploaded to the GitHub release.
 1. A Pull Request will also be created by `fermybot` containing changes to the

--- a/docs/downloads/install.sh
+++ b/docs/downloads/install.sh
@@ -28,7 +28,7 @@ print_help() {
     fancy_print 2 "This script installs Spin in the current directory."
     fancy_print 2 ""
     fancy_print 2 "Comand line arguments"
-    fancy_print 2 "--version or -v  : Provide what version to install e.g. \"v0.7.0\" or \"canary\"."
+    fancy_print 2 "--version or -v  : Provide what version to install e.g. \"v0.7.1\" or \"canary\"."
     fancy_print 2 "--help    or -h  : Shows this help message"
 }
 
@@ -48,7 +48,7 @@ while [[ $# -gt 0 ]]; do
         if [[ $# -ne 0 ]]; then
             VERSION="${1}"
         else
-            fancy_print 1 "Please provide the desired version. e.g. --version v0.7.0 or -v canary"
+            fancy_print 1 "Please provide the desired version. e.g. --version v0.7.1 or -v canary"
             exit 0
         fi
         ;;

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,4 +1,4 @@
-SDK_VERSION ?= v0.7.0
+SDK_VERSION ?= v0.7.1
 
 bump-versions: bump-go-versions bump-rust-versions
 

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
* bumps versions for the forthcoming v0.7.1 release now that the [milestone has completed](https://github.com/fermyon/spin/milestone/6)