### PR TITLE
update Github actions dependencies

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable && rustup default stable
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ runner.tool_cache }}/cargo-vet
           key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}

--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       CARGO_VET_VERSION: 0.3.0
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint Rust
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -61,7 +61,7 @@ jobs:
               extraArgs: "",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -135,7 +135,7 @@ jobs:
               hippoUrl: "https://github.com/deislabs/hippo/releases/download/v0.19.0/hippo-server-win-x64.zip",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -209,7 +209,7 @@ jobs:
               pathInWasmtimeArchive: "wasmtime-v0.36.0-x86_64-linux/wasmtime",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Retrieve saved Spin Binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,14 +147,14 @@ jobs:
         run: rustup target add wasm32-wasi
 
       - name: Install bindle
-        uses: engineerd/configurator@v0.0.8
+        uses: engineerd/configurator@v0.0.9
         with:
           name: ${{ matrix.config.bindleBinary }}
           url: ${{ matrix.config.bindleUrl }}
           pathInArchive: ${{ matrix.config.pathInBindleArchive }}
 
       - name: Install nomad
-        uses: engineerd/configurator@v0.0.8
+        uses: engineerd/configurator@v0.0.9
         with:
           name: ${{ matrix.config.nomadBinary }}
           url: ${{ matrix.config.nomadUrl }}
@@ -224,7 +224,7 @@ jobs:
           chmod +x target/debug/spin
 
       - name: Install bindle
-        uses: engineerd/configurator@v0.0.8
+        uses: engineerd/configurator@v0.0.9
         with:
           name: ${{ matrix.config.bindleBinary }}
           url: ${{ matrix.config.bindleUrl }}
@@ -242,7 +242,7 @@ jobs:
           tinygo env
 
       - name: "Install Wasmtime"
-        uses: engineerd/configurator@v0.0.8
+        uses: engineerd/configurator@v0.0.9
         with:
           name: ${{ matrix.config.wasmtimeBinary }}
           url: ${{ matrix.config.wasmtimeUrl }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -76,14 +76,14 @@ jobs:
         run: rustup target add wasm32-wasi
 
       - name: Install bindle
-        uses: engineerd/configurator@v0.0.8
+        uses: engineerd/configurator@v0.0.9
         with:
           name: ${{ matrix.config.bindleBinary }}
           url: ${{ matrix.config.bindleUrl }}
           pathInArchive: ${{ matrix.config.pathInBindleArchive }}
 
       - name: Install nomad
-        uses: engineerd/configurator@v0.0.8
+        uses: engineerd/configurator@v0.0.9
         with:
           name: ${{ matrix.config.nomadBinary }}
           url: ${{ matrix.config.nomadUrl }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -18,7 +18,7 @@ jobs:
               extraArgs: "--features openssl/vendored",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -64,7 +64,7 @@ jobs:
               hippoUrl: "https://github.com/deislabs/hippo/releases/download/v0.19.0/hippo-server-linux-x64.tar.gz",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
               targetDir: "target/release",
             }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: set the release version (tag)
         if: startsWith(github.ref, 'refs/tags/v')
@@ -217,7 +217,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set the tag to sdk/go/v*
         shell: bash
@@ -237,7 +237,7 @@ jobs:
     needs: create-go-sdk-tag
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set the spin tag
         shell: bash
@@ -276,7 +276,7 @@ jobs:
     needs: build
     if: github.event.commits[0].author.name == 'fermybot' && contains(github.event.commits[0].message, 'update sdk')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set the tag to spin/templates/v*
         shell: bash


### PR DESCRIPTION
update Github actions `engineerd/configurator`, `actions/checkout` and `actions/cache` to fix some of the warnings we get during actions run.