### PR TITLE
use composite action to avoid configuring versions/downloads multiple times

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -1,0 +1,153 @@
+name: Dependencies setup for spin integration tests
+description: 'composite action'
+inputs:
+  rust:
+    description: 'setup rust'
+    required: false
+    default: 'false'
+    type: bool
+  rust-version:
+    description: 'Rust version to setup'
+    default: '1.66'
+    required: false
+    type: string
+
+  rust-wasm:
+    description: 'setup rust wasm'
+    required: false
+    default: 'false'
+    type: bool
+  rust-cache:
+    description: 'setup rust cache'
+    required: false
+    default: 'false'
+    type: bool
+
+  bindle:
+    description: 'setup bindle'
+    required: false
+    default: 'false'
+    type: bool
+  bindle-version:
+    description: 'Bindle version to setup'
+    default: 'v0.8.0'
+    required: false
+    type: string
+
+  nomad:
+    description: 'setup nomad'
+    required: false
+    default: 'false'
+    type: bool
+  nomad-version:
+    description: 'Nomad version to setup'
+    default: '1.3.1'
+    required: false
+    type: string
+
+  hippo:
+    description: 'setup hippo'
+    required: false
+    default: 'false'
+    type: bool
+  hippo-version:
+    description: 'Hippo version to setup'
+    default: 'v0.19.0'
+    required: false
+    type: string
+
+  golang:
+    description: 'setup golang'
+    required: false
+    default: 'false'
+    type: bool
+  golang-version:
+    description: 'golang version to setup'
+    default: '1.17'
+    required: false
+    type: string
+
+  wasmtime:
+    description: 'setup wasmtime'
+    required: false
+    default: 'false'
+    type: bool
+  wasmtime-version:
+    description: 'wasmtime version to setup'
+    default: 'v0.36.0'
+    required: false
+    type: string
+
+  tinygo:
+    description: 'setup tinygo'
+    required: false
+    default: 'false'
+    type: bool    
+  tinygo-version:
+    description: 'tinygo version to setup'
+    default: 'v0.22.0'
+    required: false
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install latest Rust stable toolchain
+      uses: actions-rs/toolchain@v1
+      if: ${{ inputs.rust == 'true' }}
+      with:
+        toolchain: ${{ inputs.rust-version }}
+        default: true
+        components: clippy, rustfmt
+
+    - name: "Install Wasm Rust target"
+      run: rustup target add wasm32-wasi
+      if: ${{ inputs.rust-wasm == 'true' }}
+      shell: bash
+
+    - uses: Swatinem/rust-cache@v2
+      if: ${{ inputs.rust-cache == 'true' }}
+      with:
+        shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+
+    ## Install bindle
+    - name: Install bindle
+      uses: rajatjindal/setup-actions/bindle@v0.0.1
+      if: ${{ inputs.bindle == 'true' }}
+      with:
+        version: ${{ inputs.bindle-version }}
+
+    ## Install nomad
+    - name: Install nomad
+      uses: endocrimes/setup-nomad@0.1.3
+      if: ${{ inputs.nomad == 'true' }}
+      with:
+        version: ${{ inputs.nomad-version }}
+
+
+    ## Install hippo
+    - name: Install hippo
+      uses: rajatjindal/setup-actions/hippo@v0.0.1
+      if: ${{ inputs.hippo == 'true' }}
+      with:
+        version: ${{ inputs.hippo-version }}
+
+    ## Install wasmtime
+    - name: Install wasmtime
+      uses: rajatjindal/setup-actions/wasmtime@v0.0.1
+      if: ${{ inputs.wasmtime == 'true' }}
+      with:
+        version: ${{ inputs.wasmtime-version }}
+
+    - name: "Install Go"
+      uses: actions/setup-go@v3
+      if: ${{ inputs.golang == 'true' }}
+      with:
+        go-version: ${{ inputs.golang-version }}
+
+    ## Install tinygo
+    - name: "Install TinyGo"
+      uses: rajatjindal/setup-actions/tinygo@v0.0.1
+      if: ${{ inputs.tinygo == 'true' }}
+      with:
+        version: ${{ inputs.tinygo-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,16 +19,12 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.66
-          default: true
-          components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
         with:
-          shared-key: "${{ runner.os }}-lint-${{ hashFiles('./Cargo.lock') }}"
+          rust: true
+          rust-cache: true
 
       - name: Cargo Format
         run:
@@ -64,18 +60,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
         with:
-          toolchain: 1.66
-          default: true
-
-      - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+          rust: true
+          rust-wasm: true
+          rust-cache: true
 
       - name: Cargo Build
         run: cargo build --workspace --release --all-targets --all-features ${{ matrix.config.extraArgs }}
@@ -91,99 +81,23 @@ jobs:
 
   test-rust:
     name: Test Spin SDK - Rust
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.os }}
     needs: [lint-rust]
     strategy:
       matrix:
