### PR TITLE
Implement `spin registry login`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,27 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1198,6 +1225,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dkregistry"
+version = "0.5.1-alpha.0"
+source = "git+https://github.com/camallo/dkregistry-rs?rev=37acecb4b8139dd1b1cc83795442f94f90e1ffc5#37acecb4b8139dd1b1cc83795442f94f90e1ffc5"
+dependencies = [
+ "async-stream",
+ "base64 0.13.1",
+ "bytes",
+ "futures",
+ "http",
+ "libflate",
+ "log",
+ "mime",
+ "pin-project",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_ignored",
+ "serde_json",
+ "sha2 0.10.6",
+ "strum",
+ "strum_macros",
+ "tar",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2306,26 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "libflate"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+dependencies = [
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -3585,6 +3660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rpassword"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3883,6 +3964,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94eb4a4087ba8bdf14a9208ac44fddbf55c01a6195f7edfc511ddaff6cae45a6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4394,8 +4484,10 @@ name = "spin-publish"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "base64 0.21.0",
  "bindle",
  "dirs 4.0.0",
+ "dkregistry",
  "docker_credential",
  "dunce",
  "futures",

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -7,6 +7,8 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0"
 bindle = { workspace = true }
+base64 = "0.21.0"
+dkregistry = { git = "https://github.com/camallo/dkregistry-rs", rev = "37acecb4b8139dd1b1cc83795442f94f90e1ffc5" }
 docker_credential = "1.0"
 dirs = "4.0"
 dunce = "1.0"

--- a/crates/publish/src/oci/client.rs
+++ b/crates/publish/src/oci/client.rs
@@ -1,20 +1,25 @@
 //! Client for distributing Spin applications using OCI registries.
 
 use anyhow::{bail, Context, Result};
-use docker_credential::{CredentialRetrievalError, DockerCredential};
+use docker_credential::DockerCredential;
 use oci_distribution::{
     client::{Config, ImageLayer},
     manifest::OciImageManifest,
     secrets::RegistryAuth,
     Reference,
 };
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
 use spin_app::locked::{ContentPath, ContentRef};
 use spin_loader::oci::cache::Cache;
 use spin_manifest::Application;
 use tokio::fs;
 use walkdir::WalkDir;
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 // TODO: the media types for application, wasm module, and data layer are not final.
 const SPIN_APPLICATION_MEDIA_TYPE: &str = "application/vnd.fermyon.spin.application.v1+config";
@@ -43,7 +48,7 @@ impl Client {
             .as_ref()
             .parse()
             .with_context(|| format!("cannot parse reference {}", reference.as_ref()))?;
-        let auth = Self::auth(&reference)?;
+        let auth = Self::auth(&reference).await?;
         let working_dir = tempfile::tempdir()?;
 
         // Create a locked application from the application manifest.
@@ -139,7 +144,7 @@ impl Client {
     /// Pull a Spin application from an OCI registry.
     pub async fn pull(&mut self, reference: &str) -> Result<()> {
         let reference: Reference = reference.parse().context("cannot parse reference")?;
-        let auth = Self::auth(&reference)?;
+        let auth = Self::auth(&reference).await?;
 
         // Pull the manifest from the registry.
         let (manifest, digest) = self.oci.pull_image_manifest(&reference, &auth).await?;
@@ -209,28 +214,84 @@ impl Client {
         ))
     }
 
+    /// Save a credential set containing the registry username and password.
+    pub async fn login(
+        server: impl AsRef<str>,
+        username: impl AsRef<str>,
+        password: impl AsRef<str>,
+    ) -> Result<()> {
+        // We want to allow a user to login to both https://ghcr.io and ghcr.io.
+        let server = server.as_ref();
+        let server = match server.parse::<Url>() {
+            Ok(url) => url.host_str().unwrap_or(server).to_string(),
+            Err(_) => server.to_string(),
+        };
+
+        // First, validate the credentials. If a user accidentally enters a wrong credential set, this
+        // can catch the issue early rather than getting an error at the first operation that needs
+        // to use the credentials (first time they do a push/pull/up).
+        Self::validate_credentials(&server, &username, &password).await?;
+
+        // Save an encoded representation of the credential set in the local configuration file.
+        let mut auth = AuthConfig::load_default().await?;
+        auth.insert(server, username, password)?;
+        auth.save_default().await
+    }
+
+    /// Validate the credentials by attempting to send an authenticated request to the registry.
+    async fn validate_credentials(
+        server: impl AsRef<str>,
+        username: impl AsRef<str>,
+        password: impl AsRef<str>,
+    ) -> Result<()> {
+        let client = dkregistry::v2::Client::configure()
+            .registry(server.as_ref())
+            .insecure_registry(false)
+            .username(Some(username.as_ref().into()))
+            .password(Some(password.as_ref().into()))
+            .build()
+            .context("cannot create client to send authentication request to the registry")?;
+
+        match client
+            // We don't need to configure any scopes, we are only testing that the credentials are
+            // valid for the intended registry.
+            .authenticate(&[""])
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(e) => bail!(format!(
+                "cannot authenticate as {} to registry {}: {}",
+                username.as_ref(),
+                server.as_ref(),
+                e
+            )),
+        }
+    }
+
     /// Construct the registry authentication based on the reference.
-    fn auth(reference: &Reference) -> Result<RegistryAuth> {
+    async fn auth(reference: &Reference) -> Result<RegistryAuth> {
         let server = reference
             .resolve_registry()
             .strip_suffix('/')
             .unwrap_or_else(|| reference.resolve_registry());
 
-        let creds = docker_credential::get_credential(server);
-        match creds {
-            Err(CredentialRetrievalError::ConfigNotFound) => Ok(RegistryAuth::Anonymous),
-            Err(CredentialRetrievalError::NoCredentialConfigured) => Ok(RegistryAuth::Anonymous),
-            Err(CredentialRetrievalError::ConfigReadError) => Ok(RegistryAuth::Anonymous),
-            Err(e) => bail!("Error handling docker configuration file: {}", e),
+        match AuthConfig::get_auth_from_default(server).await {
+            Ok(c) => Ok(c),
+            Err(_) => match docker_credential::get_credential(server) {
+                Err(e) => {
+                    tracing::trace!("Cannot retrieve credentials from Docker, attempting to use anonymous auth: {}", e);
+                    Ok(RegistryAuth::Anonymous)
+                }
 
-            Ok(DockerCredential::UsernamePassword(username, password)) => {
-                tracing::trace!("Found docker credentials");
-                Ok(RegistryAuth::Basic(username, password))
-            }
-            Ok(DockerCredential::IdentityToken(_)) => {
-                println!("Cannot use contents of docker config, identity token not supported. Using anonymous auth");
-                Ok(RegistryAuth::Anonymous)
-            }
+                Ok(DockerCredential::UsernamePassword(username, password)) => {
+                    tracing::trace!("Found Docker credentials");
+                    Ok(RegistryAuth::Basic(username, password))
+                }
+                Ok(DockerCredential::IdentityToken(_)) => {
+                    tracing::trace!("Cannot use contents of Docker config, identity token not supported. Using anonymous auth");
+                    Ok(RegistryAuth::Anonymous)
+                }
+            },
         }
     }
 
@@ -246,5 +307,92 @@ impl Client {
             protocol,
             ..Default::default()
         }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct AuthConfig {
+    /// Map between registry server and base64 encoded username:password credential set.
+    pub auths: HashMap<String, String>,
+}
+
+impl AuthConfig {
+    /// Load the authentication configuration from the default location
+    /// ($XDG_CONFIG_HOME/fermyon/registry-auth.json).
+    pub async fn load_default() -> Result<Self> {
+        // TODO: add a way to override this path.
+        match Self::load(&Self::default_path()?).await {
+            Ok(s) => Ok(s),
+            Err(_) => Ok(Self {
+                auths: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Save the authentication configuration to the default location
+    /// ($XDG_CONFIG_HOME/fermyon/registry-auth.json).
+    pub async fn save_default(&self) -> Result<()> {
+        self.save(&Self::default_path()?).await
+    }
+
+    /// Insert the new credentials into the auths file, with the server as the key and base64
+    /// encoded username:password as the value.
+    pub fn insert(
+        &mut self,
+        server: impl AsRef<str>,
+        username: impl AsRef<str>,
+        password: impl AsRef<str>,
+    ) -> Result<()> {
+        let encoded = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            format!("{}:{}", username.as_ref(), password.as_ref()),
+        );
+        self.auths.insert(server.as_ref().to_string(), encoded);
+
+        Ok(())
+    }
+
+    fn default_path() -> Result<PathBuf> {
+        Ok(dirs::config_dir()
+            .context("Cannot find configuration directory")?
+            .join("fermyon")
+            .join("registry-auth.json"))
+    }
+
+    /// Get the registry authentication for a given registry from the default location.
+    async fn get_auth_from_default(server: impl AsRef<str>) -> Result<RegistryAuth> {
+        let auths = Self::load_default().await?;
+        let encoded = match auths.auths.get(&server.as_ref().to_string()) {
+            Some(e) => e,
+            None => bail!(format!("no credentials stored for {}", server.as_ref())),
+        };
+
+        let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoded)?;
+        let decoded = std::str::from_utf8(&bytes)?;
+        let parts: Vec<&str> = decoded.splitn(2, ':').collect();
+
+        tracing::trace!("Decoded registry credentials from the Spin configuration.");
+        Ok(RegistryAuth::Basic(
+            parts
+                .first()
+                .context("expected username as first element of the decoded auth")?
+                .to_string(),
+            parts
+                .get(1)
+                .context("expected secret as second element of the decoded auth")?
+                .to_string(),
+        ))
+    }
+
+    async fn load(p: &Path) -> Result<Self> {
+        let contents = tokio::fs::read_to_string(&p).await?;
+        serde_json::from_str(&contents)
+            .with_context(|| format!("cannot load authentication file {:?}", p))
+    }
+
+    async fn save(&self, p: &Path) -> Result<()> {
+        tokio::fs::write(&p, &serde_json::to_vec_pretty(&self)?)
+            .await
+            .with_context(|| format!("cannot save authentication file {:?}", p))
     }
 }

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use spin_publish::oci::client::Client;
+use std::{io::Read, path::PathBuf};
 
 use crate::opts::*;
 
@@ -10,10 +11,12 @@ use crate::opts::*;
 /// authenticate to registries.
 #[derive(Subcommand, Debug)]
 pub enum RegistryCommands {
-    /// Push a Spin application to an OCI registry.
+    /// Push a Spin application to a registry.
     Push(Push),
-    /// Pull a Spin application from an OCI registry.
+    /// Pull a Spin application from a registry.
     Pull(Pull),
+    /// Log in to a registry.
+    Login(Login),
 }
 
 impl RegistryCommands {
@@ -21,6 +24,7 @@ impl RegistryCommands {
         match self {
             RegistryCommands::Push(cmd) => cmd.run().await,
             RegistryCommands::Pull(cmd) => cmd.run().await,
+            RegistryCommands::Login(cmd) => cmd.run().await,
         }
     }
 }
@@ -87,6 +91,74 @@ impl Pull {
         let mut client = spin_publish::oci::client::Client::new(self.insecure, None).await?;
         client.pull(&self.reference).await?;
 
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct Login {
+    /// Username for the registry
+    #[clap(long = "username", short = 'u')]
+    pub username: Option<String>,
+
+    /// Password for the registry
+    #[clap(long = "password", short = 'p')]
+    pub password: Option<String>,
+
+    /// Take the password from stdin
+    #[clap(
+        long = "password-stdin",
+        takes_value = false,
+        conflicts_with = "password"
+    )]
+    pub password_stdin: bool,
+
+    #[clap()]
+    pub server: String,
+}
+
+impl Login {
+    pub async fn run(self) -> Result<()> {
+        let username = match self.username {
+            Some(u) => u,
+            None => {
+                let prompt = "Username";
+                loop {
+                    let result = dialoguer::Input::<String>::new()
+                        .with_prompt(prompt)
+                        .interact_text()?;
+                    if result.trim().is_empty() {
+                        continue;
+                    } else {
+                        break result;
+                    }
+                }
+            }
+        };
+
+        // If the --password-stdin flag is passed, read the password from standard input.
+        // Otherwise, if the --password flag was passed with a value, use that value. Finally, if
+        // neither was passed, prompt the user to input the password.
+        let password = if self.password_stdin {
+            let mut buf = String::new();
+            let mut stdin = std::io::stdin().lock();
+            stdin.read_to_string(&mut buf)?;
+            buf
+        } else {
+            match self.password {
+                Some(p) => p,
+                None => rpassword::prompt_password("Password: ")?,
+            }
+        };
+
+        Client::login(&self.server, &username, &password)
+            .await
+            .context("cannot log in to the registry")?;
+
+        println!(
+            "Successfully logged in as {} to registry {}",
+            username, &self.server
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
close #1087 

This commit implements functionality for logging in to an OCI registry. Until this commit, a user would have had to use external tooling to log in to a target registry (such as `docker login` or other registry specific tools). This had the advantage that users who already had a setup for working with container regsitries could continue to use it, but it introduced a dependency on external tools for pushing a Spin application.

This commit implements the functionality to login to a registry natively into Spin.
Specifically, it adds this a `spin regsitry login` command:

```
$ spin registry login --help
Log in to a registry

USAGE:
    spin registry login [OPTIONS] <SERVER>

ARGS:
    <SERVER>

OPTIONS:
    -h, --help                   Print help information
    -p, --password <PASSWORD>    Password for the container registry
        --password-stdin         Take the password from stdin
    -u, --username <USERNAME>    Username for the container registry
```

This command mirrors existing tools that perform login operations to registries (flags for the username and passwords, flag to read the password from standard in that takes precedence).

The credentials are base64 encoded (standard for container tools that do not use Docker's credential helpers) and written to `$XDG_CONFIG_HOME/fermyon/registry-auth.json` (side-by-side with the Fermyon Cloud authentication file).

Functionality that needs to work with a registry (`spin registry push/pull`, `spin up`) will first search the Spin configuration for the credentials, then will fallback to searching the authenticated registries in the Docker configuration file.

Examples:

```
$ echo $GHCR_PAT | spin registry login --username radu-matei ghcr.io --password-stdin
Successfully authenticated as radu-matei to registry ghcr.io

$ spin registry login --username radumatei --password <password> https://index.docker.io
Successfully authenticated as radumatei to registry https://index.docker.io

$ spin registry login index.docker.io
Username:
radumatei
Password: (prompt, hidden input)

Successfully authenticated as radumatei to registry https://index.docker.io

$ spin registry login --username radumatei --password bad-password https://index.docker.io
Error: cannot login to the registry

Caused by:
    0: cannot check credentials
    1: cannot authenticate to the registry
    2: unexpected HTTP status 401 Unauthorized
```

This functionality should make `spin registry login` a drop-in replacement for most of the existing tools that login to registries, while continuing to reuse existing credentials as a fallback.

A future commit needs to make writing the configuration file more flexible, and add unit tests for decoding credentials.