### PR TITLE
key-value-sqlite: Temporarily downgrade rusqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,11 +1762,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3631,15 +3631,16 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.28.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
+ "memchr",
  "smallvec",
 ]
 

--- a/crates/key-value-sqlite/Cargo.toml
+++ b/crates/key-value-sqlite/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 once_cell = "1"
-rusqlite = { version = "0.28.0", features = [ "bundled" ] }
+rusqlite = { version = "0.27.0", features = [ "bundled" ] }
 tokio = "1"
 wit-bindgen-wasmtime = { workspace = true }
 key-value = { path = "../key-value" }

--- a/crates/key-value-sqlite/src/lib.rs
+++ b/crates/key-value-sqlite/src/lib.rs
@@ -54,7 +54,7 @@ impl Impl for KeyValueSqlite {
 
                            PRIMARY KEY (store, key)
                         )",
-                        (),
+                        [],
                     )
                     .map_err(log_error)?;
 


### PR DESCRIPTION
We're seeing incompatible versions of libsqlite3 in a dependent project. Downgrading temporarily until we solve the incompatibility.

https://github.com/rusqlite/rusqlite/releases/tag/v0.28.0