### PR TITLE
fail fast on ci when lint job fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
   build-rust:
     name: Build Spin
     runs-on: ${{ matrix.config.os }}
+    needs: [lint-rust]
     strategy:
       matrix:
         config:
@@ -91,6 +92,7 @@ jobs:
   test-rust:
     name: Test Spin SDK - Rust
     runs-on: ${{ matrix.config.os }}
+    needs: [lint-rust]
     strategy:
       matrix:
         config:


### PR DESCRIPTION
We should fail fast on lint job failures as generally those fixes are quick ones to do but if we run other jobs before returning this failure, the feedback cycle could be upto an hour. 

Before this fix:

<img width="794" alt="Screenshot 2023-02-15 at 7 01 05 AM" src="https://user-images.githubusercontent.com/612092/218904860-80f505e3-2127-4db4-bad9-dd02ec003bbe.png">

After this fix:

<img width="1299" alt="Screenshot 2023-02-15 at 7 03 42 AM" src="https://user-images.githubusercontent.com/612092/218904902-0aa6ab68-b6e2-4231-a645-e80bfd08aeb8.png">
