### PR TITLE
perf: use wasmtime's pooling instance allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ members = [
 tracing = { version = "0.1", features = ["log"] }
 wasi-cap-std-sync = "3.0.0"
 wasi-common = "3.0.0"
-wasmtime = "3.0.0"
+wasmtime = { version = "3.0.0", features = ["pooling-allocator"] }
 wasmtime-wasi = { version = "3.0.0", features = ["tokio"] }
 
 [workspace.dependencies.bindle]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -64,7 +64,12 @@ impl Config {
         &mut self.inner
     }
 
-    /// Enable the Wasmtime compilation cache with the given path, if any, to load configuration from.
+    /// Enable the Wasmtime compilation cache. If `path` is given it will override
+    /// the system default path.
+    ///
+    /// For more information, see the [Wasmtime cache config documentation][docs].
+    ///
+    /// [docs]: https://docs.wasmtime.dev/cli-cache.html
     pub fn configure_cache(&mut self, config_path: &Option<PathBuf>) -> Result<()> {
         match config_path {
             Some(p) => self.inner.cache_config_load(p)?,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -75,6 +75,7 @@ impl Config {
     }
 
     /// Enable or update parameters for the pooling instance allocator.
+    #[cfg(not(target_os = "windows"))]
     pub fn enable_pooling(
         &mut self,
         max_memories: u32,
@@ -99,6 +100,7 @@ impl Config {
     }
 
     /// Disable the pooling instance allocator.
+    #[cfg(not(target_os = "windows"))]
     pub fn disable_pooling(&mut self) -> &mut Self {
         self.inner
             .allocation_strategy(wasmtime::InstanceAllocationStrategy::OnDemand);
@@ -113,6 +115,7 @@ impl Default for Config {
         inner.epoch_interruption(true);
 
         let mut config = Self { inner };
+        #[cfg(not(target_os = "windows"))]
         config.enable_pooling(
             DEFAULT_INSTANCE_MEMORIES,
             DEFAULT_INSTANCE_MEMORY_PAGES,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,8 +13,9 @@ mod limits;
 mod store;
 
 use std::{
+    path::PathBuf,
     sync::{Arc, Mutex},
-    time::Duration, path::PathBuf,
+    time::Duration,
 };
 
 use anyhow::Result;
@@ -91,14 +92,16 @@ impl Config {
             // Some wasm modules tend to have very large tables, in particular in non-optimized builds.
             .instance_table_elements(max_table_entries);
 
-            self.inner.allocation_strategy(InstanceAllocationStrategy::Pooling(pooling_config));
+        self.inner
+            .allocation_strategy(InstanceAllocationStrategy::Pooling(pooling_config));
 
-            self
+        self
     }
 
     /// Disable the pooling instance allocator.
     pub fn disable_pooling(&mut self) -> &mut Self {
-        self.inner.allocation_strategy(wasmtime::InstanceAllocationStrategy::OnDemand);
+        self.inner
+            .allocation_strategy(wasmtime::InstanceAllocationStrategy::OnDemand);
         self
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -114,16 +114,7 @@ impl Default for Config {
         inner.async_support(true);
         inner.epoch_interruption(true);
 
-        let mut config = Self { inner };
-        #[cfg(not(target_os = "windows"))]
-        config.enable_pooling(
-            DEFAULT_INSTANCE_MEMORIES,
-            DEFAULT_INSTANCE_MEMORY_PAGES,
-            DEFAULT_INSTANCE_TABLES,
-            DEFAULT_INSTANCE_TABLE_ELEMENTS,
-        );
-
-        config
+        Self { inner }
     }
 }
 

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -211,7 +211,12 @@ where
         if self.disable_pooling {
             config.disable_pooling();
         } else {
-            config.enable_pooling(self.max_memories, self.max_memory_pages, self.max_tables, self.max_table_entries);
+            config.enable_pooling(
+                self.max_memories,
+                self.max_memory_pages,
+                self.max_tables,
+                self.max_table_entries,
+            );
         }
 
         Ok(())

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -61,10 +61,12 @@ where
     pub cache: Option<PathBuf>,
 
     /// Disable Wasmtime's pooling instance allocator.
+    #[cfg(not(target_os = "windows"))]
     #[clap(long = "disable-pooling")]
     pub disable_pooling: bool,
 
     /// Maximum number of memories each instance can use.
+    #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-memories",
         conflicts_with = "disable-pooling",
@@ -73,6 +75,7 @@ where
     pub max_memories: u32,
 
     /// Maximum size for each instance memory, in 64kb pages.
+    #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-memory-pages",
         conflicts_with = "disable-pooling",
@@ -81,6 +84,7 @@ where
     pub max_memory_pages: u64,
 
     /// Maximum number of tables each instance can use.
+    #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-tables",
         conflicts_with = "disable-pooling",
@@ -89,6 +93,7 @@ where
     pub max_tables: u32,
 
     /// Maximum number of entries each table can contain.
+    #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-table-entries",
         conflicts_with = "disable-pooling",
@@ -208,6 +213,7 @@ where
             config.configure_cache(&self.cache)?;
         }
 
+        #[cfg(not(target_os = "windows"))]
         if self.disable_pooling {
             config.disable_pooling();
         } else {

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -18,10 +18,6 @@ pub const FOLLOW_LOG_OPT: &str = "FOLLOW_ID";
 pub const WASMTIME_CACHE_FILE: &str = "WASMTIME_CACHE_FILE";
 pub const RUNTIME_CONFIG_FILE: &str = "RUNTIME_CONFIG_FILE";
 
-// pub const DISABLE_POOLING_ALLOCATOR: &str = "DISABLE_POOLING_ALLOCATOR";
-// pub const POOLING_SLOTS: &str = "POOLING_SLOTS";
-// pub const POOLING_: &str = "POOLING_";
-
 // Set by `spin up`
 pub const SPIN_LOCKED_URL: &str = "SPIN_LOCKED_URL";
 pub const SPIN_WORKING_DIR: &str = "SPIN_WORKING_DIR";

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -56,16 +56,16 @@ where
     )]
     pub cache: Option<PathBuf>,
 
-    /// Disable Wasmtime's pooling instance allocator.
+    /// Enable Wasmtime's pooling instance allocator.
     #[cfg(not(target_os = "windows"))]
-    #[clap(long = "disable-pooling")]
-    pub disable_pooling: bool,
+    #[clap(long = "enable-pooling")]
+    pub enable_pooling: bool,
 
     /// Maximum number of memories each instance can use.
     #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-memories",
-        conflicts_with = "disable-pooling",
+        requires = "enable-pooling",
         default_value_t = spin_core::DEFAULT_INSTANCE_MEMORIES,
     )]
     pub max_memories: u32,
@@ -74,7 +74,7 @@ where
     #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-memory-pages",
-        conflicts_with = "disable-pooling",
+        requires = "enable-pooling",
         default_value_t = spin_core::DEFAULT_INSTANCE_MEMORY_PAGES,
     )]
     pub max_memory_pages: u64,