-        config:
-          - {
-              os: "ubuntu-latest",
-              extension: "",
-              # We have this enabled for releases, so we should test it.
-              extraArgs: "--features openssl/vendored",
-              bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-linux-amd64.tar.gz",
-              bindleBinary: "bindle-server",
-              pathInBindleArchive: "bindle-server",
-              nomadUrl: "https://releases.hashicorp.com/nomad/1.3.1/nomad_1.3.1_linux_amd64.zip",
-              nomadBinary: "nomad",
-              pathInNomadArchive: "nomad",
-              hippoUrl: "https://github.com/deislabs/hippo/releases/download/v0.19.0/hippo-server-linux-x64.tar.gz",
-              wasmtimeUrl: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.36.0/wasmtime-v0.36.0-x86_64-linux.tar.xz",
-              wasmtimeBinary: "wasmtime",
-              pathInWasmtimeArchive: "wasmtime-v0.36.0-x86_64-linux/wasmtime",
-              platformAgnosticChecks: true,
-            }
-          - {
-              os: "macos-latest",
-              extension: "",
-              extraArgs: "",
-              bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-macos-amd64.tar.gz",
-              bindleBinary: "bindle-server",
-              pathInBindleArchive: "bindle-server",
-              nomadUrl: "https://releases.hashicorp.com/nomad/1.3.1/nomad_1.3.1_darwin_amd64.zip",
-              nomadBinary: "nomad",
-              pathInNomadArchive: "nomad",
-              hippoUrl: "https://github.com/deislabs/hippo/releases/download/v0.19.0/hippo-server-osx-x64.tar.gz",
-            }
-          # - {
-          #     os: "windows-latest",
-          #     extension: ".exe",
-          #     extraArgs: "",
-          #     bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-windows-amd64.tar.gz",
-          #     bindleBinary: "bindle-server.exe",
-          #     pathInBindleArchive: "bindle-server.exe",
-          #     nomadUrl: "https://releases.hashicorp.com/nomad/1.3.1/nomad_1.3.1_windows_amd64.zip",
-          #     nomadBinary: "nomad.exe",
-          #     pathInNomadArchive: "nomad.exe",
-          #     hippoUrl: "https://github.com/deislabs/hippo/releases/download/v0.19.0/hippo-server-win-x64.zip",
-          #   }
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
         with:
-          toolchain: 1.66
-          default: true
-
-      - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi
-
-      - name: Install bindle
-        uses: engineerd/configurator@v0.0.9
-        with:
-          name: ${{ matrix.config.bindleBinary }}
-          url: ${{ matrix.config.bindleUrl }}
-          pathInArchive: ${{ matrix.config.pathInBindleArchive }}
-
-      - name: Install nomad
-        uses: engineerd/configurator@v0.0.9
-        with:
-          name: ${{ matrix.config.nomadBinary }}
-          url: ${{ matrix.config.nomadUrl }}
-          pathInArchive: ${{ matrix.config.pathInNomadArchive }}
-
-      - name: Install hippo
-        if: ${{ fromJSON(matrix.config.os != 'windows-latest') }}
-        run: |
-          curl -L ${{ matrix.config.hippoUrl }} -o hippo-server.tar.gz
-          mkdir hippo-server-output
-          tar xz -C hippo-server-output -f hippo-server.tar.gz
-          cp -r hippo-server-output/**/* ~/configurator/bin
-          chmod +x ~/configurator/bin/Hippo.Web
-
-      - name: Install hippo on Windows
-        if: ${{ fromJSON(matrix.config.os == 'windows-latest') }}
-        run: |
-          (New-Object System.Net.WebClient).DownloadFile("${{ matrix.config.hippoUrl }}","hippo-server.zip");
-          md hippo-server-output;
-          Expand-Archive .\hippo-server.zip .\hippo-server-output;
-          echo "$((Get-Item .\hippo-server-output).FullName)\win-x64";
-          echo "$((Get-Item .\hippo-server-output).FullName)\win-x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append;
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+          rust: true
+          rust-wasm: true
+          rust-cache: true
+          bindle: true
+          nomad: true
+          hippo: true
 
       - name: Cargo Unit Tests
         run: |
@@ -200,20 +114,8 @@ jobs:
 
   test-go:
     name: Test Spin SDK - Go
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ubuntu-latest
     needs: build-rust
-    strategy:
-      matrix:
-        config:
-          - {
-              os: "ubuntu-latest",
-              bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-linux-amd64.tar.gz",
-              bindleBinary: "bindle-server",
-              pathInBindleArchive: "bindle-server",
-              wasmtimeUrl: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.36.0/wasmtime-v0.36.0-x86_64-linux.tar.xz",
-              wasmtimeBinary: "wasmtime",
-              pathInWasmtimeArchive: "wasmtime-v0.36.0-x86_64-linux/wasmtime",
-            }
     steps:
       - uses: actions/checkout@v3
 
