### PR TITLE
Change `spin plugin` command to `spin plugins` retaining singular as an alias

### DIFF
--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -141,7 +141,7 @@ fn inner_check_supported_version(
             eprintln!("Plugin is not compatible with this version of Spin (supported: {supported_on}, actual: {spin_version}). Check overridden ... continuing to install or execute plugin.");
         } else {
             return Err(anyhow!(
-            "Plugin is not compatible with this version of Spin (supported: {supported_on}, actual: {spin_version}). Try running `spin plugin update && spin plugin upgrade --all` to install latest or override with `--override-compatibility-check`."
+            "Plugin is not compatible with this version of Spin (supported: {supported_on}, actual: {spin_version}). Try running `spin plugins update && spin plugins upgrade --all` to install latest or override with `--override-compatibility-check`."
         ));
         }
     }

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -53,8 +53,8 @@ enum SpinApp {
     Deploy(DeployCommand),
     Build(BuildCommand),
     Login(LoginCommand),
-    #[clap(subcommand, alias = "plugins")]
-    Plugin(PluginCommands),
+    #[clap(subcommand, alias = "plugin")]
+    Plugins(PluginCommands),
     #[clap(subcommand, hide = true)]
     Trigger(TriggerCommands),
     #[clap(external_subcommand)]
@@ -81,7 +81,7 @@ impl SpinApp {
             Self::Trigger(TriggerCommands::Http(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::Redis(cmd)) => cmd.run().await,
             Self::Login(cmd) => cmd.run().await,
-            Self::Plugin(cmd) => cmd.run().await,
+            Self::Plugins(cmd) => cmd.run().await,
             Self::External(cmd) => execute_external_subcommand(cmd, SpinApp::command()).await,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1201,7 +1201,7 @@ route = "/..."
         // Install plugin
         let install_args = vec![
             SPIN_BINARY,
-            "plugin",
+            "plugins",
             "install",
             "--file",
             manifest_file_path.to_str().unwrap(),
@@ -1227,7 +1227,7 @@ route = "/..."
         )?;
         let upgrade_args = vec![
             SPIN_BINARY,
-            "plugin",
+            "plugins",
             "upgrade",
             "example",
             "--file",
@@ -1248,7 +1248,7 @@ route = "/..."
         assert!(manifest.contains("0.2.1"));
 
         // Uninstall plugin
-        let uninstall_args = vec![SPIN_BINARY, "plugin", "uninstall", "example"];
+        let uninstall_args = vec![SPIN_BINARY, "plugins", "uninstall", "example"];
         run(uninstall_args, None, None)?;
         Ok(())
     }

--- a/tests/plugin/README.md
+++ b/tests/plugin/README.md
@@ -1,7 +1,7 @@
 # Example Plugin
 
 This `example.sh` script acts as an example Spin plugin for testing Spin plugin functionality.
-It is referenced in the `spin plugin` [integration tests](../integration.rs)
+It is referenced in the `spin plugins` [integration tests](../integration.rs)
 
 To recreate:
 


### PR DESCRIPTION
Swapping from top-level singular to plural command aligns the command plurality more with templates.
closes #1042 

Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>