### PR TITLE
refactor key-value host component for per-component configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,30 +2147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "key-value"
-version = "0.8.0"
-dependencies = [
- "anyhow",
- "spin-app",
- "spin-core",
- "tokio",
- "tracing",
- "wit-bindgen-wasmtime",
-]
-
-[[package]]
-name = "key-value-sqlite"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "key-value",
- "once_cell",
- "rusqlite",
- "tokio",
- "wit-bindgen-wasmtime",
-]
-
-[[package]]
 name = "kstring"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,8 +4184,6 @@ dependencies = [
  "hippo-openapi",
  "hyper",
  "is-terminal",
- "key-value",
- "key-value-sqlite",
  "lazy_static",
  "nix 0.24.3",
  "openssl",
@@ -4228,6 +4202,8 @@ dependencies = [
  "spin-build",
  "spin-config",
  "spin-http",
+ "spin-key-value",
+ "spin-key-value-sqlite",
  "spin-loader",
  "spin-manifest",
  "spin-plugins",
@@ -4307,6 +4283,30 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+ "wit-bindgen-wasmtime",
+]
+
+[[package]]
+name = "spin-key-value"
+version = "0.8.0"
+dependencies = [
+ "anyhow",
+ "spin-app",
+ "spin-core",
+ "tokio",
+ "tracing",
+ "wit-bindgen-wasmtime",
+]
+
+[[package]]
+name = "spin-key-value-sqlite"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "rusqlite",
+ "spin-key-value",
+ "tokio",
  "wit-bindgen-wasmtime",
 ]
 
@@ -4512,8 +4512,6 @@ dependencies = [
  "ctrlc",
  "dirs 4.0.0",
  "futures",
- "key-value",
- "key-value-sqlite",
  "oci-distribution",
  "outbound-http",
  "outbound-mysql",
@@ -4525,6 +4523,8 @@ dependencies = [
  "spin-app",
  "spin-config",
  "spin-core",
+ "spin-key-value",
+ "spin-key-value-sqlite",
  "spin-loader",
  "spin-manifest",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ lazy_static = "1.4.0"
 nix = { version = "0.24", features = ["signal"] }
 outbound-http = { path = "crates/outbound-http" }
 outbound-redis = { path = "crates/outbound-redis" }
-key-value = { path = "crates/key-value" }
-key-value-sqlite = { path = "crates/key-value-sqlite" }
+spin-key-value = { path = "crates/key-value" }
+spin-key-value-sqlite = { path = "crates/key-value-sqlite" }
 path-absolutize = "3.0.11"
 rand = "0.8"
 regex = "1.5.5"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -92,15 +92,6 @@ impl AppLoader {
         })
     }
 
-    /// Consumes `self` and `parts`, producing an [`OwnedApp`].
-    pub fn into_owned(self, parts: AppParts) -> OwnedApp {
-        OwnedApp::new(self, move |loader| App {
-            loader,
-            uri: parts.uri,
-            locked: parts.locked,
-        })
-    }
-
     /// Loads an [`OwnedApp`] from the given `Loader`-implementation-specific
     /// `uri`; the [`OwnedApp`] takes ownership of this [`AppLoader`].
     pub async fn load_owned_app(self, uri: String) -> Result<OwnedApp> {
@@ -139,21 +130,7 @@ pub struct App<'a> {
     locked: LockedApp,
 }
 
