### PR TITLE
ci(*): add website deployment logic

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -3,7 +3,6 @@ name: Deploy Spin Docs Website
 on:
   push:
     branches:
-      - 'vdice/website-deployment' # TODO: remove after testing
       - 'main'
 
   workflow_dispatch:
@@ -110,9 +109,8 @@ jobs:
           echo "GIT_REF=${{ github.ref }}" >> $GITHUB_ENV
           echo "GIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
 
-          # TODO: update to deploy to prod
-          echo "PRODUCTION=false" >> $GITHUB_ENV
-          echo "NOMAD_NAMESPACE=staging" >> $GITHUB_ENV
+          echo "PRODUCTION=true" >> $GITHUB_ENV
+          echo "NOMAD_NAMESPACE=prod" >> $GITHUB_ENV
 
       - name: Deploy
         shell: bash

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,143 @@
+name: Deploy Spin Docs Website
+
+on:
+  push:
+    branches:
+      - 'vdice/website-deployment' # TODO: remove after testing
+      - 'main'
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to deploy from (refs/tags/v* for tag)'
+        default: 'refs/heads/main'
+      commit:
+        description: 'Commit SHA to deploy from (optional)'
+      environment:
+        type: choice
+        description: 'Environment to deploy to (Default: canary)'
+        options:
+          - canary
+          - prod
+
+# Construct a concurrency group to be shared across workflow runs.
+# The default behavior ensures that only one is running at a time, with
+# all others queuing and thus not interrupting runs that are in-flight.
+concurrency: ${{ github.workflow }}
+
+permissions:
+  contents: read
+  id-token: write # Allow the workflow to create a JWT for AWS auth
+
+env:
+  JOB: spin-docs
+
+jobs:
+  echo-inputs:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Echo Inputs
+        run: |
+          echo ref: ${{ github.event.inputs.ref }}
+          echo commit: ${{ github.event.inputs.commit }}
+          echo environment: ${{ github.event.inputs.environment }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Nomad
+        env:
+          NOMAD_VERSION: "1.4.3"
+        run: |
+          curl -Os https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_$(dpkg --print-architecture).zip
+          unzip nomad_${NOMAD_VERSION}_linux_$(dpkg --print-architecture).zip -d /usr/local/bin
+          chmod +x /usr/local/bin/nomad
+
+      # This action currently generates a warning due to using deprecated features.
+      # https://github.com/aws-actions/configure-aws-credentials/issues/521 tracks the new behaviour.
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.INFRA_NAMESPACE }}-${{ secrets.AWS_REGION }}-gha-certs
+          role-session-name: fermyon-developer-deploy
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Fetch Nomad Certs from S3
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for cert in infra_ca \
+            api_client_cert_private_key \
+            api_client_cert_public_key; do
+
+            aws s3api get-object \
+              --bucket "infra-certs-${{ secrets.INFRA_NAMESPACE }}-${{ secrets.AWS_REGION }}" \
+              --key "${cert}" \
+              "/tmp/${cert}"
+          done
+
+      - name: Configure Nomad
+        shell: bash
+        run: |
+          echo "NOMAD_CACERT=/tmp/infra_ca" >> $GITHUB_ENV
+          echo "NOMAD_CLIENT_CERT=/tmp/api_client_cert_public_key" >> $GITHUB_ENV
+          echo "NOMAD_CLIENT_KEY=/tmp/api_client_cert_private_key" >> $GITHUB_ENV
+          echo "NOMAD_ADDR=https://nomad.${{ secrets.INFRA_NAMESPACE }}.${{ secrets.AWS_REGION }}.fermyon.link:4646" >> $GITHUB_ENV
+
+      - name: Configure manual deploy
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          echo "GIT_REF=${{ github.event.inputs.ref }}" >> $GITHUB_ENV
+          echo "GIT_SHA=${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+          
+          if [[ "${{ github.event.inputs.environment }}" == "prod" ]]; then
+            echo "PRODUCTION=true" >> $GITHUB_ENV
+            echo "NOMAD_NAMESPACE=prod" >> $GITHUB_ENV
+          else
+            echo "PRODUCTION=false" >> $GITHUB_ENV
+            echo "NOMAD_NAMESPACE=staging" >> $GITHUB_ENV
+          fi
+
+      - name: Configure auto-deploy
+        if: ${{ github.event_name == 'push' }}
+        shell: bash
+        run: |
+          echo "GIT_REF=${{ github.ref }}" >> $GITHUB_ENV
+          echo "GIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+
+          # TODO: update to deploy to prod
+          echo "PRODUCTION=false" >> $GITHUB_ENV
+          echo "NOMAD_NAMESPACE=staging" >> $GITHUB_ENV
+
+      - name: Deploy
+        shell: bash
+        run: |
+          set -euox pipefail
+
+          # purge any lingering/completed publish jobs
+          nomad job inspect publish-${{ env.JOB }} &>/dev/null && \
+            nomad stop -purge -yes publish-${{ env.JOB }}
+
+          # run the publish job
+          nomad run \
+            -var "region=${{ secrets.AWS_REGION }}" \
+            -var "git_ref=${{ env.GIT_REF }}" \
+            -var "commit_sha=${{ env.GIT_SHA }}" \
+            deploy/publish-${{ env.JOB }}.nomad
+
+          # wait for publish job to complete
+          timeout 300s bash -c 'until [[ "$(nomad job inspect publish-${{ env.JOB }} | jq -j '.Job.Status')" == "dead" ]]; do sleep 2; done'
+
+          readonly bindle_id="$(nomad logs -job publish-${{ env.JOB }} | sed -n 's/pushed: //p')"
+
+          # run/update the website job
+          nomad run \
+            -var "region=${{ secrets.AWS_REGION }}" \
+            -var "production=${{ env.PRODUCTION }}" \
+            -var "bindle_id=${bindle_id}" \
+            deploy/${{ env.JOB }}.nomad

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -6,35 +6,6 @@ on:
     tags: ["v*"]
 
 jobs:
