### PR TITLE
integration: Fix running on systems with sparse /bin

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1009,7 +1009,7 @@ mod integration_tests {
         if cfg!(target_os = "windows") {
             String::from("powershell.exe")
         } else {
-            String::from("/bin/bash")
+            String::from("bash")
         }
     }
 


### PR DESCRIPTION
`/bin/bash` is an unstable path that doesn't exist on all distributions, or may point to an unwanted version of bash. Here we switch to relying on pulling Bash from a users `PATH` to cover those cases (the same as we do in `build.rs`).

This fixes running integration tests on NixOS.