### PR TITLE
ci(perf): Improve job parallelization and disable incremental Rust builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Cargo Build
         run: cargo build --workspace --release --all-targets --all-features ${{ matrix.config.extraArgs }}
+        env:
+          CARGO_INCREMENTAL: 0
 
       - name: "Archive executable artifact"
         uses: actions/upload-artifact@v3
@@ -185,12 +187,15 @@ jobs:
       - name: Cargo Unit Tests
         run: |
           make test-unit
+        env:
+          CARGO_INCREMENTAL: 0
 
       - name: Cargo E2E Tests
         run: |
           make test-e2e
         env:
           RUST_LOG: spin=trace
+          CARGO_INCREMENTAL: 0
 
   test-go:
     name: Test Spin SDK - Go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,6 @@ jobs:
   test-rust:
     name: Test Spin SDK - Rust
     runs-on: ${{ matrix.config.os }}
-    needs: build-rust
     strategy:
       matrix:
         config:


### PR DESCRIPTION
This set of changes should hopefully make our CI runs take less time. More importantly, the first one, disabling incremental cargo builds, should also reduce disk usage enough to make Windows tests pass more reliably, and give us a bit more time before we have to [move things to another partition](https://github.com/actions/runner-images/issues/1341#issuecomment-667478747)  ...