@@ -229,30 +131,13 @@ jobs:
           ls -lah target/debug
           chmod +x target/debug/spin
 
-      - name: Install bindle
-        uses: engineerd/configurator@v0.0.9
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
         with:
-          name: ${{ matrix.config.bindleBinary }}
-          url: ${{ matrix.config.bindleUrl }}
-          pathInArchive: ${{ matrix.config.pathInBindleArchive }}
-
-      - name: "Install Go"
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.17'
-
-      - name: "Install TinyGo"
-        run: |
-          wget https://github.com/tinygo-org/tinygo/releases/download/v0.22.0/tinygo_0.22.0_amd64.deb
-          sudo dpkg -i tinygo_0.22.0_amd64.deb
-          tinygo env
-
-      - name: "Install Wasmtime"
-        uses: engineerd/configurator@v0.0.9
-        with:
-          name: ${{ matrix.config.wasmtimeBinary }}
-          url: ${{ matrix.config.wasmtimeUrl }}
-          pathInArchive: ${{ matrix.config.pathInWasmtimeArchive }}
+          bindle: true
+          golang: true
+          tinygo: true
+          wasmtime: true
 
       - name: "Test Go SDK"
         run: make test-sdk-go

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,96 +6,44 @@ on:
 jobs:
   build-rust:
     name: Build Spin
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'fermyon' }} || ${{ github.event_name == 'workflow_dispatch' }}
-    strategy:
-      matrix:
-        config:
-          - {
-              os: "ubuntu-latest",
-              extension: "",
-              # We have this enabled for releases, so we should test it.
-              extraArgs: "--features openssl/vendored",
-            }
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
         with:
-          toolchain: 1.66
-          default: true
-
-      - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+          bindle: true
+          golang: true
+          tinygo: true
+          wasmtime: true
 
       - name: Cargo Build
-        run: cargo build --workspace --all-targets --all-features ${{ matrix.config.extraArgs }}
+        run: cargo build --workspace --all-targets --all-features --features openssl/vendored
 
       - name: "Archive executable artifact"
         uses: actions/upload-artifact@v3
         with:
-          name: spin-${{ matrix.config.os }}
-          path: target/debug/spin${{ matrix.config.extension }}
+          name: spin-ubuntu-latest
+          path: target/debug/spin
 
   code-coverage:
     name: Run code coverage
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'fermyon' }} || ${{ github.event_name == 'workflow_dispatch' }}
     needs: build-rust
-    strategy:
-      matrix:
-        config:
-          - {
-              os: "ubuntu-latest",
-              extension: "",
-              # We have this enabled for releases, so we should test it.
-              extraArgs: "--features openssl/vendored",
-              bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-linux-amd64.tar.gz",
-              bindleBinary: "bindle-server",
-              pathInBindleArchive: "bindle-server",
-              nomadUrl: "https://releases.hashicorp.com/nomad/1.3.1/nomad_1.3.1_linux_amd64.zip",
-              nomadBinary: "nomad",
-              pathInNomadArchive: "nomad",
-              hippoUrl: "https://github.com/deislabs/hippo/releases/download/v0.19.0/hippo-server-linux-x64.tar.gz",
-            }
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
         with:
-          toolchain: 1.66
-          default: true
-
-      - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi
-
-      - name: Install bindle
-        uses: engineerd/configurator@v0.0.9
-        with:
-          name: ${{ matrix.config.bindleBinary }}
-          url: ${{ matrix.config.bindleUrl }}
-          pathInArchive: ${{ matrix.config.pathInBindleArchive }}
-
-      - name: Install nomad
-        uses: engineerd/configurator@v0.0.9
-        with:
-          name: ${{ matrix.config.nomadBinary }}
-          url: ${{ matrix.config.nomadUrl }}
-          pathInArchive: ${{ matrix.config.pathInNomadArchive }}
-
-      - name: Install hippo
-        run: |
-          curl -L ${{ matrix.config.hippoUrl }} -o hippo-server.tar.gz
-          mkdir hippo-server-output
-          tar xz -C hippo-server-output -f hippo-server.tar.gz
-          cp -r hippo-server-output/**/* ~/configurator/bin
-          chmod +x ~/configurator/bin/Hippo.Web
+          rust: true
+          rust-wasm: true
+          bindle: true
+          nomad: true
+          hippo: true
 
       - name: Install cargo-tarpaulin binary crate
         uses: actions-rs/install@v0.1


### PR DESCRIPTION
this basically move setting up of rust and other dependencies to a separate action file. (composite actions).

one downside is that we are setting up superset of dependencies, so we may install some which are not required in a particular step.

the upside is that:

- `build.yml` is much more readable now
- the version config is moved to a single file now (`.github/actions/spin-tests-dependencies`)

I've not changed `release` action yet to use these composite action (I can spend some more time to do that if this looks like an ok approach)


Signed-off-by: Rajat Jindal <rajatjindal83@gmail.com>