### PR TITLE
add general-purpose `execute` function to `outbound-redis`

### DIFF
--- a/crates/abi-conformance/src/outbound_redis.rs
+++ b/crates/abi-conformance/src/outbound_redis.rs
@@ -1,6 +1,6 @@
 use super::Context;
 use anyhow::{ensure, Result};
-use outbound_redis::{Error, ValueParam, ValueResult};
+use outbound_redis::{Error, RedisParameter, RedisResult};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use wasmtime::{InstancePre, Store};
@@ -100,7 +100,7 @@ pub(super) struct OutboundRedis {
     sadd_map: HashMap<(String, String, Vec<String>), i64>,
     srem_map: HashMap<(String, String, Vec<String>), i64>,
     smembers_map: HashMap<(String, String), Vec<String>>,
-    execute_map: HashMap<(String, String, Vec<String>), Vec<ValueResult>>,
+    execute_map: HashMap<(String, String, Vec<String>), Vec<RedisResult>>,
 }
 
 impl outbound_redis::OutboundRedis for OutboundRedis {
@@ -178,8 +178,8 @@ impl outbound_redis::OutboundRedis for OutboundRedis {
         &mut self,
         address: &str,
         command: &str,
-        arguments: Vec<ValueParam<'_>>,
-    ) -> Result<Vec<ValueResult>, Error> {
+        arguments: Vec<RedisParameter<'_>>,
+    ) -> Result<Vec<RedisResult>, Error> {
         self.execute_map
             .remove(&(
                 address.into(),
@@ -379,7 +379,7 @@ pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Re
                     "append".to_owned(),
                     vec!["foo".to_owned(), "baz".to_owned()],
                 ),
-                vec![ValueResult::Int(3)],
+                vec![RedisResult::Int64(3)],
             );
 
             super::run_command(

--- a/crates/abi-conformance/src/outbound_redis.rs
+++ b/crates/abi-conformance/src/outbound_redis.rs
@@ -1,5 +1,6 @@
 use super::Context;
 use anyhow::{ensure, Result};
+use outbound_redis::{Error, ValueParam, ValueResult};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use wasmtime::{InstancePre, Store};
@@ -76,6 +77,15 @@ pub struct RedisReport {
     /// "baz"))` as the result.  The host will assert that said function is called exactly once with the specified
     /// arguments.
     pub smembers: Result<(), String>,
+
+    /// Result of the Redis `execute` test
+    ///
+    /// The guest module should expect a call according to [`super::InvocationStyle`] with
+    /// \["outbound-redis-execute", "127.0.0.1", "append", "foo", "baz"\] as arguments. The module should call the
+    /// host-implemented `outbound-redis::execute` function with the arguments \["127.0.0.1", "append", "foo",
+    /// "baz"\] and expect `ok(list(value::int(3)))` as the result.  The host will assert that said function is
+    /// called exactly once with the specified arguments.
+    pub execute: Result<(), String>,
 }
 
 wit_bindgen_wasmtime::export!("../../wit/ephemeral/outbound-redis.wit");
@@ -90,92 +100,93 @@ pub(super) struct OutboundRedis {
     sadd_map: HashMap<(String, String, Vec<String>), i64>,
     srem_map: HashMap<(String, String, Vec<String>), i64>,
     smembers_map: HashMap<(String, String), Vec<String>>,
+    execute_map: HashMap<(String, String, Vec<String>), Vec<ValueResult>>,
 }
 
 impl outbound_redis::OutboundRedis for OutboundRedis {
-    fn publish(
-        &mut self,
-        address: &str,
-        channel: &str,
-        payload: &[u8],
-    ) -> Result<(), outbound_redis::Error> {
+    fn publish(&mut self, address: &str, channel: &str, payload: &[u8]) -> Result<(), Error> {
         if self
             .publish_set
             .remove(&(address.to_owned(), channel.to_owned(), payload.to_vec()))
         {
             Ok(())
         } else {
-            Err(outbound_redis::Error::Error)
+            Err(Error::Error)
         }
     }
 
-    fn get(&mut self, address: &str, key: &str) -> Result<Vec<u8>, outbound_redis::Error> {
+    fn get(&mut self, address: &str, key: &str) -> Result<Vec<u8>, Error> {
         self.get_map
             .remove(&(address.to_owned(), key.to_owned()))
-            .ok_or(outbound_redis::Error::Error)
+            .ok_or(Error::Error)
     }
 
-    fn set(&mut self, address: &str, key: &str, value: &[u8]) -> Result<(), outbound_redis::Error> {
+    fn set(&mut self, address: &str, key: &str, value: &[u8]) -> Result<(), Error> {
         if self
             .set_set
             .remove(&(address.to_owned(), key.to_owned(), value.to_vec()))
         {
             Ok(())
         } else {
-            Err(outbound_redis::Error::Error)
+            Err(Error::Error)
         }
     }
 
-    fn incr(&mut self, address: &str, key: &str) -> Result<i64, outbound_redis::Error> {
+    fn incr(&mut self, address: &str, key: &str) -> Result<i64, Error> {
         self.incr_map
             .remove(&(address.to_owned(), key.to_owned()))
             .map(|value| value + 1)
-            .ok_or(outbound_redis::Error::Error)
+            .ok_or(Error::Error)
     }
 
-    fn del(&mut self, address: &str, keys: Vec<&str>) -> Result<i64, outbound_redis::Error> {
+    fn del(&mut self, address: &str, keys: Vec<&str>) -> Result<i64, Error> {
         self.del_map
             .remove(&(
                 address.into(),
                 keys.into_iter().map(|s| s.to_owned()).collect(),
             ))
-            .ok_or(outbound_redis::Error::Error)
+            .ok_or(Error::Error)
     }
 
-    fn sadd(
-        &mut self,
-        address: &str,
-        key: &str,
-        values: Vec<&str>,
-    ) -> Result<i64, outbound_redis::Error> {
+    fn sadd(&mut self, address: &str, key: &str, values: Vec<&str>) -> Result<i64, Error> {
         self.sadd_map
             .remove(&(
                 address.into(),
                 key.to_owned(),
                 values.into_iter().map(|s| s.to_owned()).collect(),
             ))
-            .ok_or(outbound_redis::Error::Error)
+            .ok_or(Error::Error)
     }
 
-    fn srem(
-        &mut self,
-        address: &str,
-        key: &str,
-        values: Vec<&str>,
-    ) -> Result<i64, outbound_redis::Error> {
+    fn srem(&mut self, address: &str, key: &str, values: Vec<&str>) -> Result<i64, Error> {
         self.srem_map
             .remove(&(
                 address.into(),
                 key.to_owned(),
                 values.into_iter().map(|s| s.to_owned()).collect(),
             ))
-            .ok_or(outbound_redis::Error::Error)
+            .ok_or(Error::Error)
     }
 
-    fn smembers(&mut self, address: &str, key: &str) -> Result<Vec<String>, outbound_redis::Error> {
+    fn smembers(&mut self, address: &str, key: &str) -> Result<Vec<String>, Error> {
         self.smembers_map
             .remove(&(address.into(), key.to_owned()))
-            .ok_or(outbound_redis::Error::Error)
+            .ok_or(Error::Error)
+    }
+
+    fn execute(
+        &mut self,
+        address: &str,
+        command: &str,
+        arguments: Vec<ValueParam<'_>>,
+    ) -> Result<Vec<ValueResult>, Error> {
+        self.execute_map
+            .remove(&(
+                address.into(),
+                command.to_owned(),
+                arguments.iter().map(|v| format!("{v:?}")).collect(),
+            ))
+            .ok_or(Error::Error)
     }
 }
 
@@ -354,6 +365,37 @@ pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Re
                     ensure!(
                         store.data().outbound_redis.smembers_map.is_empty(),
                         "expected module to call `outbound-redis::smembers` exactly once"
+                    );
+
+                    Ok(())
+                },
+            )
+        },
+
+        execute: {
+            store.data_mut().outbound_redis.execute_map.insert(
+                (
+                    "127.0.0.1".into(),
+                    "append".to_owned(),
+                    vec!["foo".to_owned(), "baz".to_owned()],
+                ),
+                vec![ValueResult::Int(3)],
+            );
+
+            super::run_command(
+                store,
+                pre,
+                &[
+                    "outbound-redis-execute",
+                    "127.0.0.1",
+                    "append",
+                    "foo",
+                    "baz",
+                ],
+                |store| {
+                    ensure!(
+                        store.data().outbound_redis.execute_map.is_empty(),
+                        "expected module to call `outbound-redis::execute` exactly once"
                     );
 
                     Ok(())

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -95,9 +95,6 @@ impl outbound_redis::OutboundRedis for OutboundRedis {
         let conn = self.get_conn(address).await.map_err(log_error)?;
         let mut cmd = redis::cmd(command);
         arguments.iter().for_each(|value| match value {
-            RedisParameter::Str(s) => {
-                cmd.arg(s);
-            }
             RedisParameter::Int64(v) => {
                 cmd.arg(v);
             }

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -3,13 +3,33 @@ mod host_component;
 use std::collections::{hash_map::Entry, HashMap};
 
 use anyhow::Result;
-use redis::{aio::Connection, AsyncCommands};
+use redis::{aio::Connection, AsyncCommands, FromRedisValue, RedisResult, Value};
 use wit_bindgen_wasmtime::async_trait;
 
 pub use host_component::OutboundRedisComponent;
 
 wit_bindgen_wasmtime::export!({paths: ["../../wit/ephemeral/outbound-redis.wit"], async: *});
-use outbound_redis::Error;
+use outbound_redis::{Error, ValueParam, ValueResult};
+
+struct Values(Vec<ValueResult>);
+
+impl FromRedisValue for Values {
+    fn from_redis_value(value: &Value) -> RedisResult<Self> {
+        fn append(values: &mut Vec<ValueResult>, value: &Value) {
+            match value {
+                Value::Nil | Value::Okay => (),
+                Value::Int(v) => values.push(ValueResult::Int(*v)),
+                Value::Data(bytes) => values.push(ValueResult::Data(bytes.to_owned())),
+                Value::Bulk(bulk) => bulk.iter().for_each(|value| append(values, value)),
+                Value::Status(message) => values.push(ValueResult::String(message.to_owned())),
+            }
+        }
+
+        let mut values = Vec::new();
+        append(&mut values, value);
+        Ok(Values(values))
+    }
+}
 
 #[derive(Default)]
 pub struct OutboundRedis {
@@ -64,6 +84,33 @@ impl outbound_redis::OutboundRedis for OutboundRedis {
         let conn = self.get_conn(address).await.map_err(log_error)?;
         let value = conn.srem(key, values).await.map_err(log_error)?;
         Ok(value)
+    }
+
+    async fn execute(
+        &mut self,
+        address: &str,
+        command: &str,
+        arguments: Vec<ValueParam<'_>>,
+    ) -> Result<Vec<ValueResult>, Error> {
+        let conn = self.get_conn(address).await.map_err(log_error)?;
+        let mut cmd = redis::cmd(command);
+        arguments.iter().for_each(|value| match value {
+            ValueParam::Nil => (),
+            ValueParam::String(s) => {
+                cmd.arg(s);
+            }
+            ValueParam::Int(v) => {
+                cmd.arg(v);
+            }
+            ValueParam::Data(v) => {
+                cmd.arg(v);
+            }
+        });
+
+        cmd.query_async::<_, Values>(conn)
+            .await
+            .map(|values| values.0)
+            .map_err(log_error)
     }
 }
 

--- a/examples/rust-outbound-redis/Cargo.lock
+++ b/examples/rust-outbound-redis/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -43,7 +43,38 @@ pub mod http {
 /// Implementation of the spin redis interface.
 #[allow(missing_docs)]
 pub mod redis {
+    use std::hash::{Hash, Hasher};
+
     wit_bindgen_rust::import!("../../wit/ephemeral/outbound-redis.wit");
+
+    impl PartialEq for outbound_redis::ValueResult {
+        fn eq(&self, other: &Self) -> bool {
+            use outbound_redis::ValueResult::*;
+
+            match (self, other) {
+                (Nil, Nil) => true,
+                (String(a), String(b)) => a == b,
+                (Int(a), Int(b)) => a == b,
+                (Data(a), Data(b)) => a == b,
+                _ => false,
+            }
+        }
+    }
+
+    impl Eq for outbound_redis::ValueResult {}
+
+    impl Hash for outbound_redis::ValueResult {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            use outbound_redis::ValueResult::*;
+
+            match self {
+                Nil => (),
+                String(s) => s.hash(state),
+                Int(v) => v.hash(state),
+                Data(v) => v.hash(state),
+            }
+        }
+    }
 
     /// Exports the generated outbound Redis items.
     pub use outbound_redis::*;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -47,37 +47,37 @@ pub mod redis {
 
     wit_bindgen_rust::import!("../../wit/ephemeral/outbound-redis.wit");
 
-    impl PartialEq for outbound_redis::ValueResult {
+    /// Exports the generated outbound Redis items.
+    pub use outbound_redis::*;
+
+    impl PartialEq for RedisResult {
         fn eq(&self, other: &Self) -> bool {
-            use outbound_redis::ValueResult::*;
+            use RedisResult::*;
 
             match (self, other) {
                 (Nil, Nil) => true,
-                (String(a), String(b)) => a == b,
-                (Int(a), Int(b)) => a == b,
-                (Data(a), Data(b)) => a == b,
+                (Status(a), Status(b)) => a == b,
+                (Int64(a), Int64(b)) => a == b,
+                (Binary(a), Binary(b)) => a == b,
                 _ => false,
             }
         }
     }
 
-    impl Eq for outbound_redis::ValueResult {}
+    impl Eq for RedisResult {}
 
-    impl Hash for outbound_redis::ValueResult {
+    impl Hash for RedisResult {
         fn hash<H: Hasher>(&self, state: &mut H) {
-            use outbound_redis::ValueResult::*;
+            use RedisResult::*;
 
             match self {
                 Nil => (),
-                String(s) => s.hash(state),
-                Int(v) => v.hash(state),
-                Data(v) => v.hash(state),
+                Status(s) => s.hash(state),
+                Int64(v) => v.hash(state),
+                Binary(v) => v.hash(state),
             }
         }
     }
-
-    /// Exports the generated outbound Redis items.
-    pub use outbound_redis::*;
 }
 
 /// Implementation of the spin postgres db interface.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,7 +9,6 @@ mod integration_tests {
     use std::{
         collections::HashMap,
         ffi::OsStr,
-        fs,
         net::{Ipv4Addr, SocketAddrV4, TcpListener},
         path::Path,
         process::{self, Child, Command, Output},
@@ -1133,7 +1132,7 @@ route = "/..."
             ]
         });
         let manifest_file_path = dir.join("example-plugin-manifest.json");
-        fs::write(
+        std::fs::write(
             &manifest_file_path,
             serde_json::to_string(&plugin_manifest_json).unwrap(),
         )?;
@@ -1161,7 +1160,7 @@ route = "/..."
 
         // Upgrade plugin to newer version
         *plugin_manifest_json.get_mut("version").unwrap() = serde_json::json!("0.2.1");
-        fs::write(
+        std::fs::write(
             dir.join("example-plugin-manifest.json"),
             serde_json::to_string(&plugin_manifest_json).unwrap(),
         )?;
@@ -1184,7 +1183,7 @@ route = "/..."
             .join("plugins")
             .join("manifests")
             .join("example.json");
-        let manifest = fs::read_to_string(installed_manifest)?;
+        let manifest = std::fs::read_to_string(installed_manifest)?;
         assert!(manifest.contains("0.2.1"));
 
         // Uninstall plugin

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use spin_sdk::{
     http::{Request, Response},
     http_component,
-    redis::{self, ValueParam, ValueResult},
+    redis::{self, RedisParameter, RedisResult},
 };
 use std::collections::HashSet;
 
@@ -39,8 +39,8 @@ fn test(_req: Request) -> Result<Response> {
         &address,
         "set",
         &[
-            ValueParam::String("spin-example"),
-            ValueParam::Data(b"Eureka!"),
+            RedisParameter::Str("spin-example"),
+            RedisParameter::Binary(b"Eureka!"),
         ],
     )
     .map_err(|_| anyhow!("Error executing Redis set command"))?;
@@ -49,59 +49,59 @@ fn test(_req: Request) -> Result<Response> {
         &address,
         "append",
         &[
-            ValueParam::String("spin-example"),
-            ValueParam::Data(b" I've got it!"),
+            RedisParameter::Str("spin-example"),
+            RedisParameter::Binary(b" I've got it!"),
         ],
     )
-    .map_err(|_| anyhow!("Error executing Redis append command"))?;
+    .map_err(|_| anyhow!("Error executing Redis append command via `execute`"))?;
 
-    let values = redis::execute(&address, "get", &[ValueParam::String("spin-example")])
-        .map_err(|_| anyhow!("Error executing Redis get command"))?;
+    let values = redis::execute(&address, "get", &[RedisParameter::Str("spin-example")])
+        .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
 
     assert_eq!(
         values,
-        &[ValueResult::Data(b"Eureka! I've got it!".to_vec())]
+        &[RedisResult::Binary(b"Eureka! I've got it!".to_vec())]
     );
 
     redis::execute(
         &address,
         "set",
-        &[ValueParam::String("int-key"), ValueParam::Int(0)],
+        &[RedisParameter::Str("int-key"), RedisParameter::Int64(0)],
     )
-    .map_err(|_| anyhow!("Error executing Redis set command"))?;
+    .map_err(|_| anyhow!("Error executing Redis set command via `execute`"))?;
 
-    let values = redis::execute(&address, "incr", &[ValueParam::String("int-key")])
-        .map_err(|_| anyhow!("Error executing Redis incr command"))?;
+    let values = redis::execute(&address, "incr", &[RedisParameter::Str("int-key")])
+        .map_err(|_| anyhow!("Error executing Redis incr command via `execute`"))?;
 
-    assert_eq!(values, &[ValueResult::Int(1)]);
+    assert_eq!(values, &[RedisResult::Int64(1)]);
 
-    let values = redis::execute(&address, "get", &[ValueParam::String("int-key")])
-        .map_err(|_| anyhow!("Error executing Redis get command"))?;
+    let values = redis::execute(&address, "get", &[RedisParameter::Str("int-key")])
+        .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
 
-    assert_eq!(values, &[ValueResult::Data(b"1".to_vec())]);
+    assert_eq!(values, &[RedisResult::Binary(b"1".to_vec())]);
 
-    redis::execute(&address, "del", &[ValueParam::String("foo")])
-        .map_err(|_| anyhow!("Error executing Redis del command"))?;
+    redis::execute(&address, "del", &[RedisParameter::Str("foo")])
+        .map_err(|_| anyhow!("Error executing Redis del command via `execute`"))?;
 
     redis::execute(
         &address,
         "sadd",
         &[
-            ValueParam::String("foo"),
-            ValueParam::String("bar"),
-            ValueParam::String("baz"),
+            RedisParameter::Str("foo"),
+            RedisParameter::Str("bar"),
+            RedisParameter::Str("baz"),
         ],
     )
-    .map_err(|_| anyhow!("Error executing Redis sadd command"))?;
+    .map_err(|_| anyhow!("Error executing Redis sadd command via `execute`"))?;
 
-    let values = redis::execute(&address, "smembers", &[ValueParam::String("foo")])
-        .map_err(|_| anyhow!("Error executing Redis smembers command"))?;
+    let values = redis::execute(&address, "smembers", &[RedisParameter::Str("foo")])
+        .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
 
     assert_eq!(
         values.into_iter().collect::<HashSet<_>>(),
         [
-            ValueResult::Data(b"bar".to_vec()),
-            ValueResult::Data(b"baz".to_vec())
+            RedisResult::Binary(b"bar".to_vec()),
+            RedisResult::Binary(b"baz".to_vec())
         ]
         .into_iter()
         .collect::<HashSet<_>>()
@@ -110,16 +110,16 @@ fn test(_req: Request) -> Result<Response> {
     redis::execute(
         &address,
         "srem",
-        &[ValueParam::String("foo"), ValueParam::String("baz")],
+        &[RedisParameter::Str("foo"), RedisParameter::Str("baz")],
     )
-    .map_err(|_| anyhow!("Error executing Redis srem command"))?;
+    .map_err(|_| anyhow!("Error executing Redis srem command via `execute`"))?;
 
-    let values = redis::execute(&address, "smembers", &[ValueParam::String("foo")])
-        .map_err(|_| anyhow!("Error executing Redis smembers command"))?;
+    let values = redis::execute(&address, "smembers", &[RedisParameter::Str("foo")])
+        .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
 
     assert_eq!(
         values.into_iter().collect::<HashSet<_>>(),
-        [ValueResult::Data(b"bar".to_vec()),]
+        [RedisResult::Binary(b"bar".to_vec()),]
             .into_iter()
             .collect::<HashSet<_>>()
     );

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -1,8 +1,10 @@
 use anyhow::{anyhow, Result};
 use spin_sdk::{
     http::{Request, Response},
-    http_component, redis,
+    http_component,
+    redis::{self, ValueParam, ValueResult},
 };
+use std::collections::HashSet;
 
 const REDIS_ADDRESS_ENV: &str = "REDIS_ADDRESS";
 
@@ -28,10 +30,99 @@ fn test(_req: Request) -> Result<Response> {
 
     let keys = vec!["spin-example-get-set", "spin-example-incr"];
 
-    let del_keys = redis::del(&address, &keys)
-        .map_err(|_| anyhow!("Error executing Redis incr command"))?;
+    let del_keys =
+        redis::del(&address, &keys).map_err(|_| anyhow!("Error executing Redis incr command"))?;
 
     assert_eq!(del_keys, 2);
+
+    redis::execute(
+        &address,
+        "set",
+        &[
+            ValueParam::String("spin-example"),
+            ValueParam::Data(b"Eureka!"),
+        ],
+    )
+    .map_err(|_| anyhow!("Error executing Redis set command"))?;
+
+    redis::execute(
+        &address,
+        "append",
+        &[
+            ValueParam::String("spin-example"),
+            ValueParam::Data(b" I've got it!"),
+        ],
+    )
+    .map_err(|_| anyhow!("Error executing Redis set command"))?;
+
+    let values = redis::execute(&address, "get", &[ValueParam::String("spin-example")])
+        .map_err(|_| anyhow!("Error executing Redis get command"))?;
+
+    assert_eq!(
+        values,
+        &[ValueResult::Data(b"Eureka! I've got it!".to_vec())]
+    );
+
+    redis::execute(
+        &address,
+        "set",
+        &[ValueParam::String("int-key"), ValueParam::Int(0)],
+    )
+    .map_err(|_| anyhow!("Error executing Redis set command"))?;
+
+    let values = redis::execute(&address, "incr", &[ValueParam::String("int-key")])
+        .map_err(|_| anyhow!("Error executing Redis incr command"))?;
+
+    assert_eq!(values, &[ValueResult::Int(1)]);
+
+    let values = redis::execute(&address, "get", &[ValueParam::String("int-key")])
+        .map_err(|_| anyhow!("Error executing Redis get command"))?;
+
+    assert_eq!(values, &[ValueResult::Data(b"1".to_vec())]);
+
+    redis::execute(&address, "del", &[ValueParam::String("foo")])
+        .map_err(|_| anyhow!("Error executing Redis del command"))?;
+
+    redis::execute(
+        &address,
+        "sadd",
+        &[
+            ValueParam::String("foo"),
+            ValueParam::String("bar"),
+            ValueParam::String("baz"),
+        ],
+    )
+    .map_err(|_| anyhow!("Error executing Redis sadd command"))?;
+
+    let values = redis::execute(&address, "smembers", &[ValueParam::String("foo")])
+        .map_err(|_| anyhow!("Error executing Redis smembers command"))?;
+
+    assert_eq!(
+        values.into_iter().collect::<HashSet<_>>(),
+        [
+            ValueResult::Data(b"bar".to_vec()),
+            ValueResult::Data(b"baz".to_vec())
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>()
+    );
+
+    redis::execute(
+        &address,
+        "srem",
+        &[ValueParam::String("foo"), ValueParam::String("baz")],
+    )
+    .map_err(|_| anyhow!("Error executing Redis srem command"))?;
+
+    let values = redis::execute(&address, "smembers", &[ValueParam::String("foo")])
+        .map_err(|_| anyhow!("Error executing Redis smembers command"))?;
+
+    assert_eq!(
+        values.into_iter().collect::<HashSet<_>>(),
+        [ValueResult::Data(b"bar".to_vec()),]
+            .into_iter()
+            .collect::<HashSet<_>>()
+    );
 
     Ok(http::Response::builder().status(204).body(None)?)
 }

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -39,7 +39,7 @@ fn test(_req: Request) -> Result<Response> {
         &address,
         "set",
         &[
-            RedisParameter::Str("spin-example"),
+            RedisParameter::Binary(b"spin-example"),
             RedisParameter::Binary(b"Eureka!"),
         ],
     )
@@ -49,13 +49,13 @@ fn test(_req: Request) -> Result<Response> {
         &address,
         "append",
         &[
-            RedisParameter::Str("spin-example"),
+            RedisParameter::Binary(b"spin-example"),
             RedisParameter::Binary(b" I've got it!"),
         ],
     )
     .map_err(|_| anyhow!("Error executing Redis append command via `execute`"))?;
 
-    let values = redis::execute(&address, "get", &[RedisParameter::Str("spin-example")])
+    let values = redis::execute(&address, "get", &[RedisParameter::Binary(b"spin-example")])
         .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
 
     assert_eq!(
@@ -66,35 +66,35 @@ fn test(_req: Request) -> Result<Response> {
     redis::execute(
         &address,
         "set",
-        &[RedisParameter::Str("int-key"), RedisParameter::Int64(0)],
+        &[RedisParameter::Binary(b"int-key"), RedisParameter::Int64(0)],
     )
     .map_err(|_| anyhow!("Error executing Redis set command via `execute`"))?;
 
-    let values = redis::execute(&address, "incr", &[RedisParameter::Str("int-key")])
+    let values = redis::execute(&address, "incr", &[RedisParameter::Binary(b"int-key")])
         .map_err(|_| anyhow!("Error executing Redis incr command via `execute`"))?;
 
     assert_eq!(values, &[RedisResult::Int64(1)]);
 
-    let values = redis::execute(&address, "get", &[RedisParameter::Str("int-key")])
+    let values = redis::execute(&address, "get", &[RedisParameter::Binary(b"int-key")])
         .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
 
     assert_eq!(values, &[RedisResult::Binary(b"1".to_vec())]);
 
-    redis::execute(&address, "del", &[RedisParameter::Str("foo")])
+    redis::execute(&address, "del", &[RedisParameter::Binary(b"foo")])
         .map_err(|_| anyhow!("Error executing Redis del command via `execute`"))?;
 
     redis::execute(
         &address,
         "sadd",
         &[
-            RedisParameter::Str("foo"),
-            RedisParameter::Str("bar"),
-            RedisParameter::Str("baz"),
+            RedisParameter::Binary(b"foo"),
+            RedisParameter::Binary(b"bar"),
+            RedisParameter::Binary(b"baz"),
         ],
     )
     .map_err(|_| anyhow!("Error executing Redis sadd command via `execute`"))?;
 
-    let values = redis::execute(&address, "smembers", &[RedisParameter::Str("foo")])
+    let values = redis::execute(&address, "smembers", &[RedisParameter::Binary(b"foo")])
         .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
 
     assert_eq!(
@@ -110,11 +110,14 @@ fn test(_req: Request) -> Result<Response> {
     redis::execute(
         &address,
         "srem",
-        &[RedisParameter::Str("foo"), RedisParameter::Str("baz")],
+        &[
+            RedisParameter::Binary(b"foo"),
+            RedisParameter::Binary(b"baz"),
+        ],
     )
     .map_err(|_| anyhow!("Error executing Redis srem command via `execute`"))?;
 
-    let values = redis::execute(&address, "smembers", &[RedisParameter::Str("foo")])
+    let values = redis::execute(&address, "smembers", &[RedisParameter::Binary(b"foo")])
         .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
 
     assert_eq!(

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -53,7 +53,7 @@ fn test(_req: Request) -> Result<Response> {
             ValueParam::Data(b" I've got it!"),
         ],
     )
-    .map_err(|_| anyhow!("Error executing Redis set command"))?;
+    .map_err(|_| anyhow!("Error executing Redis append command"))?;
 
     let values = redis::execute(&address, "get", &[ValueParam::String("spin-example")])
         .map_err(|_| anyhow!("Error executing Redis get command"))?;

--- a/wit/ephemeral/outbound-redis.wit
+++ b/wit/ephemeral/outbound-redis.wit
@@ -24,3 +24,6 @@ smembers: func(address: string, key: string) -> expected<list<string>, error>
 
 // Remove the specified `values` from the set named `key`, returning the number of newly-removed values.
 srem: func(address: string, key: string, values: list<string>) -> expected<s64, error>
+
+// Execute an arbitrary Redis command and receive the result.
+execute: func(address: string, command: string, arguments: list<value>) -> expected<list<value>, error>

--- a/wit/ephemeral/outbound-redis.wit
+++ b/wit/ephemeral/outbound-redis.wit
@@ -26,4 +26,4 @@ smembers: func(address: string, key: string) -> expected<list<string>, error>
 srem: func(address: string, key: string, values: list<string>) -> expected<s64, error>
 
 // Execute an arbitrary Redis command and receive the result.
-execute: func(address: string, command: string, arguments: list<value>) -> expected<list<value>, error>
+execute: func(address: string, command: string, arguments: list<redis-parameter>) -> expected<list<redis-result>, error>

--- a/wit/ephemeral/redis-types.wit
+++ b/wit/ephemeral/redis-types.wit
@@ -7,10 +7,17 @@ enum error {
 // The message payload.
 type payload = list<u8>
 
-// An argument and return type for the general-purpose `execute` function.
-variant value {
+// A parameter type for the general-purpose `execute` function.
+variant redis-parameter {
+    str(string),
+    int64(s64),
+    binary(payload)
+}
+
+// A return type for the general-purpose `execute` function.
+variant redis-result {
     nil,
-    %string(string),
-    int(s64),
-    data(payload)
+    status(string),
+    int64(s64),
+    binary(payload)
 }

--- a/wit/ephemeral/redis-types.wit
+++ b/wit/ephemeral/redis-types.wit
@@ -9,7 +9,6 @@ type payload = list<u8>
 
 // A parameter type for the general-purpose `execute` function.
 variant redis-parameter {
-    str(string),
     int64(s64),
     binary(payload)
 }

--- a/wit/ephemeral/redis-types.wit
+++ b/wit/ephemeral/redis-types.wit
@@ -6,3 +6,11 @@ enum error {
 
 // The message payload.
 type payload = list<u8>
+
+// An argument and return type for the general-purpose `execute` function.
+variant value {
+    nil,
+    %string(string),
+    int(s64),
+    data(payload)
+}


### PR DESCRIPTION
By popular request, this function should allow executing any arbitrary Redis command and retrieving its result, if any.  Ideally, we'd support a statically typed interface for every command, but that would be a pretty huge effort, so we settle for dynamic typing for now. Once we have TCP socket support, users will be able to use their favorite Redis client library and enjoy static typing at that level, if applicable.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>