### PR TITLE
fix(tinygo): Regenerate canoncial_abi_* methods

### DIFF
--- a/sdk/go/config/spin-config.c
+++ b/sdk/go/config/spin-config.c
@@ -5,9 +5,11 @@ __attribute__((weak, export_name("canonical_abi_realloc")))
 void *canonical_abi_realloc(
 void *ptr,
 size_t orig_size,
-size_t org_align,
+size_t align,
 size_t new_size
 ) {
+  if (new_size == 0)
+  return (void*) align;
   void *ret = realloc(ptr, new_size);
   if (!ret)
   abort();
@@ -20,6 +22,8 @@ void *ptr,
 size_t size,
 size_t align
 ) {
+  if (size == 0)
+  return;
   free(ptr);
 }
 #include <string.h>

--- a/sdk/go/http/spin-http.c
+++ b/sdk/go/http/spin-http.c
@@ -5,9 +5,11 @@ __attribute__((weak, export_name("canonical_abi_realloc")))
 void *canonical_abi_realloc(
 void *ptr,
 size_t orig_size,
-size_t org_align,
+size_t align,
 size_t new_size
 ) {
+  if (new_size == 0)
+  return (void*) align;
   void *ret = realloc(ptr, new_size);
   if (!ret)
   abort();
@@ -20,6 +22,8 @@ void *ptr,
 size_t size,
 size_t align
 ) {
+  if (size == 0)
+  return;
   free(ptr);
 }
 #include <string.h>

--- a/sdk/go/http/wasi-outbound-http.c
+++ b/sdk/go/http/wasi-outbound-http.c
@@ -5,9 +5,11 @@ __attribute__((weak, export_name("canonical_abi_realloc")))
 void *canonical_abi_realloc(
 void *ptr,
 size_t orig_size,
-size_t org_align,
+size_t align,
 size_t new_size
 ) {
+  if (new_size == 0)
+  return (void*) align;
   void *ret = realloc(ptr, new_size);
   if (!ret)
   abort();
@@ -20,6 +22,8 @@ void *ptr,
 size_t size,
 size_t align
 ) {
+  if (size == 0)
+  return;
   free(ptr);
 }
 #include <string.h>

--- a/sdk/go/redis/outbound-redis.c
+++ b/sdk/go/redis/outbound-redis.c
@@ -5,9 +5,11 @@ __attribute__((weak, export_name("canonical_abi_realloc")))
 void *canonical_abi_realloc(
 void *ptr,
 size_t orig_size,
-size_t org_align,
+size_t align,
 size_t new_size
 ) {
+  if (new_size == 0)
+  return (void*) align;
   void *ret = realloc(ptr, new_size);
   if (!ret)
   abort();
@@ -20,6 +22,8 @@ void *ptr,
 size_t size,
 size_t align
 ) {
+  if (size == 0)
+  return;
   free(ptr);
 }
 #include <string.h>

--- a/sdk/go/redis/spin-redis.c
+++ b/sdk/go/redis/spin-redis.c
@@ -5,9 +5,11 @@ __attribute__((weak, export_name("canonical_abi_realloc")))
 void *canonical_abi_realloc(
 void *ptr,
 size_t orig_size,
-size_t org_align,
+size_t align,
 size_t new_size
 ) {
+  if (new_size == 0)
+  return (void*) align;
   void *ret = realloc(ptr, new_size);
   if (!ret)
   abort();
@@ -20,6 +22,8 @@ void *ptr,
 size_t size,
 size_t align
 ) {
+  if (size == 0)
+  return;
   free(ptr);
 }
 void spin_redis_payload_free(spin_redis_payload_t *ptr) {


### PR DESCRIPTION
This pulls in fixes backported to wit-bindgen-backports that should resolve issues with Tinygo's handling of zero-sized allocations.