### PR TITLE
Fix Vault config example to point to correct wasm source path

### DIFF
--- a/tests/http/vault-config-test/spin.toml
+++ b/tests/http/vault-config-test/spin.toml
@@ -10,7 +10,7 @@ password = { required = true }
 
 [[component]]
 id = "config-test"
-source = "target/wasm32-wasi/release/config_test.wasm"
+source = "target/wasm32-wasi/release/vault_config_test.wasm"
 [component.trigger]
 route = "/..."
 [component.build]


### PR DESCRIPTION
The [example for using the Vault Config Provider](https://developer.fermyon.com/spin/configuration#vault-config-provider) points to the wrong path for the Wasm source.

Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>