### PR TITLE
Support new static-fileserver apps

### DIFF
--- a/templates/static-fileserver/content/spin.toml
+++ b/templates/static-fileserver/content/spin.toml
@@ -1,0 +1,13 @@
+spin_version = "1"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+name = "{{project-name}}"
+trigger = { type = "http", base = "{{http-base}}" }
+version = "0.1.0"
+
+[[component]]
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+id = "{{ project-name }}"
+files = [ { source = "{{ files-path }}", destination = "/" } ]
+[component.trigger]
+route = "{{ http-path | http_wildcard }}"

--- a/templates/static-fileserver/metadata/spin-template.toml
+++ b/templates/static-fileserver/metadata/spin-template.toml
@@ -3,13 +3,14 @@ id = "static-fileserver"
 description = "Serves static files from an asset directory"
 trigger_type = "http"
 
-[new_application]
-supported = false
-
 [add_component]
+skip_files = ["spin.toml"]
+skip_parameters = ["http-base", "project-description"]
 [add_component.snippets]
 component = "component.txt"
 
 [parameters]
+project-description = { type = "string",  prompt = "Project description", default = "" }
+http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/static/...", pattern = "^/\\S*$" }
 files-path = { type = "string", prompt = "Directory containing the files to serve", default = "assets", pattern = "^\\S+$" }


### PR DESCRIPTION
When I wrote the static-fileserver template, I assumed it would only really be used to add static file support to larger applications.  As @mikkelhegn has pointed out, that's a questionable assumption.  (After all, he questioned it.  _Res ipsa loquitur._)  And there is no particular reason to block it so why not.  So this removes that restriction, and allows you to `spin new` a static file server.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>