### PR TITLE
ci(build.yml): only upload to codecov if fermyon org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,9 +317,12 @@ jobs:
         env:
           RUST_LOG: spin=trace
 
+      # Only attempt to upload to codecov.io if the repo owner is fermyon.
+      # This allows forks to run CI on their own main branches as usual,
+      # without needing to have a codecov token for uploading.
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'fermyon' }}
         with:
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
For now, only attempt to upload codecov reports if this is running on this `fermyon` origin, where we can guarantee a codecov token is present.  Forks may not have such a token and we don't wish to fail their CI runs on this detail.

(We _do_ wish to preserve the `fail_ci_if_error` toggle so that we're alerted when there are issues uploading when running from the `fermyon` org, hence keeping this set to true.)