### PR TITLE
Use term application rather than project in `spin new` and `spin add`

### DIFF
--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -66,6 +66,14 @@ impl TemplateVariantInfo {
             Self::AddComponent { .. } => "add component",
         }
     }
+
+    /// The noun that should be used for the variant in a prompt
+    pub fn prompt_noun(&self) -> &'static str {
+        match self {
+            Self::NewApplication => "application",
+            Self::AddComponent { .. } => "component",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/templates/http-c/metadata/spin-template.toml
+++ b/templates/http-c/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-c"
 description = "HTTP request handler using C and the Zig toolchain"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-empty/metadata/spin-template.toml
+++ b/templates/http-empty/metadata/spin-template.toml
@@ -3,5 +3,5 @@ id = "http-empty"
 description = "HTTP application with no components"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }

--- a/templates/http-go/metadata/spin-template.toml
+++ b/templates/http-go/metadata/spin-template.toml
@@ -9,6 +9,6 @@ skip_parameters = ["http-base"]
 component = "component.txt"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-grain/metadata/spin-template.toml
+++ b/templates/http-grain/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-grain"
 description = "HTTP request handler using Grain"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-php/metadata/spin-template.toml
+++ b/templates/http-php/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-php"
 description = "HTTP request handler using PHP"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-rust/metadata/spin-template.toml
+++ b/templates/http-rust/metadata/spin-template.toml
@@ -9,6 +9,6 @@ skip_parameters = ["http-base"]
 component = "component.txt"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-swift/metadata/spin-template.toml
+++ b/templates/http-swift/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-swift"
 description = "HTTP request handler using SwiftWasm"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/http-zig/metadata/spin-template.toml
+++ b/templates/http-zig/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "http-zig"
 description = "HTTP request handler using Zig"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/redis-go/metadata/spin-template.toml
+++ b/templates/redis-go/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "redis-go"
 description = "Redis message handler using (Tiny)Go"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 redis-address = { type = "string", prompt = "Redis address", default = "redis://localhost:6379" }
 redis-channel = { type = "string", prompt = "Redis channel" }

--- a/templates/redis-rust/metadata/spin-template.toml
+++ b/templates/redis-rust/metadata/spin-template.toml
@@ -3,6 +3,6 @@ id = "redis-rust"
 description = "Redis message handler using Rust"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 redis-address = { type = "string", prompt = "Redis address", default = "redis://localhost:6379" }
 redis-channel = { type = "string", prompt = "Redis channel" }

--- a/templates/static-fileserver/metadata/spin-template.toml
+++ b/templates/static-fileserver/metadata/spin-template.toml
@@ -10,7 +10,7 @@ skip_parameters = ["http-base", "project-description"]
 component = "component.txt"
 
 [parameters]
-project-description = { type = "string",  prompt = "Project description", default = "" }
+project-description = { type = "string",  prompt = "Description", default = "" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/static/...", pattern = "^/\\S*$" }
 files-path = { type = "string", prompt = "Directory containing the files to serve", default = "assets", pattern = "^\\S+$" }


### PR DESCRIPTION
## Changes
- Make prompts for name specific to `spin new` and `spin add` and user "application/component" rather than "project"
- Make prompts for description `spin new` and `spin add` agnostic.

## Example

```
$ spin target/release/spin new
Pick a template to start your application with: http-rust (HTTP request handler using Rust)
Enter a name for your new application: asdf
Description:
HTTP base: /
HTTP path: /...
$ ../target/release/spin add
Pick a template to start your component with: http-rust (HTTP request handler using Rust)
Enter a name for your new component: new
Description: asdf
HTTP path: /...
```

## TODO
- Update template in js sdk repo
- File issue for internal template names.

Closes #1074 