### PR TITLE
ci(build.yml): rm e2e-tests concurrency config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,8 +155,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-22.04
     needs: build-rust-ubuntu
-    concurrency:
-      group: e2e-tests
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This configuration can block PRs as it is currently written.  However, I don't see a need to prevent concurrent runs for this job, so removing.