### PR TITLE
Make template upgrade kinder to old installs of common repos

### DIFF
--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -289,13 +289,14 @@ impl Upgrade {
             eprintln!("To upgrade them, run `spin templates install --upgrade` with the --git or --dir option");
             eprintln!();
             if !self.all {
-                eprintln!("The following template repositories can be automatically upgraded:");
+                eprintln!("The following template repositories can be automatically upgraded.");
             }
         }
 
         let selected_sources = if self.all {
             sources
         } else {
+            eprintln!("Select repos to upgrade. Use Space to select/deselect and Enter to confirm selection.");
             let selected_indexes = match dialoguer::MultiSelect::new()
                 .items(&sources)
                 .interact_opt()?

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -229,10 +229,22 @@ impl Upgrade {
         let (origin, no_origin): (Vec<_>, Vec<_>) = existing_templates
             .iter()
             .partition(|t| t.source_repo().is_some());
-        let repos = origin
+
+        let mut repos = origin
             .iter()
             .filter_map(|t| t.source_repo())
             .collect::<HashSet<_>>();
+
+        // Try to detect two repos that are likely to have been installed before
+        // we started recording upgrade info.
+        let has_unorigined_default_templates = no_origin.iter().any(|t| t.id() == "http-rust");
+        let has_unorigined_js_templates = no_origin.iter().any(|t| t.id() == "http-js");
+        if has_unorigined_default_templates {
+            repos.insert("https://github.com/fermyon/spin");
+        }
+        if has_unorigined_js_templates {
+            repos.insert("https://github.com/fermyon/spin-js-sdk");
+        }
 
         let mut sources = vec![];
         for repo in repos {
@@ -255,7 +267,19 @@ impl Upgrade {
             return Ok(None);
         }
 
-        if !no_origin.is_empty() {
+        // The logic here is that if there are unorigined templates, then *probably*
+        // they are the most popular ones, which we will sub in anyway.  So we only
+        // warn if we've already established that there are unorigined templates and
+        // the most popular ones are *not* among them.  This will result in a missed
+        // warning if the user has other unorigined templates too, but that's probably
+        // better than printing over a dozen templates saying we won't upgrade them
+        // and then offering to upgrade them all the same!  (The trouble being that we
+        // can't readily exclude all the popular templates from printing without building in a
+        // LOT of knowledge here. Or looking in the Git repos, or something.  But I think
+        // the heuristic will cover 99% of cases.)
+        let can_offer_all =
+            no_origin.is_empty() || has_unorigined_default_templates || has_unorigined_js_templates;
+        if !can_offer_all {
             eprintln!(
                 "Spin could not determine where the following templates were installed from:"
             );


### PR DESCRIPTION
If a user has template installs from 0.8 or earlier, they will not have repo information.  So if the user tries to upgrade them, they will instead get prompted to install-update them.

This PR attempts to provide a better experience for the Spin and Spin JS SDK repos, which are the ones users are most likely to have existing installs of.  It tries, heuristically, to detect if the user has old installs of those repos, and if so inserts them into the list of repos to offer for upgrade.  This means that a user who has installed from one of those repos in the past will now get the nice auto upgrade rather than being asked to use the incantation.  E.g.:

```
# User installed from JS SDK repo with old Spin so no origin info
$ spin templates list --verbose
+------------------------------------------------------------------+
| Name      Description                             Installed from |
+==================================================================+
| http-js   HTTP request handler using Javascript                  |
| http-ts   HTTP request handler using Typescript                  |
+------------------------------------------------------------------+

# What sorcery is this? Upgrade still gives friendly selector instead of manual warning
 $ spin templates upgrade
> [ ] https://github.com/fermyon/spin-js-sdk (at spin/templates/v0.8)
```

There are a couple of ways this can go wrong:

1. The heuristic is fooled if the user has uninstalled the templates we use for sniffing.  In this case the user will be shown the remaining templates as "we couldn't tell where to upgrade from."  This is not delightful but it is benign and a user who is engaged enough to curate individual templates can probably deal with it.

2. If the user is sniffed as having the special repos, we hide *all* manual upgrade warnings.  This is to avoid embedding a full list of special templates into the code.  If the user has other templates that cannot be upgraded, from other repos or from local directories, _no warning will be displayed for these_.  Once the user has upgraded their blessed repos, so that they have origin info, the warnings for the skipped templates will reappear.  This behaviour is admittedly weird and hard to explain to users, but I think the number of people affected will be very small.

Otherwise it seems to work correctly though I'm a bit anxious about having logic this complicated.  Hopefully we can remove it after a few releases!