### PR TITLE
Support SSL/TLS in `outbound-mysql`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,6 +2758,7 @@ dependencies = [
  "spin-core",
  "tokio",
  "tracing",
+ "url",
  "wit-bindgen-wasmtime",
 ]
 

--- a/crates/outbound-mysql/Cargo.toml
+++ b/crates/outbound-mysql/Cargo.toml
@@ -14,4 +14,5 @@ mysql_common = "0.29.1"
 spin-core = { path = "../core" }
 tokio = { version = "1", features = [ "rt-multi-thread" ] }
 tracing = { version = "0.1", features = [ "log" ] }
+url = "2.3.1"
 wit-bindgen-wasmtime = { workspace = true }


### PR DESCRIPTION
This is a hack workaround to support SSL/TLS in the `outbound-mysql` host component. Our dependency `mysql_async` wasn't properly parsing the ssl parameters so we do it ourselves here and then hide that parameter from the `mysql_async`.

I've tested without SSL/TLS against a local database and against Planetscale with SSL/TLS.