### PR TITLE
fix: handling up for local apps was breaking CI

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -99,7 +99,7 @@ where
     pub help_args_only: bool,
 
     /// Load the application from the registry.
-    #[clap(long = "from-registry")]
+    #[clap(long = "from-registry", hide = true)]
     pub from_registry: bool,
 }
 


### PR DESCRIPTION
Slight oversight with how we prepare locked application for local vs. remote introduced by [#1146](https://github.com/fermyon/spin/pull/1146) being merged _eagerly_.

This commit rearranges some code in `up` to allow inspecting the trigger type from `spin_manifest::Application` for local applications (vs. `LockedApp` for remote).