### PR TITLE
Rename `spin oci` to `spin registry`

### DIFF
--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -9,8 +9,8 @@ use spin_cli::commands::{
     external::execute_external_subcommand,
     login::LoginCommand,
     new::{AddCommand, NewCommand},
-    oci::OciCommands,
     plugins::PluginCommands,
+    registry::RegistryCommands,
     templates::TemplateCommands,
     up::UpCommand,
 };
@@ -52,8 +52,8 @@ enum SpinApp {
     Up(UpCommand),
     #[clap(subcommand)]
     Bindle(BindleCommands),
-    #[clap(subcommand)]
-    Oci(OciCommands),
+    #[clap(subcommand, alias = "oci")]
+    Registry(RegistryCommands),
     Deploy(DeployCommand),
     Build(BuildCommand),
     Login(LoginCommand),
@@ -82,7 +82,7 @@ impl SpinApp {
             Self::New(cmd) => cmd.run().await,
             Self::Add(cmd) => cmd.run().await,
             Self::Bindle(cmd) => cmd.run().await,
-            Self::Oci(cmd) => cmd.run().await,
+            Self::Registry(cmd) => cmd.run().await,
             Self::Deploy(cmd) => cmd.run().await,
             Self::Build(cmd) => cmd.run().await,
             Self::Trigger(TriggerCommands::Http(cmd)) => cmd.run().await,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,10 +12,10 @@ pub mod external;
 pub mod login;
 /// Command for creating a new application.
 pub mod new;
-/// Commands for working with OCI registries.
-pub mod oci;
 /// Command for adding a plugin to Spin
 pub mod plugins;
+/// Commands for working with OCI registries.
+pub mod registry;
 /// Commands for working with templates.
 pub mod templates;
 /// Commands for starting the runtime.

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -16,7 +16,7 @@ use crate::opts::*;
 /// Currently, the OCI commands are reusing the credentials from ~/.docker/config.json to
 /// authenticate to registries.
 #[derive(Subcommand, Debug)]
-pub enum OciCommands {
+pub enum RegistryCommands {
     /// Push a Spin application to an OCI registry.
     Push(Push),
     /// Pull a Spin application from an OCI registry.
@@ -25,12 +25,12 @@ pub enum OciCommands {
     Run(Run),
 }
 
-impl OciCommands {
+impl RegistryCommands {
     pub async fn run(self) -> Result<()> {
         match self {
-            OciCommands::Push(cmd) => cmd.run().await,
-            OciCommands::Pull(cmd) => cmd.run().await,
-            OciCommands::Run(cmd) => cmd.run().await,
+            RegistryCommands::Push(cmd) => cmd.run().await,
+            RegistryCommands::Pull(cmd) => cmd.run().await,
+            RegistryCommands::Run(cmd) => cmd.run().await,
         }
     }
 }


### PR DESCRIPTION
As I have started using the OCI functionality a bit more, I realized that "OCI" is a fairly specialized three letter acronym, and expecting a user to know it and immediately understand "this has something to do with registries" might not be reasonable.

This commit changes the top level `spin oci` command to `spin registry`, while still keeping an alias for `spin oci`.

This should be more intuitive for a user.
Happy to close this PR if people think `spin oci` is more specific.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>