### PR TITLE
Better guidance when unable to upgrade templates

### DIFF
--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -240,6 +240,15 @@ impl Upgrade {
 
         if sources.is_empty() {
             eprintln!("No template repositories found to upgrade");
+            eprintln!();
+            if existing_templates.is_empty() {
+                prompt_install_default_templates(template_manager).await?;
+            } else {
+                eprintln!("Your template repositories were either:");
+                eprintln!("* Installed from a directory; or");
+                eprintln!("* Installed using an older version of Spin");
+                eprintln!("To upgrade them, run `spin templates install --upgrade` with the --git or --dir option");
+            }
             return Ok(None);
         }
 


### PR DESCRIPTION
If the user has templates installed with Spin 0.8 or earlier, they will have no info saved saying where they come from, and `spin templates upgrade` will not work.  The current message is a bit misleading.  This PR tweaks the experience as follows:

* User has no templates installed at all - standard "prompt to install the default set" experience:

```
$ spin templates upgrade
No template repositories found to upgrade

You don't have any templates yet. Would you like to install the default set?
```

* User has templates, but none of them have origin information - point them in the right direction to perform an incantatory upgrade:

```
$ spin templates upgrade
No template repositories found to upgrade

Your template repositories were either:
* Installed from a directory; or
* Installed using an older version of Spin
To upgrade them, run `spin templates install --upgrade` with the --git or --dir option
```

Very open to ~~bikeshedding~~ wordsmithing on that new text.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>