### PR TITLE
Simpler error when command neither recognised nor plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,6 +2229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "lexical"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4304,6 +4310,7 @@ dependencies = [
  "hyper",
  "is-terminal",
  "lazy_static",
+ "levenshtein",
  "nix 0.24.3",
  "openssl",
  "outbound-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2.2"
 uuid = "^1.0"
 wasmtime = { workspace = true }
+levenshtein = "1.0.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
 use spin_cli::commands::{
@@ -96,7 +96,7 @@ impl SpinApp {
             Self::Trigger(TriggerCommands::Redis(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::HelpArgsOnly(cmd)) => cmd.run().await,
             Self::Plugins(cmd) => cmd.run().await,
-            Self::External(cmd) => execute_external_subcommand(cmd, SpinApp::command()).await,
+            Self::External(cmd) => execute_external_subcommand(cmd).await,
         }
     }
 }

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
 use spin_cli::commands::{
@@ -96,7 +96,7 @@ impl SpinApp {
             Self::Trigger(TriggerCommands::Redis(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::HelpArgsOnly(cmd)) => cmd.run().await,
             Self::Plugins(cmd) => cmd.run().await,
-            Self::External(cmd) => execute_external_subcommand(cmd).await,
+            Self::External(cmd) => execute_external_subcommand(cmd, SpinApp::command()).await,
         }
     }
 }

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -32,7 +32,10 @@ fn parse_subcommand(mut cmd: Vec<String>) -> anyhow::Result<(String, Vec<String>
 /// Executes a Spin plugin as a subprocess, expecting the first argument to
 /// indicate the plugin to execute. Passes all subsequent arguments on to the
 /// subprocess.
-pub async fn execute_external_subcommand(cmd: Vec<String>) -> anyhow::Result<()> {
+pub async fn execute_external_subcommand(
+    cmd: Vec<String>,
+    app: clap::App<'_>,
+) -> anyhow::Result<()> {
     let (plugin_name, args, override_compatibility_check) = parse_subcommand(cmd)?;
     let plugin_store = PluginStore::try_default()?;
     match plugin_store.read_plugin_manifest(&plugin_name) {
@@ -48,6 +51,7 @@ pub async fn execute_external_subcommand(cmd: Vec<String>) -> anyhow::Result<()>
         Err(Error::NotFound(e)) => {
             tracing::debug!("Tried to resolve {plugin_name} to plugin, got {e}");
             eprintln!("Error: '{plugin_name}' is not a known Spin command. See spin --help.\n");
+            print_similar_commands(app, &plugin_name);
             process::exit(2);
         }
         Err(e) => return Err(e.into()),
@@ -67,6 +71,33 @@ pub async fn execute_external_subcommand(cmd: Vec<String>) -> anyhow::Result<()>
         }
     }
     Ok(())
+}
+
+fn print_similar_commands(app: clap::App, plugin_name: &str) {
+    let similar = similar_commands(app, plugin_name);
+    match similar.len() {
+        0 => (),
+        1 => eprintln!("The most similar command is:"),
+        _ => eprintln!("The most similar commands are:"),
+    }
+    for cmd in &similar {
+        eprintln!("    {cmd}");
+    }
+    if !similar.is_empty() {
+        eprintln!();
+    }
+}
+
+fn similar_commands(app: clap::App, target: &str) -> Vec<String> {
+    app.get_subcommands()
+        .filter_map(|sc| {
+            if levenshtein::levenshtein(sc.get_name(), target) <= 2 {
+                Some(sc.get_name().to_owned())
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn get_env_vars_map() -> Result<HashMap<String, String>> {

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -1,6 +1,5 @@
 use crate::opts::PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG;
 use anyhow::{anyhow, Result};
-use clap::App;
 use spin_plugins::{error::Error, manifest::check_supported_version, PluginStore};
 use std::{collections::HashMap, env, process};
 use tokio::process::Command;
@@ -33,7 +32,7 @@ fn parse_subcommand(mut cmd: Vec<String>) -> anyhow::Result<(String, Vec<String>
 /// Executes a Spin plugin as a subprocess, expecting the first argument to
 /// indicate the plugin to execute. Passes all subsequent arguments on to the
 /// subprocess.
-pub async fn execute_external_subcommand(cmd: Vec<String>, app: App<'_>) -> anyhow::Result<()> {
+pub async fn execute_external_subcommand(cmd: Vec<String>) -> anyhow::Result<()> {
     let (plugin_name, args, override_compatibility_check) = parse_subcommand(cmd)?;
     let plugin_store = PluginStore::try_default()?;
     match plugin_store.read_plugin_manifest(&plugin_name) {
@@ -47,9 +46,8 @@ pub async fn execute_external_subcommand(cmd: Vec<String>, app: App<'_>) -> anyh
             }
         }
         Err(Error::NotFound(e)) => {
-            // Manifest file cannot be found for a plugin with the given name.
-            eprintln!("Unknown command: {e}\n");
-            app.clone().print_help()?;
+            tracing::debug!("Tried to resolve {plugin_name} to plugin, got {e}");
+            eprintln!("Error: '{plugin_name}' is not a known Spin command. See spin --help.\n");
             process::exit(2);
         }
         Err(e) => return Err(e.into()),


### PR DESCRIPTION
Fixes #1187.

```
$ ./target/debug/spin versio
Unknown command: 'versio' is not a Spin command. See spin --help.
```

Confirmed that plugins are still resolved correctly and that built-in commands still work.

We could amend the wording to say "is not a Spin command or plugin" but, as @bacongobbler notes, from a new user point of view this is introducing a whole new concept when all they want to do is run their thing.  But I'm happy to wordsmith if folks have opinions!

If.  Heh.