-/// The parts of an app exclusive of the [`AppLoader`]
-pub struct AppParts {
-    uri: String,
-    locked: LockedApp,
-}
-
 impl<'a> App<'a> {
-    /// Consume `self`, producing an [`AppParts`]
-    pub fn into_parts(self) -> AppParts {
-        AppParts {
-            uri: self.uri,
-            locked: self.locked,
-        }
-    }
-
     /// Returns a [`Loader`]-implementation-specific URI for this app.
     pub fn uri(&self) -> &str {
         &self.uri

--- a/crates/key-value-sqlite/Cargo.toml
+++ b/crates/key-value-sqlite/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "key-value-sqlite"
+name = "spin-key-value-sqlite"
 version = "0.1.0"
 edition = "2021"
 
@@ -9,4 +9,4 @@ once_cell = "1"
 rusqlite = { version = "0.27.0", features = [ "bundled" ] }
 tokio = "1"
 wit-bindgen-wasmtime = { workspace = true }
-key-value = { path = "../key-value" }
+spin-key-value = { path = "../key-value" }

--- a/crates/key-value/Cargo.toml
+++ b/crates/key-value/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "key-value"
+name = "spin-key-value"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/key-value/src/host_component.rs
+++ b/crates/key-value/src/host_component.rs
@@ -1,17 +1,37 @@
-use crate::{Impl, KeyValueDispatch};
-use spin_app::DynamicHostComponent;
+use crate::{KeyValueDispatch, StoreManager};
+use spin_app::{App, AppComponent, DynamicHostComponent};
 use spin_core::HostComponent;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 pub const KEY_VALUE_STORES_METADATA_KEY: &str = "key_value_stores";
 
+pub trait StoreManagerManager: Sync + Send {
+    fn get(&self, app: &App) -> Arc<dyn StoreManager>;
+}
+
+impl<F: (Fn(&App) -> Arc<dyn StoreManager>) + Sync + Send> StoreManagerManager for F {
+    fn get(&self, app: &App) -> Arc<dyn StoreManager> {
+        self(app)
+    }
+}
+
+/// Help the rustc type inference engine understand that the specified closure has a higher-order bound so it can
+/// be used as a [`StoreManagerManager`].
+///
+/// See https://stackoverflow.com/a/46198877 for details.
+pub fn manager<F: for<'a> Fn(&'a App) -> Arc<dyn StoreManager>>(f: F) -> F {
+    f
+}
+
 pub struct KeyValueComponent {
-    impls: Arc<HashMap<String, Box<dyn Impl>>>,
+    manager: Box<dyn StoreManagerManager>,
 }
 
 impl KeyValueComponent {
-    pub fn new(impls: Arc<HashMap<String, Box<dyn Impl>>>) -> Self {
-        Self { impls }
+    pub fn new(manager: impl StoreManagerManager + 'static) -> Self {
+        Self {
+            manager: Box::new(manager),
+        }
     }
 }
 
@@ -26,21 +46,20 @@ impl HostComponent for KeyValueComponent {
     }
 
     fn build_data(&self) -> Self::Data {
-        KeyValueDispatch::new(self.impls.clone())
+        KeyValueDispatch::new()
     }
 }
 
 impl DynamicHostComponent for KeyValueComponent {
-    fn update_data(
-        &self,
-        data: &mut Self::Data,
-        component: &spin_app::AppComponent,
-    ) -> anyhow::Result<()> {
-        data.allowed_stores = component
-            .get_metadata::<Vec<String>>(KEY_VALUE_STORES_METADATA_KEY)?
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
+    fn update_data(&self, data: &mut Self::Data, component: &AppComponent) -> anyhow::Result<()> {
+        data.init(
+            component
+                .get_metadata::<Vec<String>>(KEY_VALUE_STORES_METADATA_KEY)?
+                .unwrap_or_default()
+                .into_iter()
+                .collect(),
+            self.manager.get(component.app),
+        );
 
         Ok(())
     }

--- a/crates/key-value/src/host_component.rs
+++ b/crates/key-value/src/host_component.rs
@@ -1,17 +1,17 @@
 use crate::{KeyValueDispatch, StoreManager};
-use spin_app::{App, AppComponent, DynamicHostComponent};
+use spin_app::{AppComponent, DynamicHostComponent};
 use spin_core::HostComponent;
 use std::sync::Arc;
 
 pub const KEY_VALUE_STORES_METADATA_KEY: &str = "key_value_stores";
 
 pub trait StoreManagerManager: Sync + Send {
-    fn get(&self, app: &App) -> Arc<dyn StoreManager>;
+    fn get(&self, component: &AppComponent) -> Arc<dyn StoreManager>;
 }
 
-impl<F: (Fn(&App) -> Arc<dyn StoreManager>) + Sync + Send> StoreManagerManager for F {
-    fn get(&self, app: &App) -> Arc<dyn StoreManager> {
-        self(app)
+impl<F: (Fn(&AppComponent) -> Arc<dyn StoreManager>) + Sync + Send> StoreManagerManager for F {
+    fn get(&self, component: &AppComponent) -> Arc<dyn StoreManager> {
+        self(component)
     }
 }
 
@@ -19,7 +19,7 @@ impl<F: (Fn(&App) -> Arc<dyn StoreManager>) + Sync + Send> StoreManagerManager f
 /// be used as a [`StoreManagerManager`].
 ///
 /// See https://stackoverflow.com/a/46198877 for details.
-pub fn manager<F: for<'a> Fn(&'a App) -> Arc<dyn StoreManager>>(f: F) -> F {
+pub fn manager<F: for<'a> Fn(&'a AppComponent) -> Arc<dyn StoreManager>>(f: F) -> F {
     f
 }
 
@@ -58,7 +58,7 @@ impl DynamicHostComponent for KeyValueComponent {
                 .unwrap_or_default()
                 .into_iter()
                 .collect(),
-            self.manager.get(component.app),
+            self.manager.get(component),
         );
 
         Ok(())

--- a/crates/key-value/src/util.rs
+++ b/crates/key-value/src/util.rs
@@ -1,0 +1,33 @@
+use crate::{Error, Store, StoreManager};
+use std::{collections::HashMap, sync::Arc};
+use wit_bindgen_wasmtime::async_trait;
+
+pub struct EmptyStoreManager;
+
+#[async_trait]
+impl StoreManager for EmptyStoreManager {
+    async fn get(&self, _name: &str) -> Result<Arc<dyn Store>, Error> {
+        Err(Error::NoSuchStore)
+    }
+}
+
+pub struct DelegatingStoreManager {
+    delegates: HashMap<String, Arc<dyn StoreManager>>,
+}
+
+impl DelegatingStoreManager {
+    pub fn new(delegates: HashMap<String, Arc<dyn StoreManager>>) -> Self {
+        Self { delegates }
+    }
+}
+
+#[async_trait]
+impl StoreManager for DelegatingStoreManager {
+    async fn get(&self, name: &str) -> Result<Arc<dyn Store>, Error> {
+        self.delegates
+            .get(name)
+            .ok_or(Error::NoSuchStore)?
+            .get(name)
+            .await
+    }
+}

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -16,8 +16,8 @@ outbound-http = { path = "../outbound-http" }
 outbound-redis = { path = "../outbound-redis" }
 outbound-pg = { path = "../outbound-pg" }
 outbound-mysql = { path = "../outbound-mysql" }
-key-value = { path = "../key-value" }
-key-value-sqlite = { path = "../key-value-sqlite" }
+spin-key-value = { path = "../key-value" }
+spin-key-value-sqlite = { path = "../key-value-sqlite" }
 sanitize-filename = "0.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -103,7 +103,7 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
 
                 self.loader.add_dynamic_host_component(
                     &mut builder,
-                    spin_key_value::KeyValueComponent::new(spin_key_value::manager(|app| {
+                    spin_key_value::KeyValueComponent::new(spin_key_value::manager(|component| {
                         // TODO: Once we have runtime configuration for key-value stores, the user will be able to
                         // both change the default store configuration (e.g. use Redis, or an SQLite in-memory
                         // database, or use a different path) and add other named stores with their own
@@ -113,7 +113,9 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
                             [(
                                 "default".to_owned(),
                                 Arc::new(spin_key_value_sqlite::KeyValueSqlite::new(
-                                    if let Some(key_value_file) = key_value_file_location(app) {
+                                    if let Some(key_value_file) =
+                                        key_value_file_location(component.app)
+                                    {
                                         spin_key_value_sqlite::DatabaseLocation::Path(
                                             key_value_file,
                                         )


### PR DESCRIPTION
Previously, the set of available stores needed to be determined by the time `KeyValueComponent` was created, which turned out to be too early for some use cases.  In this commit, I've changed
`KeyValueComponent::new` to take a function which may be used to create a `StoreManager` (formerly known as `Impl`) for any number of applications.  That `StoreManager`, in turn, may be used to open any number of `Store`s (formerly known as `ImplStore`s).

Note that I've used `Arc<dyn _>` rather than `Box<dyn _>` to represent trait objects in order to facilitate connection reuse where appropriate, among both `Store`s and `StoreManager`s.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>