### PR TITLE
ref(Dockerfiles): go/tinygo bumps per latest 0.9.0 go templates/SDK

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,12 +12,12 @@ ARG BINDLE_URL="https://github.com/deislabs/bindle/releases/download/v0.8.0/bind
 RUN curl -sL "$BINDLE_URL" | tar -xzf - -C /usr/local/bin bindle bindle-server
 
 # Go installation, see https://go.dev/doc/install
-ARG GO_URL="https://go.dev/dl/go1.17.9.linux-amd64.tar.gz"
+ARG GO_URL="https://go.dev/dl/go1.20.1.linux-amd64.tar.gz"
 RUN curl -sL "$GO_URL" | tar -xzf - -C /usr/local
 ENV PATH "$PATH:/usr/local/go/bin"
 
 # TinyGo installation, see https://tinygo.org/getting-started/install/linux/ for instructions
-ARG TINYGO_URL="https://github.com/tinygo-org/tinygo/releases/download/v0.22.0/tinygo_0.22.0_amd64.deb"
+ARG TINYGO_URL="https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_amd64.deb"
 RUN curl -sL "$TINYGO_URL" -o tinygo_amd64.deb && dpkg -i tinygo_amd64.deb && rm tinygo_amd64.deb
 
 # Install the gopls Go Language Server, see https://github.com/golang/tools/tree/master/gopls

--- a/e2e-tests-aarch64.Dockerfile
+++ b/e2e-tests-aarch64.Dockerfile
@@ -8,13 +8,13 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 RUN apt-get install -y nodejs npm
 
 # golang
-RUN wget https://go.dev/dl/go1.19.5.linux-arm64.tar.gz && \
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.5.linux-arm64.tar.gz
+RUN wget https://go.dev/dl/go1.20.1.linux-arm64.tar.gz && \
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.20.1.linux-arm64.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"
 
 # tinygo
-RUN wget https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo_0.25.0_arm64.deb && \
-    sudo dpkg -i tinygo_0.25.0_arm64.deb && \
+RUN wget https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_arm64.deb && \
+    sudo dpkg -i tinygo_0.27.0_arm64.deb && \
     tinygo env
 
 RUN wget https://ziglang.org/download/0.10.0/zig-linux-aarch64-0.10.0.tar.xz && \

--- a/e2e-tests.Dockerfile
+++ b/e2e-tests.Dockerfile
@@ -8,13 +8,13 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 RUN apt-get install -y nodejs npm
 
 # golang
-RUN wget https://go.dev/dl/go1.19.5.linux-amd64.tar.gz && \
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.5.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.20.1.linux-amd64.tar.gz && \
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.20.1.linux-amd64.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"
 
 # tinygo
-RUN wget https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo_0.25.0_amd64.deb && \
-    sudo dpkg -i tinygo_0.25.0_amd64.deb && \
+RUN wget https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_amd64.deb && \
+    sudo dpkg -i tinygo_0.27.0_amd64.deb && \
     tinygo env
 
 # zig


### PR DESCRIPTION
- further updates bumping go/tinygo (follow-up from https://github.com/fermyon/spin/pull/1165)

~~Passing e2e is blocked on https://github.com/fermyon/spin/pull/1153#issuecomment-1433512964.  I don't think these bumps are urgent, so this is fine to wait.~~