### PR TITLE
Enable TLS for outbound Redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522f2f30f72de409fc04f88df25a031f98cfc5c398a94e0b892cabb33a1464cb"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bigdecimal",
  "bindgen",
  "bitflags",
@@ -3286,11 +3286,13 @@ dependencies = [
  "combine",
  "futures-util",
  "itoa 1.0.4",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1 0.6.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-util 0.7.4",
  "url",
 ]

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-redis = { version = "0.21", features = ["tokio-comp"] }
+redis = { version = "0.21", features = ["tokio-comp", "tokio-native-tls-comp"] }
 spin-core = { path = "../core" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }


### PR DESCRIPTION
This commit enables the `tokio-native-tls-comp` feature for the Redis crate used when making outbound Redis calls from Spin apps.

This lets users connect to Redis instances with TLS enabled (`rediss://`).

Signed-off-by: Radu Matei <radu.matei@fermyon.com>