### PR TITLE
Mostly flagless app source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,6 +4312,7 @@ dependencies = [
  "lazy_static",
  "levenshtein",
  "nix 0.24.3",
+ "oci-distribution",
  "openssl",
  "outbound-http",
  "outbound-redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ hippo = { git = "https://github.com/deislabs/hippo-cli", tag = "v0.16.1" }
 is-terminal = "0.4"
 lazy_static = "1.4.0"
 nix = { version = "0.24", features = ["signal"] }
+oci-distribution = { git = "https://github.com/radu-matei/oci-distribution", branch = "update-dockerhub-default-registry" }
 outbound-http = { path = "crates/outbound-http" }
 outbound-redis = { path = "crates/outbound-redis" }
 spin-key-value = { path = "crates/key-value" }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -11,12 +11,13 @@ use super::up::UpCommand;
 #[derive(Parser, Debug)]
 #[clap(about = "Build the Spin application", allow_hyphen_values = true)]
 pub struct BuildCommand {
-    /// Path to spin.toml.
+    /// Path to application manifest. The default is "spin.toml".
     #[clap(
-            name = APP_CONFIG_FILE_OPT,
-            short = 'f',
-            long = "file",
-        )]
+        name = APP_CONFIG_FILE_OPT,
+        short = 'f',
+        long = "from",
+        alias = "file",
+    )]
     pub app: Option<PathBuf>,
 
     /// Run the application after building.
@@ -33,7 +34,6 @@ impl BuildCommand {
             .app
             .as_deref()
             .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
-
         spin_build::build(manifest_file).await?;
 
         if self.up {
@@ -44,7 +44,7 @@ impl BuildCommand {
                 )))
                 .chain(self.up_args),
             );
-            cmd.app = Some(manifest_file.into());
+            cmd.file_source = Some(manifest_file.into());
             cmd.run().await
         } else {
             Ok(())


### PR DESCRIPTION
Fixes #1155.

This is similar to #1159 but compromises on total flaglessness to make it play nicely with trigger options.  With this, you still have to write `-f` for anything other than the default source (current directory + spin.toml), but you don't need to write `--from-file` or `--from-registry` unless the "inference engine" gets it wrong.  E.g.

```
# Infers: File: ./spin.toml
spin up

# Infers: File: ./app.toml
spin up -f app.toml

# Infers: File: ./guest/spin.toml
spin up -f guest

# Infers: Registry: ghcr.io/test/myapp:v1
spin up -f ghcr.io/test/myapp:v1
```

Error cases:

```
# If not a file/directory
$ spin up -f guest2
Error: File or directory 'guest2' not found. If you meant to load from a registry, use the `--from-registry` option.

# If not a file/directory, *but* something that looks like a tag is present
$ spin up -f guest2/bish/bosh:v1
Error: cannot pull Spin application from registry

Caused by:
    Not authorized: url https://index.docker.io/v2/guest2/bish/bosh/manifests/v1
```

The following tweaks are also made to the `spin up` UI:
* Bindle flags are hidden but continue to work (no deprecation warning is issued)
* The `from-bindle` alias is added despite this, because consistency even on the edge of the pit
* `--file` is moved to an alias but continues to be supported

There should be no breaking change for the `-f` flag, except that if it is pointed at a non-existent file, it _may_ now fail with a registry error instead of a file not found error.

**NOTE:** this currently has the full, tragic commit history of the flagless work; if we decide to adopt it, then this should be squashed before merging.