### PR TITLE
outbound-http: Enable gzip compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,6 +3580,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
+ "async-compression",
  "base64 0.21.0",
  "bytes",
  "encoding_rs",

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 anyhow  = "1.0"
 http = "0.2"
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["gzip"] }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 tracing = { workspace = true }


### PR DESCRIPTION
> If the gzip feature is turned on, the default option is enabled.