### PR TITLE
chore: add tools directory and include modsurfer

### DIFF
--- a/tools/modsurfer/README.md
+++ b/tools/modsurfer/README.md
@@ -1,0 +1,37 @@
+# Modsurfer Module Validation
+
+Using the [Modsurfer](https://github.com/dylibso/modsurfer) tool to validate and scan your Spin
+modules is simple. Use the CLI or the [GitHub Action](https://github.com/modsurfer-validate-action) 
+to ensure compatibility with the Fermyon Cloud or self-hosted Platform, and check for security or
+performance concerns before you deploy your code.
+
+The easiest way to start is by using the GitHub Action. Add the following to your project repository:
+
+#### `./github/workflows/modsurfer.yml`
+
+```yaml
+name: Modsurfer Validate - Fermyon
+on: [push, pull_request]
+jobs:
+  check-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: modsurfer validate
+        uses: dylibso/modsurfer-validate-action@main
+        with:
+            path: path/to/your/module.wasm
+            check: mod.yaml
+```
+
+And include a "checkfile" in a file called `mod.yaml` (or whichever file you've referenced in the `check` field above):
+
+```yaml
+validate:
+  url: https://raw.githubusercontent.com/fermyon/spin/main/tools/modsurfer/http/mod.yaml
+```
+
+The checkfile above uses a remote reference to ensure your Fermyon Spin project is compatible with 
+the latest requirements of the Spin SDKs. This is based off the "http" templates. If you are using
+a different template, such as "redis", then find the related checkfile that matches the template 
+you're using. 

--- a/tools/modsurfer/http/mod.yaml
+++ b/tools/modsurfer/http/mod.yaml
@@ -1,0 +1,76 @@
+# For more information about other checkfile options, see the documentation at https://dev.dylib.so/docs/modsurfer/cli#checkfile
+validate:
+  allow_wasi: true
+  imports:
+    include:
+    - namespace: wasi_snapshot_preview1
+      name: fd_write
+      params:
+      - I32
+      - I32
+      - I32
+      - I32
+      results:
+      - I32
+    - namespace: wasi_snapshot_preview1
+      name: random_get
+      params:
+      - I32
+      - I32
+      results:
+      - I32
+    - namespace: wasi_snapshot_preview1
+      name: environ_get
+      params:
+      - I32
+      - I32
+      results:
+      - I32
+    - namespace: wasi_snapshot_preview1
+      name: environ_sizes_get
+      params:
+      - I32
+      - I32
+      results:
+      - I32
+    - namespace: wasi_snapshot_preview1
+      name: proc_exit
+      params:
+      - I32
+      results: []
+    namespace:
+      include:
+      - wasi_snapshot_preview1
+  exports:
+    include:
+    - name: handle-http-request
+      params:
+      - I32
+      - I32
+      - I32
+      - I32
+      - I32
+      - I32
+      - I32
+      - I32
+      - I32
+      - I32
+      results:
+      - I32
+    - name: canonical_abi_realloc
+      params:
+      - I32
+      - I32
+      - I32
+      - I32
+      results:
+      - I32
+    - name: canonical_abi_free
+      params:
+      - I32
+      - I32
+      - I32
+      results: []
+    max: 3
+  complexity:
+    max_risk: medium

--- a/tools/modsurfer/redis/mod.yaml
+++ b/tools/modsurfer/redis/mod.yaml
@@ -1,0 +1,61 @@
+# For more information about other checkfile options, see the documentation at https://dev.dylib.so/docs/modsurfer/cli#checkfile
+validate:
+  allow_wasi: true
+  imports:
+    include:
+    - namespace: wasi_snapshot_preview1
+      name: fd_write
+      params:
+      - I32
+      - I32
+      - I32
+      - I32
+      results:
+      - I32
+    - namespace: wasi_snapshot_preview1
+      name: environ_get
+      params:
+      - I32
+      - I32
+      results:
+      - I32
+    - namespace: wasi_snapshot_preview1
+      name: environ_sizes_get
+      params:
+      - I32
+      - I32
+      results:
+      - I32
+    - namespace: wasi_snapshot_preview1
+      name: proc_exit
+      params:
+      - I32
+      results: []
+    namespace:
+      include:
+      - wasi_snapshot_preview1
+  exports:
+    include:
+    - name: handle-redis-message
+      params:
+      - I32
+      - I32
+      results:
+      - I32
+    - name: canonical_abi_realloc
+      params:
+      - I32
+      - I32
+      - I32
+      - I32
+      results:
+      - I32
+    - name: canonical_abi_free
+      params:
+      - I32
+      - I32
+      - I32
+      results: []
+    max: 3
+  complexity:
+    max_risk: medium


### PR DESCRIPTION
In reference to https://github.com/fermyon/spin/issues/1120, this PR includes a `tools` directory along with the contents of the `modsurfer` directory within it. I am happy to update this PR according to any other location in the repo at your suggestion!

I've tested that the remote reference to a Spin checkfile works as documented in the README here, and will update the [Modsurfer workflows](https://github.com/dylibso/modsurfer/blob/main/.github/workflows/ci-vendor-fermyon.yml) to use these same remotes as soon as the PR is merged. 

Closes #1120