### PR TITLE
add e2e tests for redis trigger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.11.2",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -1121,12 +1130,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.11.2",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core 0.12.0",
  "syn",
 ]
 
@@ -1287,7 +1318,9 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "derive_builder 0.12.0",
  "hyper",
+ "hyper-tls",
  "nix 0.26.2",
  "regex",
  "reqwest",
@@ -5294,7 +5327,7 @@ checksum = "267f958930e08323a44c12e6c5461f3eaaa16d88785e9ec8550215b8aafc3d0b"
 dependencies = [
  "async-trait",
  "bytes",
- "derive_builder",
+ "derive_builder 0.11.2",
  "http",
  "reqwest",
  "rustify",

--- a/crates/e2e-testing/Cargo.toml
+++ b/crates/e2e-testing/Cargo.toml
@@ -16,3 +16,5 @@ regex = "1.5.5"
 reqwest = { version = "0.11", features = ["blocking"] }
 nix = "0.26.1"
 url = "2.2.2"
+derive_builder = "0.12.0"
+hyper-tls = "0.5.0"

--- a/crates/e2e-testing/src/asserts.rs
+++ b/crates/e2e-testing/src/asserts.rs
@@ -1,20 +1,28 @@
 use anyhow::Result;
+use hyper::client::HttpConnector;
+use hyper::{body, Body, Client, Request, Response};
+use hyper_tls::HttpsConnector;
+use std::str;
 
-pub fn assert_status(url: &str, expected: u16) -> Result<()> {
-    let resp = req(url)?;
+pub async fn assert_status(url: &str, expected: u16) -> Result<()> {
+    let resp = make_request("GET", url, "").await?;
     let status = resp.status();
-    let body = resp.text()?;
-    assert_eq!(status, expected, "{}", body);
+
+    let response = body::to_bytes(resp.into_body()).await.unwrap().to_vec();
+    let actual_body = str::from_utf8(&response).unwrap().to_string();
+
+    assert_eq!(status, expected, "{}", actual_body);
+
     Ok(())
 }
 
-pub fn assert_http_response(
+pub async fn assert_http_response(
     url: &str,
     expected: u16,
     expected_headers: &[(&str, &str)],
     expected_body: Option<&str>,
 ) -> Result<()> {
-    let res = req(url)?;
+    let res = make_request("GET", url, "").await?;
 
     let status = res.status();
     assert_eq!(expected, status.as_u16());
@@ -31,14 +39,33 @@ pub fn assert_http_response(
     }
 
     if let Some(expected_body_str) = expected_body {
-        let body = &res.text()?;
-        assert_eq!(expected_body_str, body);
+        let response = body::to_bytes(res.into_body()).await.unwrap().to_vec();
+        let actual_body = str::from_utf8(&response).unwrap().to_string();
+        assert_eq!(expected_body_str, actual_body);
     }
 
     Ok(())
 }
 
-fn req(url: &str) -> reqwest::Result<reqwest::blocking::Response> {
-    println!("{}", url);
-    reqwest::blocking::get(url)
+pub async fn create_request(method: &str, url: &str, body: &str) -> Result<Request<Body>> {
+    let req = Request::builder()
+        .method(method)
+        .uri(url)
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+
+    Ok(req)
+}
+
+pub fn create_client() -> Client<HttpsConnector<HttpConnector>> {
+    let connector = HttpsConnector::new();
+    Client::builder().build::<_, hyper::Body>(connector)
+}
+
+pub async fn make_request(method: &str, path: &str, body: &str) -> Result<Response<Body>> {
+    let c = create_client();
+    let req = create_request(method, path, body);
+
+    let resp = c.request(req.await?).await.unwrap();
+    Ok(resp)
 }

--- a/crates/e2e-testing/src/controller.rs
+++ b/crates/e2e-testing/src/controller.rs
@@ -2,6 +2,8 @@ use crate::metadata_extractor::AppMetadata;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::process::Output;
+use tokio::io::BufReader;
+use tokio::process::{ChildStderr, ChildStdout};
 
 /// defines crate::controller::Controller trait
 /// this is to enable running same set of tests
@@ -11,10 +13,15 @@ pub trait Controller {
     fn name(&self) -> String;
     fn login(&self) -> Result<()>;
     fn template_install(&self, args: Vec<&str>) -> Result<Output>;
-    fn new_app(&self, template_name: &str, app_name: &str) -> Result<Output>;
+    fn new_app(&self, template_name: &str, app_name: &str, args: Vec<&str>) -> Result<Output>;
     fn build_app(&self, app_name: &str) -> Result<Output>;
     fn install_plugins(&self, plugins: Vec<&str>) -> Result<Output>;
-    async fn run_app(&self, app_name: &str) -> Result<AppInstance>;
+    async fn run_app(
+        &self,
+        app_name: &str,
+        trigger_type: &str,
+        mut args: Vec<&str>,
+    ) -> Result<AppInstance>;
     async fn stop_app(
         &self,
         app_name: Option<&str>,
@@ -27,6 +34,8 @@ pub trait Controller {
 pub struct AppInstance {
     pub metadata: AppMetadata,
     pub process: Option<tokio::process::Child>,
+    pub stdout_stream: Option<BufReader<ChildStdout>>,
+    pub stderr_stream: Option<BufReader<ChildStderr>>,
 }
 
 impl AppInstance {
@@ -34,6 +43,8 @@ impl AppInstance {
         AppInstance {
             metadata,
             process: None,
+            stdout_stream: None,
+            stderr_stream: None,
         }
     }
 
@@ -41,6 +52,25 @@ impl AppInstance {
         metadata: AppMetadata,
         process: Option<tokio::process::Child>,
     ) -> AppInstance {
-        AppInstance { metadata, process }
+        AppInstance {
+            metadata,
+            process,
+            stdout_stream: None,
+            stderr_stream: None,
+        }
+    }
+
+    pub fn new_with_process_and_logs_stream(
+        metadata: AppMetadata,
+        process: Option<tokio::process::Child>,
+        stdout_stream: Option<BufReader<ChildStdout>>,
+        stderr_stream: Option<BufReader<ChildStderr>>,
+    ) -> AppInstance {
+        AppInstance {
+            metadata,
+            process,
+            stdout_stream,
+            stderr_stream,
+        }
     }
 }

--- a/crates/e2e-testing/src/spin.rs
+++ b/crates/e2e-testing/src/spin.rs
@@ -26,14 +26,18 @@ pub fn template_install(mut args: Vec<&str>) -> Result<Output> {
     result
 }
 
-pub fn new_app(template_name: &str, app_name: &str) -> Result<Output> {
+pub fn new_app<'a>(
+    template_name: &'a str,
+    app_name: &'a str,
+    mut args: Vec<&'a str>,
+) -> Result<Output> {
     let basedir = utils::testcases_base_dir();
+    let mut cmd = vec!["spin", "new", template_name, app_name, "--accept-defaults"];
+    if !args.is_empty() {
+        cmd.append(&mut args);
+    }
 
-    return utils::run(
-        vec!["spin", "new", template_name, app_name, "--accept-defaults"],
-        Some(basedir.as_str()),
-        None,
-    );
+    return utils::run(cmd, Some(basedir.as_str()), None);
 }
 
 pub fn install_plugins(plugins: Vec<&str>) -> Result<Output> {
@@ -69,7 +73,7 @@ pub fn appdir(appname: &str) -> String {
 #[cfg(target_family = "unix")]
 pub async fn stop_app_process(process: &mut tokio::process::Child) -> Result<(), anyhow::Error> {
     let pid = process.id().unwrap();
-    println!("stopping app with pid {}", pid);
+    // println!("stopping app with pid {}", pid);
     let pid = Pid::from_raw(pid as i32);
     kill(pid, Signal::SIGINT).map_err(anyhow::Error::msg)
 }

--- a/e2e-tests-aarch64.Dockerfile
+++ b/e2e-tests-aarch64.Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_SPIN=false
 ARG SPIN_VERSION=canary
 
 WORKDIR /root
-RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config
+RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config redis
 
 # nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
@@ -56,13 +56,13 @@ COPY . .
 
 # spin
 RUN if [ "${BUILD_SPIN}" != "true" ]; then                                                                                      \
-        wget https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-aarch64.tar.gz &&     \
-        tar -xvf spin-${SPIN_VERSION}-linux-aarch64.tar.gz &&                                                                   \
-        ls -ltr &&                                                                                                              \
-        mv spin /usr/local/bin/spin;                                                                                            \
+    wget https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-aarch64.tar.gz &&     \
+    tar -xvf spin-${SPIN_VERSION}-linux-aarch64.tar.gz &&                                                                   \
+    ls -ltr &&                                                                                                              \
+    mv spin /usr/local/bin/spin;                                                                                            \
     else                                                                                                                        \
-        cargo build --release &&                                                                                                \
-        cp target/release/spin /usr/local/bin/spin;                                                                             \
+    cargo build --release &&                                                                                                \
+    cp target/release/spin /usr/local/bin/spin;                                                                             \
     fi
 
 RUN spin --version

--- a/e2e-tests-docker-compose.yml
+++ b/e2e-tests-docker-compose.yml
@@ -14,9 +14,16 @@ services:
       MYSQL_USER: spin
       MYSQL_PASSWORD: spin
 
+  redis:
+    image: ${REDIS_IMAGE:-redis:7.0.8-alpine3.17}
+    ports:
+      - "6379:6379"
+    restart: always
+
   e2e-tests:
     depends_on:
       - mysql
+      - redis
     image: spin-e2e-tests
     entrypoint: cargo test spinup_tests --features new-e2e-tests --no-fail-fast -- --nocapture
 

--- a/e2e-tests.Dockerfile
+++ b/e2e-tests.Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 WORKDIR /root
-RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config
+RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config redis
 
 # nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,7 +24,7 @@ docker compose -f e2e-tests-docker-compose.yml run e2e-tests
 ```
 ## go to root dir of the project, e2e-tests-aarch64.Dockerfile is located there
 docker build -t spin-e2e-tests -f e2e-tests-aarch64.Dockerfile .
-MYSQL_IMAGE=arm64v8/mysql:8.0.32 docker compose         \
+MYSQL_IMAGE=arm64v8/mysql:8.0.32 REDIS_IMAGE=arm64v8/redis:6.0-alpine3.17 docker compose         \
     -f e2e-tests-docker-compose.yml run                 \
     e2e-tests
 ```

--- a/tests/spinup_tests.rs
+++ b/tests/spinup_tests.rs
@@ -70,4 +70,14 @@ mod spinup_tests {
     async fn http_rust_outbound_mysql_works() {
         testcases::all::http_rust_outbound_mysql_works(CONTROLLER).await
     }
+
+    #[tokio::test]
+    async fn redis_go_works() {
+        testcases::all::redis_go_works(CONTROLLER).await
+    }
+
+    #[tokio::test]
+    async fn redis_rust_works() {
+        testcases::all::redis_rust_works(CONTROLLER).await
+    }
 }

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -4,203 +4,250 @@ pub mod all {
     use e2e_testing::asserts::assert_http_response;
     use e2e_testing::controller::Controller;
     use e2e_testing::metadata_extractor::AppMetadata;
-    use e2e_testing::testcase::TestCase;
+    use e2e_testing::testcase::TestCaseBuilder;
+    use e2e_testing::utils;
+    use std::time::Duration;
+    use tokio::io::BufReader;
+    use tokio::process::{ChildStderr, ChildStdout};
+    use tokio::time::sleep;
 
     fn get_url(base: &str, path: &str) -> String {
         format!("{}{}", base, path)
     }
 
     pub async fn http_go_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
-            return assert_http_response(
-                metadata.base.as_str(),
-                200,
-                &[],
-                Some("Hello Fermyon!\n"),
-            );
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello Fermyon!\n")).await
         }
 
-        let tc = TestCase {
-            name: "http-go template".to_string(),
-            appname: None,
-            template: Some("http-go".to_string()),
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("http-go-template".to_string())
+            .template(Some("http-go".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap();
     }
 
     pub async fn http_c_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
-            return assert_http_response(
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            assert_http_response(
                 metadata.base.as_str(),
                 200,
                 &[],
                 Some("Hello from WAGI/1\n"),
-            );
+            )
+            .await
         }
 
-        let tc = TestCase {
-            name: "http-c template".to_string(),
-            appname: None,
-            template: Some("http-c".to_string()),
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("http-c-template".to_string())
+            .template(Some("http-c".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn http_rust_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
-            return assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello, Fermyon"));
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello, Fermyon")).await
         }
 
-        let tc = TestCase {
-            name: "http-rust-template".to_string(),
-            appname: None,
-            template: Some("http-rust".to_string()),
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("http-rust-template".to_string())
+            .template(Some("http-rust".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn http_zig_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
-            return assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello World!\n"));
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello World!\n")).await
         }
 
-        let tc = TestCase {
-            name: "http-zig-template".to_string(),
-            appname: None,
-            template: Some("http-zig".to_string()),
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("http-zig-template".to_string())
+            .template(Some("http-zig".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     #[allow(unused)]
     pub async fn http_grain_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
-            return assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello, World\n"));
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello, World\n")).await
         }
 
-        let tc = TestCase {
-            name: "http-grain-template".to_string(),
-            appname: None,
-            template: Some("http-grain".to_string()),
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("http-grain-template".to_string())
+            .template(Some("http-grain".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn http_ts_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
-            return assert_http_response(
-                metadata.base.as_str(),
-                200,
-                &[],
-                Some("Hello from TS-SDK"),
-            );
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello from TS-SDK")).await
         }
 
-        let tc = TestCase {
-            name: "http-ts-template".to_string(),
-            appname: None,
-            template: Some("http-ts".to_string()),
-            template_install_args: Some(vec![
+        let tc = TestCaseBuilder::default()
+            .name("http-ts-template".to_string())
+            .template(Some("http-ts".to_string()))
+            .template_install_args(Some(vec![
                 "--git".to_string(),
                 "https://github.com/fermyon/spin-js-sdk".to_string(),
                 "--update".to_string(),
-            ]),
-            assertions: checks,
-            plugins: Some(vec!["js2wasm".to_string()]),
-            deploy_args: None,
-            pre_build_hooks: Some(vec![vec!["npm".to_string(), "install".to_string()]]),
-        };
+            ]))
+            .plugins(Some(vec!["js2wasm".to_string()]))
+            .pre_build_hooks(Some(vec![vec!["npm".to_string(), "install".to_string()]]))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn http_js_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
-            return assert_http_response(
-                metadata.base.as_str(),
-                200,
-                &[],
-                Some("Hello from JS-SDK"),
-            );
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            assert_http_response(metadata.base.as_str(), 200, &[], Some("Hello from JS-SDK")).await
         }
 
-        let tc = TestCase {
-            name: "http-js-template".to_string(),
-            appname: None,
-            template: Some("http-js".to_string()),
-            template_install_args: Some(vec![
+        let tc = TestCaseBuilder::default()
+            .name("http-js-template".to_string())
+            .template(Some("http-js".to_string()))
+            .template_install_args(Some(vec![
                 "--git".to_string(),
                 "https://github.com/fermyon/spin-js-sdk".to_string(),
                 "--update".to_string(),
-            ]),
-            assertions: checks,
-            plugins: Some(vec!["js2wasm".to_string()]),
-            deploy_args: None,
-            pre_build_hooks: Some(vec![vec!["npm".to_string(), "install".to_string()]]),
-        };
+            ]))
+            .plugins(Some(vec!["js2wasm".to_string()]))
+            .pre_build_hooks(Some(vec![vec!["npm".to_string(), "install".to_string()]]))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn assets_routing_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
             assert_http_response(
                 get_url(metadata.base.as_str(), "/static/thisshouldbemounted/1").as_str(),
                 200,
                 &[],
                 Some("1\n"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/static/thisshouldbemounted/2").as_str(),
                 200,
                 &[],
                 Some("2\n"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/static/thisshouldbemounted/3").as_str(),
                 200,
                 &[],
                 Some("3\n"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/static/donotmount/a").as_str(),
                 404,
                 &[],
                 Some("Not Found"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(
@@ -211,33 +258,41 @@ pub mod all {
                 404,
                 &[],
                 Some("Not Found"),
-            )?;
+            )
+            .await?;
 
             Ok(())
         }
 
-        let tc = TestCase {
-            name: "assets-test".to_string(),
-            appname: Some("assets-test".to_string()),
-            template: None,
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("assets-test".to_string())
+            .appname(Some("assets-test".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn simple_spin_rust_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
             assert_http_response(
                 get_url(metadata.base.as_str(), "/test/hello").as_str(),
                 200,
                 &[],
                 Some("I'm a teapot"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(
@@ -248,134 +303,278 @@ pub mod all {
                 200,
                 &[],
                 Some("I'm a teapot"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/thisshouldfail").as_str(),
                 404,
                 &[],
                 None,
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/test/hello/test-placement").as_str(),
                 200,
                 &[],
                 Some("text for test"),
-            )?;
+            )
+            .await?;
 
             Ok(())
         }
 
-        let tc = TestCase {
-            name: "simple-spin-rust-test".to_string(),
-            appname: Some("simple-spin-rust-test".to_string()),
-            template: None,
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("simple-spin-rust-test".to_string())
+            .appname(Some("simple-spin-rust-test".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn header_env_routes_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
             assert_http_response(
                 get_url(metadata.base.as_str(), "/env").as_str(),
                 200,
                 &[],
                 Some("I'm a teapot"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/env/foo").as_str(),
                 200,
                 &[("env_some_key", "some_value")],
                 Some("I'm a teapot"),
-            )?;
+            )
+            .await?;
 
             Ok(())
         }
 
-        let tc = TestCase {
-            name: "headers-env-routes-test".to_string(),
-            appname: Some("headers-env-routes-test".to_string()),
-            template: None,
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("headers-env-routes-test".to_string())
+            .appname(Some("headers-env-routes-test".to_string()))
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn header_dynamic_env_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
             assert_http_response(
                 get_url(metadata.base.as_str(), "/env").as_str(),
                 200,
                 &[],
                 Some("I'm a teapot"),
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/env/foo").as_str(),
                 200,
                 &[("env_some_key", "some_value")],
                 Some("I'm a teapot"),
-            )?;
+            )
+            .await?;
 
             Ok(())
         }
 
-        let tc = TestCase {
-            name: "headers-dynamic-env-test".to_string(),
-            appname: Some("headers-dynamic-env-test".to_string()),
-            template: None,
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: Some(vec!["--env".to_string(), "foo=bar".to_string()]),
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("headers-dynamic-env-test".to_string())
+            .appname(Some("headers-dynamic-env-test".to_string()))
+            .deploy_args(vec!["--env".to_string(), "foo=bar".to_string()])
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }
 
     pub async fn http_rust_outbound_mysql_works(controller: &dyn Controller) {
-        fn checks(metadata: &AppMetadata) -> Result<()> {
+        async fn checks(
+            metadata: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
             assert_http_response(
                 get_url(metadata.base.as_str(), "/test_numeric_types").as_str(),
                 200,
                 &[],
                 None,
-            )?;
+            )
+            .await?;
 
             assert_http_response(
                 get_url(metadata.base.as_str(), "/test_character_types").as_str(),
                 200,
                 &[],
                 None,
-            )?;
+            )
+            .await?;
 
             Ok(())
         }
 
-        let tc = TestCase {
-            name: "http-rust-outbound-mysql".to_string(),
-            appname: Some("http-rust-outbound-mysql".to_string()),
-            template: None,
-            template_install_args: None,
-            assertions: checks,
-            plugins: None,
-            deploy_args: None,
-            pre_build_hooks: None,
-        };
+        let tc = TestCaseBuilder::default()
+            .name("http-rust-outbound-mysql".to_string())
+            .appname(Some("http-rust-outbound-mysql".to_string()))
+            .deploy_args(vec!["--env".to_string(), "foo=bar".to_string()])
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
+
+        tc.run(controller).await.unwrap()
+    }
+
+    pub async fn redis_go_works(controller: &dyn Controller) {
+        async fn checks(
+            _: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            stderr_stream: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            //TODO: wait for spin up to be ready dynamically
+            sleep(Duration::from_secs(10)).await;
+
+            utils::run(
+                vec![
+                    "redis-cli",
+                    "-u",
+                    "redis://redis:6379",
+                    "PUBLISH",
+                    "redis-go-works-channel",
+                    "msg-from-go-channel",
+                ],
+                None,
+                None,
+            )?;
+
+            let stderr =
+                utils::get_output_from_stderr(stderr_stream, Duration::from_secs(5)).await?;
+            let expected_logs = vec!["Payload::::", "msg-from-go-channel"];
+
+            assert!(expected_logs
+                .iter()
+                .all(|item| stderr.contains(&item.to_string())));
+
+            Ok(())
+        }
+
+        let tc = TestCaseBuilder::default()
+            .name("redis-go".to_string())
+            .template(Some("redis-go".to_string()))
+            .new_app_args(vec![
+                "--value".to_string(),
+                "redis-channel=redis-go-works-channel".to_string(),
+                "--value".to_string(),
+                "redis-address=redis://redis:6379".to_string(),
+            ])
+            .trigger_type("redis".to_string())
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
+
+        tc.run(controller).await.unwrap()
+    }
+
+    pub async fn redis_rust_works(controller: &dyn Controller) {
+        async fn checks(
+            _: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            stderr_stream: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            //TODO: wait for spin up to be ready dynamically
+            sleep(Duration::from_secs(20)).await;
+
+            utils::run(
+                vec![
+                    "redis-cli",
+                    "-u",
+                    "redis://redis:6379",
+                    "PUBLISH",
+                    "redis-rust-works-channel",
+                    "msg-from-rust-channel",
+                ],
+                None,
+                None,
+            )?;
+
+            let stderr =
+                utils::get_output_from_stderr(stderr_stream, Duration::from_secs(5)).await?;
+
+            let expected_logs = vec!["msg-from-rust-channel"];
+
+            assert!(expected_logs
+                .iter()
+                .all(|item| stderr.contains(&item.to_string())));
+
+            Ok(())
+        }
+
+        let tc = TestCaseBuilder::default()
+            .name("redis-rust".to_string())
+            .template(Some("redis-rust".to_string()))
+            .new_app_args(vec![
+                "--value".to_string(),
+                "redis-channel=redis-rust-works-channel".to_string(),
+                "--value".to_string(),
+                "redis-address=redis://redis:6379".to_string(),
+            ])
+            .trigger_type("redis".to_string())
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
 
         tc.run(controller).await.unwrap()
     }


### PR DESCRIPTION
This PR restructures framework to add support for:

- Passing custom values when creating new app
- use `hyper` http client instead of `reqwest` 
- pass stdout/stderr stream to assertions function to verify logs if needed
- add `trigger_type` to `TestCase` to support `redis trigger`
- added test for `redis trigger`