@@ -83,7 +83,7 @@ where
     #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-tables",
-        conflicts_with = "disable-pooling",
+        requires = "enable-pooling",
         default_value_t = spin_core::DEFAULT_INSTANCE_TABLES,
     )]
     pub max_tables: u32,
@@ -92,7 +92,7 @@ where
     #[cfg(not(target_os = "windows"))]
     #[clap(
         long = "pooling-max-table-entries",
-        conflicts_with = "disable-pooling",
+        requires = "enable-pooling",
         default_value_t = spin_core::DEFAULT_INSTANCE_TABLE_ELEMENTS,
     )]
     pub max_table_entries: u32,
@@ -210,15 +210,15 @@ where
         }
 
         #[cfg(not(target_os = "windows"))]
-        if self.disable_pooling {
-            config.disable_pooling();
-        } else {
+        if self.enable_pooling {
             config.enable_pooling(
                 self.max_memories,
                 self.max_memory_pages,
                 self.max_tables,
                 self.max_table_entries,
             );
+        } else {
+            config.disable_pooling();
         }
 
         Ok(())

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -66,8 +66,8 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
     /// !!!Warning!!! Using a custom Wasmtime Config is entirely unsupported;
     /// many configurations are likely to cause errors or unexpected behavior.
     #[doc(hidden)]
-    pub fn wasmtime_config_mut(&mut self) -> &mut spin_core::wasmtime::Config {
-        self.config.wasmtime_config()
+    pub fn config_mut(&mut self) -> &mut spin_core::Config {
+        &mut self.config
     }
 
     pub fn hooks(&mut self, hooks: impl TriggerHooks + 'static) -> &mut Self {


### PR DESCRIPTION
For environments like Spin that create many wasm instances with a short lifetime, the pooling allocator can substantially improve performance, in particular in high-concurrency setups.

This commit enables the pooling allocator, improving performance for the `spin-executor/sleep-1ms/concurrency-{8,32}` benchmarks by about 85%. E.g. the `concurrency-8` benchmark on my machine goes from about 2.7ms to about 350us per iteration. These numbers are all on macOS, and should be better on Linux, where the kernel provides more efficient syscalls for the pooling allocator to use.

The pooling allocator requires choosing limits on the resources an instance can use. This patch makes those configurable, and sets the following defaults:
- max number of memories: 1
- max memory size, in 64kb wasm pages: 2048 (128MB)
- max number of tables: 1
- max number of table entries: 100,000