### PR TITLE
Rename `spin_version` to `spin_manifest_version` in Spin.toml

### DIFF
--- a/crates/bindle/src/expander.rs
+++ b/crates/bindle/src/expander.rs
@@ -20,7 +20,7 @@ pub async fn expand_manifest(
     let app_file = absolutize(app_file)?;
     let manifest = spin_loader::local::raw_manifest_from_file(&app_file).await?;
     validate_raw_app_manifest(&manifest)?;
-    let local_schema::RawAppManifestAnyVersion::V1(manifest) = manifest;
+    let manifest = manifest.into_v1();
     let app_dir = parent_dir(&app_file)?;
 
     // * create a new spin.toml-like document where

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -16,7 +16,7 @@ pub async fn build(manifest_file: &Path) -> Result<()> {
     let manifest_text = tokio::fs::read_to_string(manifest_file)
         .await
         .with_context(|| format!("Cannot read manifest file from {}", manifest_file.display()))?;
-    let BuildAppInfoAnyVersion::V1(app) = toml::from_str(&manifest_text)?;
+    let app = toml::from_str(&manifest_text).map(BuildAppInfoAnyVersion::into_v1)?;
     let app_dir = parent_dir(manifest_file)?;
 
     if app.components.iter().all(|c| c.build.is_none()) {

--- a/crates/build/src/manifest.rs
+++ b/crates/build/src/manifest.rs
@@ -1,12 +1,30 @@
+use serde::{Deserialize, Serialize};
+use spin_loader::local::config::FixedStringVersion;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "spin_version")]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
 pub(crate) enum BuildAppInfoAnyVersion {
-    #[serde(rename = "1")]
-    V1(BuildAppInfoV1),
+    V1Old {
+        #[allow(dead_code)]
+        spin_version: FixedStringVersion<1>,
+        #[serde(flatten)]
+        manifest: BuildAppInfoV1,
+    },
+    V1New {
+        #[allow(dead_code)]
+        spin_manifest_version: FixedStringVersion<1>,
+        #[serde(flatten)]
+        manifest: BuildAppInfoV1,
+    },
+}
+impl BuildAppInfoAnyVersion {
+    pub fn into_v1(self) -> BuildAppInfoV1 {
+        match self {
+            BuildAppInfoAnyVersion::V1New { manifest, .. } => manifest,
+            BuildAppInfoAnyVersion::V1Old { manifest, .. } => manifest,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -15,7 +15,7 @@ use spin_http::routes::RoutePattern;
 use spin_http::AppInfo;
 use spin_http::WELL_KNOWN_PREFIX;
 use spin_loader::bindle::BindleConnectionInfo;
-use spin_loader::local::config::{RawAppManifest, RawAppManifestAnyVersion};
+use spin_loader::local::config::RawAppManifest;
 use spin_loader::local::{assets, config, parent_dir};
 use spin_manifest::ApplicationTrigger;
 use spin_manifest::{HttpTriggerConfiguration, TriggerConfig};
@@ -188,7 +188,7 @@ impl DeployCommand {
 
     async fn deploy_hippo(self, login_connection: LoginConnection) -> Result<()> {
         let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app).await?;
-        let RawAppManifestAnyVersion::V1(cfg) = cfg_any;
+        let cfg = cfg_any.into_v1();
 
         ensure!(!cfg.components.is_empty(), "No components in spin.toml!");
 
@@ -318,7 +318,7 @@ impl DeployCommand {
         let client = CloudClient::new(connection_config.clone());
 
         let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app).await?;
-        let RawAppManifestAnyVersion::V1(cfg) = cfg_any;
+        let cfg = cfg_any.into_v1();
 
         ensure!(!cfg.components.is_empty(), "No components in spin.toml!");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,10 +2,7 @@
 mod integration_tests {
     use anyhow::{Context, Result};
     use hyper::{Body, Client, Response};
-    use spin_loader::local::{
-        config::{RawAppManifestAnyVersion, RawModuleSource},
-        raw_manifest_from_file,
-    };
+    use spin_loader::local::{config::RawModuleSource, raw_manifest_from_file};
     use std::{
         collections::HashMap,
         ffi::OsStr,
@@ -994,7 +991,7 @@ mod integration_tests {
     /// in `spin.toml` inside `dir`.
     async fn do_test_build_command(dir: impl AsRef<Path>) -> Result<()> {
         let manifest_file = dir.as_ref().join("spin.toml");
-        let RawAppManifestAnyVersion::V1(manifest) = raw_manifest_from_file(&manifest_file).await?;
+        let manifest = raw_manifest_from_file(&manifest_file).await?.into_v1();
 
         let mut sources = vec![];
         for component_manifest in manifest.components.iter() {


### PR DESCRIPTION
Ensures backwards compatibility.

Required bringing in `spin-app` crate to `build` and `loader` crates to access `LockedVersion` type.

fixes #1069 
Thank you @lann for suggested implementation and @fibonacci1729 for pairing!