### PR TITLE
Provide MSRV in Rust SDK

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-sdk"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.64"
 
 [lib]
 name = "spin_sdk"


### PR DESCRIPTION
Partial fix for #1059.

This uses 1.64 as that is the MSRV for building Spin itself.  I tested with Rust 1.64 and a basic app worked fine:

![image](https://user-images.githubusercontent.com/865538/214982081-0a27361c-40db-4d58-b90d-2b450e7069f4.png)

Signed-off-by: itowlson <ivan.towlson@fermyon.com>