### PR TITLE
Add initial cache for Spin URL component sources

### DIFF
--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -28,7 +28,7 @@ use spin_manifest::{
 };
 use tokio::{fs::File, io::AsyncReadExt};
 
-use crate::{bindle::BindleConnectionInfo, digest::bytes_sha256_string};
+use crate::{bindle::BindleConnectionInfo, digest::bytes_sha256_string, oci::cache::Cache};
 use config::{
     FileComponentUrlSource, RawAppInformation, RawAppManifest, RawAppManifestAnyVersion,
     RawAppManifestAnyVersionPartial, RawComponentManifest, RawComponentManifestPartial,
@@ -297,29 +297,46 @@ impl UrlSource {
 
     /// Gets the data from the source as a byte buffer.
     pub async fn get(&self) -> anyhow::Result<Vec<u8>> {
-        let response = reqwest::get(self.url.clone())
-            .await
-            .with_context(|| format!("Error fetching source URL {}", self.url))?;
-        // TODO: handle redirects
-        let status = response.status();
-        if status != reqwest::StatusCode::OK {
-            let reason = status.canonical_reason().unwrap_or("(no reason provided)");
-            anyhow::bail!(
-                "Error fetching source URL {}: {} {}",
-                self.url,
-                status.as_u16(),
-                reason
-            );
+        // TODO: when `spin up` integrates running an app from OCI, pass the configured
+        // cache root to this function. For now, use the default cache directory.
+        let cache = Cache::new(None).await?;
+        match cache.wasm_file(self.digest_str()) {
+            Ok(p) => {
+                tracing::debug!(
+                    "Using local cache for module source {} with digest {}",
+                    &self.url,
+                    &self.digest_str()
+                );
+                Ok(tokio::fs::read(p).await?)
+            }
+            Err(_) => {
+                tracing::debug!("Pulling module from URL {}", &self.url);
+                let response = reqwest::get(self.url.clone())
+                    .await
+                    .with_context(|| format!("Error fetching source URL {}", self.url))?;
+                // TODO: handle redirects
+                let status = response.status();
+                if status != reqwest::StatusCode::OK {
+                    let reason = status.canonical_reason().unwrap_or("(no reason provided)");
+                    anyhow::bail!(
+                        "Error fetching source URL {}: {} {}",
+                        self.url,
+                        status.as_u16(),
+                        reason
+                    );
+                }
+                let body = response
+                    .bytes()
+                    .await
+                    .with_context(|| format!("Error loading source URL {}", self.url))?;
+                let bytes = body.into_iter().collect_vec();
+
+                self.digest.verify(&bytes).context("Incorrect digest")?;
+                cache.write_wasm(&bytes, self.digest_str()).await?;
+
+                Ok(bytes)
+            }
         }
-        let body = response
-            .bytes()
-            .await
-            .with_context(|| format!("Error loading source URL {}", self.url))?;
-        let bytes = body.into_iter().collect_vec();
-
-        self.digest.verify(&bytes).context("Incorrect digest")?;
-
-        Ok(bytes)
     }
 }
 


### PR DESCRIPTION
ref #455

Before this commit, for a `spin.toml` file that had a URL module source for a component (such as the file server and redirect templates), subsequent runs of `spin up` would always download the module from the URL before starting the application.

https://github.com/fermyon/spin/pull/1014 added a content-addressed registry cache that can be used to store remote module sources.

This commit updates the Spin local loader to use that cache to store the component sources referenced through URL in `spin.toml`.

Before fetching a component, the loader will check the local cache first. If present, it will read the file and return its content; otherwise, it will fetch it, store it in the cache, then return its content.

Currently, the default cache root is always used. Once `spin up` will have a way to configure it, that will be propagated here as well.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>