-  changes:
-    name: Detect files changed
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'fermyon' }}
-    outputs:
-      docs: ${{ steps.filter.outputs.docs }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            docs:
-              - 'docs/**'
-
-  dispatch-spin-docs:
-    name: Dispatch spin-docs-updated event
-    needs: changes
-    if: ${{ needs.changes.outputs.docs == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.DEST_REPO_ACCESS_TOKEN }}
-          repository: ${{ secrets.DEST_REPO }}
-          event-type: spin-docs-updated
-          client-payload: '{"event_type": "spin-docs-updated", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
-
   dispatch-rust-docs:
     name: Dispatch rust-docs spin-update event
     runs-on: ubuntu-latest

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,21 @@
+# Deployments
+
+The [Spin Docs](https://spin.fermyon.dev) website is deployed via the [deploy-website.yaml](../.github/workflows/deploy-website.yml) GitHub workflow.
+
+(Note: currently this website consists of redirects to the Spin Docs hosted on Fermyon's [Developer site](https://developer.fermyon.com/spin))
+
+## Auto Deploys
+
+The production version of the website is deployed whenever commits are pushed to the `main` branch.
+
+## Manual Deploys
+
+Deployments may also be [triggered manually](https://github.com/fermyon/spin/actions/workflows/deploy-website.yml), providing a choice of `ref`, `sha` and `environment` (eg canary or prod).
+
+## Nomad jobs
+
+We currently deploy the website via its Nomad job directly. (In the future, we envision running the website as a Fermyon Cloud app.)
+
+The [publish-spin-docs](./publish-spin-docs.nomad) Nomad job checks out this repo's source code and publishes it to Bindle.
+
+The [spin-docs](./spin-docs.nomad) Nomad job contains configuration for the running website, including the bindle ID to run from.

--- a/deploy/publish-spin-docs.nomad
+++ b/deploy/publish-spin-docs.nomad
@@ -1,0 +1,78 @@
+variable "region" {
+  type    = string
+}
+
+variable "git_ref" {
+  type        = string
+  default     = "refs/heads/main"
+  description = "Git ref to use for the spin repo clone. Default: refs/heads/main"
+}
+
+variable "commit_sha" {
+  type        = string
+  default     = ""
+  description = "Specific commit SHA to check out. Default: empty/none"
+}
+
+job "publish-spin-docs" {
+  type        = "batch"
+  datacenters = [
+    "${var.region}a",
+    "${var.region}b",
+    "${var.region}c",
+    "${var.region}d",
+    "${var.region}e",
+    "${var.region}f"
+  ]
+
+  group "publish-spin-docs" {
+    count = 1
+
+    task "publish-spin-docs" {
+      driver = "exec"
+
+      artifact {
+        source = "https://github.com/fermyon/spin/releases/download/v0.8.0/spin-v0.8.0-linux-amd64.tar.gz"
+        options {
+          checksum = "sha256:0ef31fe6e2b4d34ddd089b01a1f88820f88c456276bfe4e1477836a6087654c1"
+        }
+      }
+
+      env {
+        BINDLE_URL = "http://bindle.service.consul:3030/v1"
+      }
+
+      template {
+        data = <<-EOF
+        #!/bin/bash
+        set -euo pipefail
+
+        readonly repo_dir="${NOMAD_ALLOC_DIR}/spin"
+
+        # Capture branch/tag name from full ref
+        readonly branch="$(echo ${var.git_ref} | cut -d'/' -f3-)"
+        
+        # Directory and contents may be non-empty if this job is retrying while the
+        # bindle server is still coming up. (git clone will complain)
+        rm -rf ${repo_dir}
+        git clone -b ${branch} https://github.com/fermyon/spin.git ${repo_dir}
+        cd ${repo_dir}/docs
+
+        # Check out commit if provided
+        [[ "${var.commit_sha}" == "" ]] || git checkout ${var.commit_sha}
+
+        ${NOMAD_TASK_DIR}/spin bindle push \
+          -f spin.toml \
+          -d ./staging_dir \
+          --buildinfo "g$(git rev-parse HEAD)-$(date '+%Y%m%d%M%H%M%S')"
+        EOF
+        destination = "${NOMAD_TASK_DIR}/publish.bash"
+        perms       = "700"
+      }
+
+      config {
+        command = "${NOMAD_TASK_DIR}/publish.bash"
+      }
+    }
+  }
+}

--- a/deploy/spin-docs.nomad
+++ b/deploy/spin-docs.nomad
@@ -1,0 +1,135 @@
+variable "region" {
+  type    = string
+}
+
+variable "production" {
+  type        = bool
+  default     = false
+  description = "Whether or not this job should run in production mode. Default: false."
+}
+
+variable "dns_domain" {
+  type        = string
+  default     = "fermyon.dev"
+  description = "The root DNS domain for the Spin docs website, e.g. fermyon.dev, fermyon.link"
+}
+
+variable "hostname" {
+  type        = string
+  default     = null
+  description = "An alternative hostname to use (defaults are <canary>.spin.<dns_domain>})"
+}
+
+variable "letsencrypt_env" {
+  type    = string
+  default = "prod"
+  description = <<EOF
+The Let's Encrypt cert resolver to use. Options are 'staging' and 'prod'. (Default: prod)
+
+With the letsencrypt-prod cert resolver, we're limited to *5 requests per week* for a cert with matching domain and SANs.
+For testing/staging, it is recommended to use letsencrypt-staging, which has vastly increased limits.
+EOF
+
+  validation {
+    condition     = var.letsencrypt_env == "staging" || var.letsencrypt_env == "prod"
+    error_message = "The Let's Encrypt env must be either 'staging' or 'prod'."
+  }
+}
+
+variable "bindle_id" {
+  type        = string
+  default     = "spin-docs/0.1.0"
+  description = "A bindle id, such as foo/bar/1.2.3"
+}
+
+locals {
+  hostname = "${var.hostname == null ? "${var.production == true ? "spin.${var.dns_domain}" : "canary.spin.${var.dns_domain}"}" : var.hostname}"
+}
+
+job "spin-docs" {
+  type = "service"
+  datacenters = [
+    "${var.region}a",
+    "${var.region}b",
+    "${var.region}c",
+    "${var.region}d",
+    "${var.region}e",
+    "${var.region}f"
+  ]
+
+  group "spin-docs" {
+    count = 3
+
+    update {
+      max_parallel      = 1
+      canary            = 3
+      min_healthy_time  = "10s"
+      healthy_deadline  = "10m"
+      progress_deadline = "15m"
+      auto_revert       = true
+      auto_promote      = true
+    }
+
+    network {
+      port "http" {}
+    }
+
+    service {
+      name = "spin-docs-${NOMAD_NAMESPACE}"
+      port = "http"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.spin-docs-${NOMAD_NAMESPACE}.rule=Host(`${local.hostname}`)",
+        "traefik.http.routers.spin-docs-${NOMAD_NAMESPACE}.entryPoints=websecure",
+        "traefik.http.routers.spin-docs-${NOMAD_NAMESPACE}.tls=true",
+        "traefik.http.routers.spin-docs-${NOMAD_NAMESPACE}.tls.certresolver=letsencrypt-cf-${var.letsencrypt_env}",
+        "traefik.http.routers.spin-docs-${NOMAD_NAMESPACE}.tls.domains[0].main=${local.hostname}"
+      ]
+
+      check {
+        type     = "http"
+        path     = "/.well-known/spin/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "server" {
+      driver = "exec"
+
+      artifact {
+        source = "https://github.com/fermyon/spin/releases/download/v0.8.0/spin-v0.8.0-linux-amd64.tar.gz"
+        options {
+          checksum = "sha256:0ef31fe6e2b4d34ddd089b01a1f88820f88c456276bfe4e1477836a6087654c1"
+        }
+      }
+
+      # Canary spin binary for running the canary site
+      artifact {
+        source = "https://github.com/fermyon/spin/releases/download/canary/spin-canary-linux-amd64.tar.gz"
+        destination = "{NOMAD_ALLOC_DIR}/canary"
+      }
+
+      env {
+        RUST_LOG   = "spin=trace"
+        BINDLE_URL = "http://bindle.service.consul:3030/v1"
+        BASE_URL   = "https://${local.hostname}"
+      }
+
+      config {
+        command = var.production ? "spin" : "{NOMAD_ALLOC_DIR}/canary/spin"
+        args = [
+          "up",
+          "--listen", "${NOMAD_IP_http}:${NOMAD_PORT_http}",
+          "--bindle", var.bindle_id,
+          "--log-dir", "${NOMAD_ALLOC_DIR}/logs",
+          "--temp", "${NOMAD_ALLOC_DIR}/tmp",
+
+          # Set BASE_URL for Bartholomew to override default (localhost:3000)
+          "-e", "BASE_URL=${BASE_URL}",
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Adds website deployment logic (auto on pushes to `main`; support for manual/ad hoc triggering as well)
- Deploys to the prod version of the website on every push to `main` (once toggled below)
- Removes unecessary logic from dispatch.yml workflow (previously used to coordinate deploys)

As noted in the added `deploy/README.md`, the website here has been redirect-based for some time, pointing to the official docs sub-site at https://developer.fermyon.com/spin (all content being in the [fermyon/developer repo](https://github.com/fermyon/developer)).  However, until we sunset the classic domain (spin.fermyon.dev), I'd like to have this auto-deployment logic available for any potential website changes in the meantime (including transitioning to a Fermyon Cloud app when ready).  We can remove the works after the classic domain has been removed.

Deployment (to canary) from initial PR version tested in: https://github.com/fermyon/spin/actions/runs/4068116760

TODO:
- [x] remove testing branch from deploy.yml
- [x] update to deploy to prod on merges to `main`
