### PR TITLE
Show common trigger options on `spin up --help`

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -205,3 +205,25 @@ async fn warn_slow_wasm_build() {
     println!("Preparing Wasm modules is taking a few seconds...");
     println!();
 }
+
+pub mod help {
+    use super::*;
+
+    /// Null object to support --help-args-only in the absence of
+    /// a `spin.toml` file.
+    pub struct HelpArgsOnlyTrigger;
+
+    #[async_trait::async_trait]
+    impl TriggerExecutor for HelpArgsOnlyTrigger {
+        const TRIGGER_TYPE: &'static str = "help-args-only";
+        type RuntimeData = ();
+        type TriggerConfig = ();
+        type RunConfig = NoArgs;
+        fn new(_: crate::TriggerAppEngine<Self>) -> Result<Self> {
+            Ok(Self)
+        }
+        async fn run(self, _: Self::RunConfig) -> Result<()> {
+            Ok(())
+        }
+    }
+}

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -15,6 +15,7 @@ use spin_cli::commands::{
 };
 use spin_http::HttpTrigger;
 use spin_redis_engine::RedisTrigger;
+use spin_trigger::cli::help::HelpArgsOnlyTrigger;
 use spin_trigger::cli::TriggerExecutorCommand;
 
 #[tokio::main]
@@ -65,6 +66,8 @@ enum SpinApp {
 enum TriggerCommands {
     Http(TriggerExecutorCommand<HttpTrigger>),
     Redis(TriggerExecutorCommand<RedisTrigger>),
+    #[clap(name = spin_cli::HELP_ARGS_ONLY_TRIGGER_TYPE, hide = true)]
+    HelpArgsOnly(TriggerExecutorCommand<HelpArgsOnlyTrigger>),
 }
 
 impl SpinApp {
@@ -80,6 +83,7 @@ impl SpinApp {
             Self::Build(cmd) => cmd.run().await,
             Self::Trigger(TriggerCommands::Http(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::Redis(cmd)) => cmd.run().await,
+            Self::Trigger(TriggerCommands::HelpArgsOnly(cmd)) => cmd.run().await,
             Self::Login(cmd) => cmd.run().await,
             Self::Plugins(cmd) => cmd.run().await,
             Self::External(cmd) => execute_external_subcommand(cmd, SpinApp::command()).await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ use semver::BuildMetadata;
 use spin_publish::PublishError;
 use std::path::Path;
 
+pub use crate::opts::HELP_ARGS_ONLY_TRIGGER_TYPE;
+
 pub(crate) fn push_all_failed_msg(path: &Path, server_url: &str) -> String {
     format!(
         "Failed to push bindle from '{}' to the server at '{}'",

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -19,3 +19,4 @@ pub const PLUGIN_REMOTE_PLUGIN_MANIFEST_OPT: &str = "REMOTE_PLUGIN_MANIFEST";
 pub const PLUGIN_LOCAL_PLUGIN_MANIFEST_OPT: &str = "LOCAL_PLUGIN_MANIFEST";
 pub const PLUGIN_ALL_OPT: &str = "ALL";
 pub const PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG: &str = "override-compatibility-check";
+pub const HELP_ARGS_ONLY_TRIGGER_TYPE: &str = "provide-help-args-no-app";


### PR DESCRIPTION
Fixes #1078, #815.

When the user runs `spin up --help` and there is no application (that is, the default application file doesn't exist), it now shows the common trigger CLI flags.

To maximise consistency with the standard help flow (where there _is_ an application), this gets the trigger help options by handing off to a trigger command; however in the no-app case it is a hidden no-op trigger type that has only the base set of trigger CLI flags.

If an application manifest is present, its trigger type is invoked as usual (e.g. if there is a HTTP app present, the user still sees the `--listen` and TLS flags).

Signed-off-by: itowlson <ivan.towlson@fermyon.com>