### PR TITLE
Update clap dependency from v3 to v4.1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,538 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-abi-conformance'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-abi-conformance"
+                ],
+                "filter": {
+                    "name": "spin-abi-conformance",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'spin-abi-conformance'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=spin-abi-conformance",
+                    "--package=spin-abi-conformance"
+                ],
+                "filter": {
+                    "name": "spin-abi-conformance",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'spin-abi-conformance'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=spin-abi-conformance",
+                    "--package=spin-abi-conformance"
+                ],
+                "filter": {
+                    "name": "spin-abi-conformance",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-app'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-app"
+                ],
+                "filter": {
+                    "name": "spin-app",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-core'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-core"
+                ],
+                "filter": {
+                    "name": "spin-core",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'integration_test'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=integration_test",
+                    "--package=spin-core"
+                ],
+                "filter": {
+                    "name": "integration_test",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-build'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-build"
+                ],
+                "filter": {
+                    "name": "spin-build",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-loader'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-loader"
+                ],
+                "filter": {
+                    "name": "spin-loader",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'outbound-http'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=outbound-http"
+                ],
+                "filter": {
+                    "name": "outbound-http",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-manifest'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-manifest"
+                ],
+                "filter": {
+                    "name": "spin-manifest",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-config'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-config"
+                ],
+                "filter": {
+                    "name": "spin-config",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-http'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-http"
+                ],
+                "filter": {
+                    "name": "spin-http",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'baseline'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=baseline",
+                    "--package=spin-http"
+                ],
+                "filter": {
+                    "name": "baseline",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-trigger'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-trigger"
+                ],
+                "filter": {
+                    "name": "spin-trigger",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'outbound-mysql'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=outbound-mysql"
+                ],
+                "filter": {
+                    "name": "outbound-mysql",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'outbound-pg'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=outbound-pg"
+                ],
+                "filter": {
+                    "name": "outbound-pg",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'outbound-redis'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=outbound-redis"
+                ],
+                "filter": {
+                    "name": "outbound-redis",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-testing'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-testing"
+                ],
+                "filter": {
+                    "name": "spin-testing",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-plugins'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-plugins"
+                ],
+                "filter": {
+                    "name": "spin-plugins",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-redis-engine'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-redis-engine"
+                ],
+                "filter": {
+                    "name": "spin-redis-engine",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-templates'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-templates"
+                ],
+                "filter": {
+                    "name": "spin-templates",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin_sdk'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-sdk"
+                ],
+                "filter": {
+                    "name": "spin_sdk",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-cli'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-cli"
+                ],
+                "filter": {
+                    "name": "spin-cli",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'spin'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=spin",
+                    "--package=spin-cli"
+                ],
+                "filter": {
+                    "name": "spin",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'spin'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=spin",
+                    "--package=spin-cli"
+                ],
+                "filter": {
+                    "name": "spin",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'integration'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=integration",
+                    "--package=spin-cli"
+                ],
+                "filter": {
+                    "name": "integration",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'cloud'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=cloud"
+                ],
+                "filter": {
+                    "name": "cloud",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'spin-publish'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=spin-publish"
+                ],
+                "filter": {
+                    "name": "spin-publish",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,13 +537,47 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
+version = "4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+dependencies = [
+ "bitflags",
+ "clap_derive 4.1.0",
+ "clap_lex 0.3.1",
+ "is-terminal 0.4.2",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6540eedc41f8a5a76cf3d8d458057dcdf817be4158a55b5f861f7a5483de75"
+dependencies = [
+ "clap 4.1.4",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0c76d8fcf782a1102ccfcd10ca8246e7fdd609c1cd6deddbb96cb638e9bb5c"
+dependencies = [
+ "clap 4.1.4",
+ "clap_complete",
 ]
 
 [[package]]
@@ -560,10 +594,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -4108,7 +4164,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "cap-std",
- "clap 3.2.23",
+ "clap 4.1.4",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -4159,7 +4215,9 @@ dependencies = [
  "bytes",
  "cargo-target-dep",
  "chrono",
- "clap 3.2.23",
+ "clap 4.1.4",
+ "clap_complete",
+ "clap_complete_fig",
  "cloud",
  "cloud-openapi",
  "comfy-table",
@@ -4249,7 +4307,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 3.2.23",
+ "clap 4.1.4",
  "criterion",
  "futures",
  "futures-util",
@@ -4470,7 +4528,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 3.2.23",
+ "clap 4.1.4",
  "ctrlc",
  "dirs 4.0.0",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ async-trait = "0.1"
 bindle = { workspace = true }
 bytes = "1.1"
 chrono = "0.4"
-clap = { version = "3.1.15", features = ["derive", "env"] }
+clap = { version = "4.1", features = ["derive", "env"] }
+clap_complete = { version = "4.1", optional = true }
+clap_complete_fig = { version = "4.1", optional = true }
 cloud = { path = "crates/cloud" }
 cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi" }
 comfy-table = "5.0"
@@ -80,12 +82,13 @@ vergen = { version = "7", default-features = false, features = [
 ] }
 
 [features]
-default = []
+default = ["generate-completions"]
 e2e-tests = []
 outbound-redis-tests = []
 config-provider-tests = []
 outbound-pg-tests = []
 outbound-mysql-tests = []
+generate-completions = ["dep:clap_complete", "dep:clap_complete_fig"]
 
 [workspace]
 members = [

--- a/crates/abi-conformance/Cargo.toml
+++ b/crates/abi-conformance/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0.44"
 cap-std = "0.26.1"
-clap = { version = "3.1.15", features = ["derive", "env"] }
+clap = { version = "4.1", features = ["derive", "env"] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_core = "0.6.3"

--- a/crates/abi-conformance/src/bin/spin-abi-conformance.rs
+++ b/crates/abi-conformance/src/bin/spin-abi-conformance.rs
@@ -8,18 +8,18 @@ use std::{
 use wasmtime::{Config, Engine, Module};
 
 #[derive(Parser)]
-#[clap(author, version, about)]
+#[command(author, version, about)]
 pub struct Options {
     /// Name of Wasm file to test (or stdin if not specified)
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub input: Option<PathBuf>,
 
     /// Name of JSON file to write report to (or stdout if not specified)
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub output: Option<PathBuf>,
 
     /// Name of TOML configuration file to use
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub config: Option<PathBuf>,
 }
 

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-clap = "3"
+clap = "4.1"
 futures = "0.3"
 futures-util = "0.3.8"
 http = "0.2"

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-clap = { version = "3.1.15", features = ["derive", "env"] }
+clap = { version = "4.1", features = ["derive", "env"] }
 ctrlc = { version = "3.2", features = ["termination"] }
 dirs = "4"
 futures = "0.3"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,5 @@
+pub mod cli;
+pub mod component;
+pub mod app_source;
+pub mod manifest_file;
+pub mod temp;

--- a/src/args/app_source.rs
+++ b/src/args/app_source.rs
@@ -1,0 +1,125 @@
+use crate::{args::manifest_file::ManifestFile, commands::up::UpCommand, opts::BINDLE_URL_ENV};
+use anyhow::Result;
+use clap::{error::ErrorKind, Args, Command, CommandFactory, Error, FromArgMatches, Id};
+use spin_manifest::Application;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub enum AppSource {
+    Local(LocalSource),
+    Bindle(BindleSource),
+}
+
+impl Default for AppSource {
+    fn default() -> Self {
+        Self::Local(LocalSource::default())
+    }
+}
+
+impl AppSource {
+    pub async fn load(&self, working_dir: &PathBuf) -> Result<Application, Error> {
+        match self {
+            AppSource::Local(app) => {
+                spin_loader::from_file(
+                    &app.file,
+                    if app.direct_mounts {
+                        Some(&working_dir)
+                    } else {
+                        None
+                    },
+                    &None,
+                )
+                .await
+            }
+            AppSource::Bindle(bindle) => {
+                spin_loader::from_bindle(
+                    bindle.bindle.as_str(),
+                    bindle.bindle_server.as_str(),
+                    &working_dir,
+                )
+                .await
+            }
+        }
+        .map_err(|_| Error::new(ErrorKind::Io).with_cmd(&UpCommand::command()))
+    }
+}
+
+impl FromArgMatches for AppSource {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, Error> {
+        let bindle = BindleSource::from_arg_matches(matches);
+        let local = LocalSource::from_arg_matches(matches);
+
+        if matches.contains_id("BindleOptions") && matches.contains_id("LocalOptions") {
+            return Err(Error::new(ErrorKind::ArgumentConflict));
+        }
+
+        match (local, bindle) {
+            (Err(local), Err(_)) => return Err(local),
+            (Ok(local), _) => Ok(Self::Local(local)),
+            (_, Ok(bindle)) => Ok(Self::Bindle(bindle)),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), Error> {
+        Ok(*self = Self::from_arg_matches(matches)?)
+    }
+}
+
+impl Args for AppSource {
+    fn group_id() -> Option<Id> {
+        None
+    }
+    fn augment_args(cmd: Command) -> Command {
+        BindleSource::augment_args(LocalSource::augment_args(cmd))
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        BindleSource::augment_args_for_update(LocalSource::augment_args_for_update(cmd))
+    }
+}
+
+#[derive(Args, Clone, Debug, Default)]
+#[command(next_help_heading = "Local Options")]
+pub struct LocalSource {
+    /// Path to spin.toml
+    #[arg(long, short, default_value_t = ManifestFile::default(), required = false)]
+    file: ManifestFile,
+
+    /// For local apps with directory mounts and no excluded files, mount them directly instead of using a temporary
+    /// directory.
+    ///
+    /// This allows you to update the assets on the host filesystem such that the updates are visible to the guest
+    /// without a restart.  This cannot be used with bindle apps or apps which use file patterns and/or exclusions.
+    #[arg(long)]
+    direct_mounts: bool,
+}
+
+impl LocalSource {
+    pub fn new(file: ManifestFile, direct_mounts: bool) -> Self {
+        Self {
+            file,
+            direct_mounts,
+        }
+    }
+}
+
+#[derive(Args, Clone, Debug, Default)]
+#[command(next_help_heading = "Bindle Options")]
+pub struct BindleSource {
+    #[arg(long, short, required = false)]
+    bindle: String,
+    /// URL of bindle server.
+    #[arg(long, env = BINDLE_URL_ENV, required = false)]
+    bindle_server: String,
+
+    /// Basic http auth username for the bindle server
+    #[arg(long, env, requires = "bindle_password")]
+    bindle_username: Option<String>,
+    /// Basic http auth password for the bindle server
+    #[arg(long, env, requires = "bindle_username")]
+    bindle_password: Option<String>,
+
+    /// Ignore server certificate errors from bindle server
+    #[arg(short = 'k', long)]
+    insecure: bool,
+}

--- a/src/args/cli.rs
+++ b/src/args/cli.rs
@@ -1,0 +1,215 @@
+use std::ffi::OsString;
+
+use clap::{Arg, Args, CommandFactory, FromArgMatches, Parser};
+
+fn format_error<I: CommandFactory>(err: clap::Error) -> clap::Error {
+    let mut cmd = I::command();
+    err.format(&mut cmd)
+}
+
+pub struct App<P>
+where
+    P: Parser + CommandFactory,
+{
+    parser: P,
+}
+
+impl<P> App<P>
+where
+    P: Parser + CommandFactory,
+{
+    pub fn get_parser(self) -> P {
+        self.parser
+    }
+}
+
+impl<P> CommandFactory for App<P>
+where
+    P: Parser + CommandFactory,
+{
+    fn command() -> clap::Command {
+        P::command()
+    }
+
+    fn command_for_update() -> clap::Command {
+        P::command_for_update()
+    }
+}
+
+impl<P> FromArgMatches for App<P>
+where
+    P: Parser + CommandFactory,
+{
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        Ok(Self {
+            parser: P::from_arg_matches(&matches)?,
+        })
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        P::update_from_arg_matches(&mut self.parser, matches)
+    }
+}
+
+impl<P> Parser for App<P>
+where
+    P: Parser + CommandFactory,
+{
+    fn parse() -> Self {
+        let mut matches = <Self as clap::CommandFactory>::command().get_matches();
+        let res = <Self as clap::FromArgMatches>::from_arg_matches_mut(&mut matches)
+            .map_err(format_error::<Self>);
+        match res {
+            Ok(s) => s,
+            Err(e) => {
+                // Since this is more of a development-time error, we aren't doing as fancy of a quit
+                // as `get_matches`
+                e.exit()
+            }
+        }
+    }
+
+    fn try_parse() -> Result<Self, clap::Error> {
+        let mut matches = <P as clap::CommandFactory>::command().try_get_matches()?;
+        Ok(Self {
+            parser: <P as clap::FromArgMatches>::from_arg_matches_mut(&mut matches)
+                .map_err(format_error::<P>)?,
+        })
+    }
+
+    fn parse_from<I, T>(itr: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let mut matches = <P as clap::CommandFactory>::command().get_matches_from(itr);
+        let res = <P as clap::FromArgMatches>::from_arg_matches_mut(&mut matches)
+            .map_err(format_error::<P>);
+        match res {
+            Ok(s) => Self { parser: s },
+            Err(e) => {
+                // Since this is more of a development-time error, we aren't doing as fancy of a quit
+                // as `get_matches_from`
+                e.exit()
+            }
+        }
+    }
+
+    fn try_parse_from<I, T>(itr: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let mut matches = <P as clap::CommandFactory>::command().try_get_matches_from(itr)?;
+        Ok(Self {
+            parser: <P as clap::FromArgMatches>::from_arg_matches_mut(&mut matches)
+                .map_err(format_error::<P>)?,
+        })
+    }
+
+    fn update_from<I, T>(&mut self, itr: I)
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let mut matches = <P as clap::CommandFactory>::command_for_update().get_matches_from(itr);
+        let res = <P as clap::FromArgMatches>::update_from_arg_matches_mut(
+            &mut self.parser,
+            &mut matches,
+        )
+        .map_err(format_error::<P>);
+        if let Err(e) = res {
+            // Since this is more of a development-time error, we aren't doing as fancy of a quit
+            // as `get_matches_from`
+            e.exit()
+        }
+    }
+}
+
+impl<P> App<P>
+where
+    P: Parser + CommandFactory,
+{
+    pub fn without_errors() -> Result<Self, clap::Error> {
+        Ok(Self {
+            parser: P::from_arg_matches(&P::command().ignore_errors(true).try_get_matches()?)?,
+        })
+    }
+    pub fn start<O>(map_err: O) -> Result<Self, clap::Error>
+    where
+        O: FnOnce(Result<Self, clap::Error>, Self) -> Result<Self, clap::Error>,
+    {
+        map_err(Self::try_parse(), Self::without_errors()?)
+    }
+}
+
+#[derive(Debug)]
+pub struct Command<P>
+where
+    P: Parser,
+{
+    args: P,
+}
+
+impl<P> Command<P>
+where
+    P: Parser,
+{
+    pub fn get_args(self) -> P {
+        self.args
+    }
+
+    pub fn catch(self, error: clap::Error) -> ! {
+        error.exit()
+    }
+}
+
+impl<P> FromArgMatches for Command<P>
+where
+    P: Parser,
+{
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        Ok(Self {
+            args: P::from_arg_matches(&matches)?,
+        })
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        P::update_from_arg_matches(&mut self.args, matches)
+    }
+}
+
+impl<P> Args for Command<P>
+where
+    P: Args + Parser,
+{
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        P::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        P::augment_args_for_update(cmd)
+    }
+}
+
+pub fn mut_subs<F>(f: F) -> impl Fn(clap::Command) -> clap::Command
+where
+    F: Fn(clap::Command) -> clap::Command,
+{
+    move |cmd| {
+        cmd.clone()
+            .get_subcommands_mut()
+            .fold(cmd, |cmd, sub| cmd.mut_subcommand(sub.get_name(), &f))
+    }
+}
+
+pub fn mut_args<F>(f: F) -> impl Fn(clap::Command) -> clap::Command
+where
+    F: Fn(Arg) -> Arg,
+{
+    move |cmd| {
+        cmd.clone()
+            .get_arguments()
+            .fold(cmd, |cmd, arg| cmd.mut_arg(arg.get_id(), &f))
+    }
+}

--- a/src/args/component.rs
+++ b/src/args/component.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use super::temp::TempDir;
+use anyhow::{bail, Result};
+use clap::Args;
+
+/// Options to pass to components
+#[derive(Args, Debug, Clone, Default)]
+#[command(next_help_heading = "Component Options")]
+pub struct ComponentOptions {
+    /// Temporary directory for the static assets of the components.
+    #[arg(long, default_value_t = TempDir::default())]
+    pub temp: TempDir,
+    /// Pass an environment variable (key=value) to all components of the application.
+    #[arg(short, long, value_parser = parse_env_var)]
+    pub env: Vec<(String, String)>,
+}
+
+impl ComponentOptions {
+    pub fn working_dir(&self) -> Result<PathBuf> {
+        Ok(self.temp.as_path().canonicalize()?)
+    }
+}
+
+// Parse the environment variables passed in `key=value` pairs.
+fn parse_env_var(env: &str) -> Result<(String, String)> {
+    if let Some((var, value)) = env.split_once('=') {
+        Ok((var.to_owned(), value.to_owned()))
+    } else {
+        bail!("Environment variable must be of the form `key=value`")
+    }
+}

--- a/src/args/manifest_file.rs
+++ b/src/args/manifest_file.rs
@@ -1,0 +1,64 @@
+use std::{
+    fmt,
+    fmt::{Debug, Display, Formatter},
+    path::{Path, PathBuf},
+    str::FromStr, convert::Infallible,
+};
+
+pub use anyhow::{Result, Error};
+pub use crate::opts::DEFAULT_MANIFEST_FILE;
+
+#[derive(Clone, Debug)]
+pub struct ManifestFile {
+    relative_path: PathBuf
+}
+
+impl ManifestFile {
+    pub fn new(relative_path: PathBuf) -> Self {
+        Self { relative_path }
+    }
+    pub fn canonicalize(&self) -> Result<PathBuf> {
+        Ok(self.relative_path.canonicalize()?)
+    }
+
+    pub async fn build(&self) -> Result<()> {
+        spin_build::build(&self.relative_path).await
+    }
+}
+
+impl AsRef<Path> for ManifestFile {
+    fn as_ref(&self) -> &Path {
+        &self.relative_path
+    }
+}
+
+impl From<&Path> for ManifestFile {
+    fn from(value: &Path) -> Self {
+        value.to_path_buf().into()
+    }
+}
+
+impl From<PathBuf> for ManifestFile {
+    fn from(value: PathBuf) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Default for ManifestFile {
+    fn default() -> Self {
+        PathBuf::from(DEFAULT_MANIFEST_FILE).into()
+    }
+}
+
+impl FromStr for ManifestFile {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Infallible> {
+        PathBuf::from_str(s).map(Self::from)
+    }
+}
+
+impl Display for ManifestFile {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        self.relative_path.fmt(f)
+    }
+}

--- a/src/args/temp.rs
+++ b/src/args/temp.rs
@@ -1,0 +1,41 @@
+use std::{
+    fmt::{Debug, Display, Error, Formatter},
+    path::{PathBuf, Path},
+    str::FromStr,
+};
+
+use anyhow::Result;
+use tempfile::tempdir;
+
+#[derive(Clone, Debug)]
+pub struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    pub fn new(path: PathBuf) -> TempDir {
+        Self { path }
+    }
+    pub fn as_path(&self) -> &Path {
+        self.path.as_path()
+    }
+}
+
+impl Default for TempDir {
+    fn default() -> Self {
+        Self::new(tempdir().expect("Temp").path().to_path_buf())
+    }
+}
+
+impl Display for TempDir {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        Ok(self.path.fmt(f)?)
+    }
+}
+
+impl FromStr for TempDir {
+    type Err = <PathBuf as FromStr>::Err;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(PathBuf::from_str(s)?))
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,6 +9,9 @@ pub mod deploy;
 /// Commands for external subcommands (i.e. plugins)
 pub mod external;
 // Command for logging into the server
+#[cfg(feature = "generate-completions")]
+/// Command for generating completions.
+pub mod generate_completions;
 pub mod login;
 /// Command for creating a new application.
 pub mod new;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,53 +1,26 @@
-use std::{ffi::OsString, path::PathBuf};
-
+use super::up::{UpCommand, Flag};
+use crate::{args::manifest_file::ManifestFile, dispatch::Dispatch};
+use crate::dispatch::Runner;
 use anyhow::Result;
+use async_trait::async_trait;
 use clap::Parser;
 
-use crate::opts::{APP_CONFIG_FILE_OPT, BUILD_UP_OPT, DEFAULT_MANIFEST_FILE};
-
-use super::up::UpCommand;
-
-/// Run the build command for each component.
+/// Build the Spin application
 #[derive(Parser, Debug)]
-#[clap(about = "Build the Spin application", allow_hyphen_values = true)]
+#[command(subcommand_required=false)]
 pub struct BuildCommand {
     /// Path to spin.toml.
-    #[clap(
-            name = APP_CONFIG_FILE_OPT,
-            short = 'f',
-            long = "file",
-        )]
-    pub app: Option<PathBuf>,
-
-    /// Run the application after building.
-    #[clap(name = BUILD_UP_OPT, short = 'u', long = "up")]
-    pub up: bool,
-
-    #[clap(requires = BUILD_UP_OPT)]
-    pub up_args: Vec<OsString>,
+    #[arg(long, short, default_value_t = ManifestFile::default(), required = false)]
+    pub file: ManifestFile,
+    #[command(subcommand)]
+    pub up: Flag<UpCommand>,
 }
 
