### PR TITLE
feat: Add TLS connection support for outbound PG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522f2f30f72de409fc04f88df25a031f98cfc5c398a94e0b892cabb33a1464cb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bigdecimal",
  "bindgen",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,9 +2501,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2662,9 +2662,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2694,9 +2694,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.76"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -2766,6 +2766,8 @@ name = "outbound-pg"
 version = "0.7.1"
 dependencies = [
  "anyhow",
+ "native-tls",
+ "postgres-native-tls",
  "spin-core",
  "tokio",
  "tokio-postgres",
@@ -3016,6 +3018,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d442770e2b1e244bb5eb03b31c79b65bb2568f413b899eaba850fa945a65954"
+dependencies = [
+ "futures",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/crates/outbound-pg/Cargo.toml
+++ b/crates/outbound-pg/Cargo.toml
@@ -9,6 +9,8 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
+native-tls = "0.2.11"
+postgres-native-tls = "0.5.0"
 spin-core = { path = "../core" }
 tokio = { version = "1", features = [ "rt-multi-thread" ] }
 tokio-postgres = { version = "0.7.7" }

--- a/crates/outbound-pg/src/lib.rs
+++ b/crates/outbound-pg/src/lib.rs
@@ -242,7 +242,7 @@ impl OutboundPg {
 async fn build_client(address: &str) -> anyhow::Result<Client> {
     let config = address.parse::<tokio_postgres::Config>()?;
 
-    tracing::log::debug!("Build new connection: {}", address);
+    tracing::debug!("Build new connection: {}", address);
 
     if config.get_ssl_mode() == SslMode::Disable {
         connect(config).await
@@ -275,7 +275,7 @@ where
 {
     tokio::spawn(async move {
         if let Err(e) = connection.await {
-            tracing::warn!("Postgres connection error: {}", e);
+            tracing::error!("Postgres connection error: {}", e);
         }
     });
 }

--- a/examples/config-rust/Cargo.lock
+++ b/examples/config-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/http-rust-outbound-http/Cargo.lock
+++ b/examples/http-rust-outbound-http/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/redis-rust/Cargo.lock
+++ b/examples/redis-rust/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/rust-outbound-pg/Cargo.lock
+++ b/examples/rust-outbound-pg/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/rust-outbound-redis/Cargo.lock
+++ b/examples/rust-outbound-redis/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Underneath it conditionally uses `NoTls` when `sslmode=disable` and
sets up tls connector otherwise.

NOTE:
By default, `tokio_postgres` is using `sslmode=prefer`, so to
avoid [SSL setup overhead](https://github.com/fermyon/spin/pull/1003/files#diff-f65e2bbae4f787ee6d317acab2e0e1b4d583fe1ba676febf33162986ee978200R263-R264) `sslmode=disable` should be provided
explicitly.

Refs: https://github.com/fermyon/spin/issues/936

Signed-off-by: Konstantin Shabanov <mail@etehtsea.me>