### PR TITLE
Record where templates were installed from

### DIFF
--- a/crates/templates/src/reader.rs
+++ b/crates/templates/src/reader.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Context;
 use indexmap::IndexMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "manifest_version")]
@@ -53,4 +53,16 @@ pub(crate) struct RawCustomFilter {
 
 pub(crate) fn parse_manifest_toml(text: impl AsRef<str>) -> anyhow::Result<RawTemplateManifest> {
     toml::from_str(text.as_ref()).context("Failed to parse template manifest TOML")
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case", untagged)]
+pub(crate) enum RawInstalledFrom {
+    Git { git: String },
+    File { dir: String },
+}
+
+pub(crate) fn parse_installed_from(text: impl AsRef<str>) -> Option<RawInstalledFrom> {
+    // If we can't load it then it's not worth an error
+    toml::from_str(text.as_ref()).ok()
 }

--- a/crates/templates/src/source.rs
+++ b/crates/templates/src/source.rs
@@ -56,6 +56,24 @@ impl TemplateSource {
             spin_version: spin_version.to_owned(),
         }))
     }
+
+    pub(crate) fn to_install_record(&self) -> Option<crate::reader::RawInstalledFrom> {
+        match self {
+            Self::Git(g) => Some(crate::reader::RawInstalledFrom::Git {
+                git: g.url.to_string(),
+            }),
+            Self::File(p) => {
+                // Saving a relative path would be meaningless (but should never happen)
+                if p.is_absolute() {
+                    Some(crate::reader::RawInstalledFrom::File {
+                        dir: format!("{}", p.display()),
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+    }
 }
 
 pub(crate) struct LocalTemplateSource {

--- a/crates/templates/src/store.rs
+++ b/crates/templates/src/store.rs
@@ -77,6 +77,8 @@ const SNIPPETS_DIR_NAME: &str = "snippets";
 
 const MANIFEST_FILE_NAME: &str = "spin-template.toml";
 
+const INSTALLATION_RECORD_FILE_NAME: &str = ".install.toml";
+
 impl TemplateLayout {
     pub fn new(template_dir: impl AsRef<Path>) -> Self {
         Self {
@@ -106,5 +108,9 @@ impl TemplateLayout {
 
     pub fn snippets_dir(&self) -> PathBuf {
         self.metadata_dir().join(SNIPPETS_DIR_NAME)
+    }
+
+    pub fn install_record_file(&self) -> PathBuf {
+        self.template_dir.join(INSTALLATION_RECORD_FILE_NAME)
     }
 }


### PR DESCRIPTION
This adds a `spin templates list --verbose` flag which adds an "installed from" column to the table:

```
+-----------------------------------------------------------------------------------------------------------------+
| Name                Description                                          Installed from                         |
+=================================================================================================================+
| http-grain          HTTP request handler using Grain                     /home/ivan/github/spin                 |
| http-js             HTTP request handler using Javascript                https://github.com/fermyon/spin-js-sdk |
| http-php            HTTP request handler using PHP                       /home/ivan/github/spin                 |
```

If there is no record (as there won't be for templates installed before this patch) then the column is blank; it will get populated on next update.

This will also provide a foundation for a simpler update/sync experience in a future thrilling episode.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>