-impl BuildCommand {
-    pub async fn run(self) -> Result<()> {
-        let manifest_file = self
-            .app
-            .as_deref()
-            .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
-
-        spin_build::build(manifest_file).await?;
-
-        if self.up {
-            let mut cmd = UpCommand::parse_from(
-                std::iter::once(OsString::from(format!(
-                    "{} up",
-                    std::env::args().next().unwrap()
-                )))
-                .chain(self.up_args),
-            );
-            cmd.app = Some(manifest_file.into());
-            cmd.run().await
-        } else {
-            Ok(())
-        }
+#[async_trait(?Send)]
+impl Dispatch for BuildCommand {
+    async fn run(&self) -> Result<()> {
+        let Self { file, up } = self;
+        file.build().await?;
+        up.run().await
     }
 }

--- a/src/commands/generate_completions.rs
+++ b/src/commands/generate_completions.rs
@@ -1,0 +1,66 @@
+use anyhow::Error;
+use async_trait::async_trait;
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap_complete::{generate, Generator, Shell};
+use clap_complete_fig::Fig;
+
+use crate::dispatch::Dispatch;
+
+#[derive(Subcommand)]
+pub enum GenerateCompletionsCommands {
+    Shell(GenerateCompletionsShellCommand),
+    Fig(GenerateCompletionsFigCommand),
+}
+
+#[async_trait(?Send)]
+impl Dispatch for GenerateCompletionsCommands {
+    async fn run(&self) -> Result<(), Error> {
+        match self {
+            Self::Shell(cmd) => cmd.run().await,
+            Self::Fig(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct GenerateCompletionsArgs {
+    /// Shell to generate completions for
+    shell: Shell,
+    /// Generate completions for fig
+    fig: bool,
+}
+
+/// Generate Fig completions
+#[derive(Parser, Debug)]
+pub struct GenerateCompletionsFigCommand;
+
+#[async_trait(?Send)]
+impl Dispatch for GenerateCompletionsFigCommand {
+    async fn run(&self) -> Result<(), Error> {
+        Self::print_completions(Fig);
+        Ok(())
+    }
+}
+
+/// Generate Shell completions
+#[derive(Parser, Debug)]
+pub struct GenerateCompletionsShellCommand {
+    #[arg(value_parser = clap::value_parser!(clap_complete::Shell))]
+    pub shell: clap_complete::Shell,
+}
+
+#[async_trait(?Send)]
+impl Dispatch for GenerateCompletionsShellCommand {
+    async fn run(&self) -> Result<(), Error> {
+        Self::print_completions(self.shell);
+        Ok(())
+    }
+}
+
+trait Completions: CommandFactory {
+    fn print_completions<G: Generator>(gen: G) {
+        generate(gen, &mut Self::command(), "spin", &mut std::io::stdout())
+    }
+}
+
+impl<T: CommandFactory> Completions for T {}

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,0 +1,33 @@
+pub use async_trait::async_trait;
+pub use anyhow::Result;
+
+#[async_trait(?Send)]
+pub trait Runner {
+    async fn run(&self) -> Result<()>;
+    async fn help(&self) -> Result<()>;
+}
+
+#[async_trait(?Send)]
+pub trait Dispatch {
+    async fn dispatch(&self, action: &Action) -> Result<()> {
+        match action {
+            Action::Run => self.run().await,
+            Action::Help => self.help().await
+        }
+    }
+
+    async fn run(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn help(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub enum Action {
+    Run,
+    Help
+}
+
+pub mod macros;

--- a/src/dispatch/macros.rs
+++ b/src/dispatch/macros.rs
@@ -1,0 +1,113 @@
+#[macro_export]
+macro_rules! __match_trait {
+    ($enum:ident, $type:ident, [$($variant:ident),*], $value:ident, $block:block) => {
+        match $enum { $($type::$variant($value) => $block,)* }
+    };
+}
+
+#[macro_export]
+macro_rules! match_trait {
+    (
+        match $enum:ident {
+            $type:ident::($($variant:ident)|*)($value:ident) => $block:block
+        }
+    ) => {
+        __match_trait!($enum, $type, [$($variant),*], $value, $block);
+    };
+}
+
+#[macro_export]
+macro_rules! __impl_trait {
+    ([$($attrs:meta),*], $trait:ident, $type:ident, $function:ident, $value:ident, [$($variant:ident),*], $arg:ident, $argtype:ty, $ret:ty, $block:block) => {
+        $(#[$attrs])*
+        impl $trait for $type {
+            async fn $function(&self, $arg: $argtype) -> $ret {
+                __match_trait!(self, Self, [$($variant),*], $value, $block)
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_trait {
+    (
+        $(#[$attrs:meta])*
+        impl $trait:ident for $type:ident {
+            async fn $function:ident($value:ident: $($variant:ident)|*, $arg:ident: $argtype:ty) -> $ret:ty $block:block
+        }
+    ) => {
+        __impl_trait!([$($attrs),*], $trait, $type, $function, $value, [$($variant),*], $arg, $argtype, $ret, $block);
+    }
+}
+
+#[macro_export]
+macro_rules! __type_enum {
+    ($($enum_attrs:meta)*, $enum:ident, $($($var_attrs:meta)*, $variant:ident, $type:ident),*) => {
+        $(#[$enum_attrs])*
+        enum $enum {
+            $(
+                $(#[$var_attrs])*
+                $variant($type)
+            ),*
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! type_enum {
+    (
+        $(#[$enum_attrs:meta])*
+        enum $enum:ident {
+            $(
+                $(#[$var_attrs:meta])*
+                $variant:ident($type:ident)
+            ),*
+        }
+    ) => {
+        __type_enum!($($enum_attrs)*, $enum, $($($var_attrs)*, $variant, $type),*);
+    }
+}
+
+#[macro_export]
+macro_rules! trait_enum {
+        ($(#[$attrs:meta])*
+        enum $enum:ident: $trait:ty {
+            $(
+                $(#[$var_attrs:meta])*
+                $variant:ident($type:ident)
+        ),*
+        }
+    ) => {
+        __type_enum!($($attrs)*, $enum, $($($var_attrs)*, $variant, $type),*);
+        impl_dispatch!($enum::{$($type),*});
+    }
+}
+
+
+#[macro_export]
+macro_rules! match_action  {
+    ($value:ident[$action:ident]$(.$ex:ident)*) => {
+        match $action {
+            Action::Run => $value.run()$(.$ex)*,
+            Action::Help => $value.help()$(.$ex)*
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_dispatch {
+    ($type:ident::{$($variant:ident),*}) => {
+        __impl_trait!(
+            [async_trait::async_trait(?Send)],
+            Dispatch, 
+            $type, 
+            dispatch,
+            value,
+            [$($variant),*],
+            action,
+            &Action,
+            Result<()>,
+            { match_action!(value[action].await) }
+        );
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod args;
 pub mod commands;
 pub(crate) mod opts;
 mod sloth;
+pub mod dispatch;
 
 use anyhow::{anyhow, Result};
 use semver::BuildMetadata;
@@ -8,7 +10,7 @@ use spin_publish::bindle::PublishError;
 use std::path::Path;
 
 pub use crate::opts::HELP_ARGS_ONLY_TRIGGER_TYPE;
-
+pub use crate::dispatch::macros;
 pub(crate) fn push_all_failed_msg(path: &Path, server_url: &str) -> String {
     format!(
         "Failed to push bindle from '{}' to the server at '{}'",

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,6 +1,5 @@
 pub const DEFAULT_MANIFEST_FILE: &str = "spin.toml";
 pub const APP_CONFIG_FILE_OPT: &str = "APP_CONFIG_FILE";
-pub const BINDLE_ID_OPT: &str = "BINDLE_ID";
 pub const BINDLE_SERVER_URL_OPT: &str = "BINDLE_SERVER_URL";
 pub const BINDLE_URL_ENV: &str = "BINDLE_URL";
 pub const BINDLE_USERNAME: &str = "BINDLE_USERNAME";
@@ -13,7 +12,6 @@ pub const HIPPO_URL_ENV: &str = "HIPPO_URL";
 pub const HIPPO_USERNAME: &str = "HIPPO_USERNAME";
 pub const HIPPO_PASSWORD: &str = "HIPPO_PASSWORD";
 pub const DEPLOYMENT_ENV_NAME_ENV: &str = "FERMYON_DEPLOYMENT_ENVIRONMENT";
-pub const BUILD_UP_OPT: &str = "UP";
 pub const PLUGIN_NAME_OPT: &str = "PLUGIN_NAME";
 pub const PLUGIN_REMOTE_PLUGIN_MANIFEST_OPT: &str = "REMOTE_PLUGIN_MANIFEST";
 pub const PLUGIN_LOCAL_PLUGIN_MANIFEST_OPT: &str = "LOCAL_PLUGIN_MANIFEST";


### PR DESCRIPTION
The current clap version could make it difficult to improve the CLI's DevX with the newest CLI practices.
The update by itself already makes some improvements, but I'm looking forward to using this new version to add new capabilities.

Here's the full changelog: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28

Leaving this as draft for now while I test this further, but it seems to be working fine.
Also decided to depend on #1052 to test these crate updates together rather than after merge.

Signed-off-by: Matheus Cardoso <matheus@cardo.so>