### PR TITLE
Skip flake when running under code coverage

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -146,6 +146,7 @@ mod integration_tests {
         }
 
         #[tokio::test]
+        #[cfg(not(tarpaulin))] // Flaky under `cargo tarpaulin`, was blocking CI
         async fn test_bindle_static_assets() -> Result<()> {
             // start the Bindle registry.
             let config = BindleTestControllerConfig {


### PR DESCRIPTION
See if this bypass the tarpaulin bug until #1061 gets resolved

Signed-off-by: itowlson <ivan.towlson@fermyon.com>