### PR TITLE
Start tracking the workspace `Cargo.lock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ ignored-assets
 main.wasm
 .parcel-cache
 .vscode/*.log
-Cargo.lock
+tests/**/Cargo.lock
+crates/**/Cargo.lock


### PR DESCRIPTION
Start tracking the workspace `Cargo.lock` because it was accidentally untracked before. Note that I didn't have to commit `Cargo.lock` because it already was.

Signed-off-by: Caleb Schoepp <caleb.schoepp@fermyon.com>