### PR TITLE
Fix duplicate package warnings

### DIFF
--- a/examples/rust-key-value/Cargo.toml
+++ b/examples/rust-key-value/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "spin-key-value"
+name    = "rust-key-value"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/rust-key-value/spin.toml
+++ b/examples/rust-key-value/spin.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 
 [[component]]
 id = "hello"
-source = "target/wasm32-wasi/release/spin_key_value.wasm"
+source = "target/wasm32-wasi/release/rust_key_value.wasm"
 key_value_stores = ["default"]
 [component.trigger]
 route = "/..."

--- a/tests/testcases/headers-dynamic-env-test/Cargo.toml
+++ b/tests/testcases/headers-dynamic-env-test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "env"
+name    = "headers-dynamic-env-test"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/testcases/headers-dynamic-env-test/spin.toml
+++ b/tests/testcases/headers-dynamic-env-test/spin.toml
@@ -7,7 +7,7 @@ trigger = {type = "http", base = "/"}
 
 [[component]]
 id = "env"
-source = "target/wasm32-wasi/release/env.wasm"
+source = "target/wasm32-wasi/release/headers_dynamic_env_test.wasm"
 environment = { some_key = "some_value" }
 [component.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/tests/testcases/headers-env-routes-test/Cargo.toml
+++ b/tests/testcases/headers-env-routes-test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "env"
+name    = "headers-env-routes-test"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/testcases/headers-env-routes-test/spin.toml
+++ b/tests/testcases/headers-env-routes-test/spin.toml
@@ -7,7 +7,7 @@ trigger = {type = "http", base = "/"}
 
 [[component]]
 id = "env"
-source = "target/wasm32-wasi/release/env.wasm"
+source = "target/wasm32-wasi/release/headers_env_routes_test.wasm"
 environment = { some_key = "some_value" }
 [component.trigger]
 route = "/env/..."

--- a/tests/testcases/http-rust-outbound-mysql/Cargo.toml
+++ b/tests/testcases/http-rust-outbound-mysql/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http-rust-outbound-mysql"
+name = "http-rust-outbound-mysql-test"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/testcases/http-rust-outbound-mysql/spin.toml
+++ b/tests/testcases/http-rust-outbound-mysql/spin.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [[component]]
 environment = { DB_URL = "mysql://spin:spin@mysql/spin_dev" }
 id = "outbound-mysql"
-source = "target/wasm32-wasi/release/http_rust_outbound_mysql.wasm"
+source = "target/wasm32-wasi/release/http_rust_outbound_mysql_test.wasm"
 [component.trigger]
 route = "/..."
 [component.build]

--- a/tests/testcases/simple-spin-rust-test/Cargo.toml
+++ b/tests/testcases/simple-spin-rust-test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "simple-spin-rust"
+name    = "simple-spin-rust-test"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/testcases/simple-spin-rust-test/spin.toml
+++ b/tests/testcases/simple-spin-rust-test/spin.toml
@@ -10,7 +10,7 @@ object = { default = "teapot" }
 
 [[component]]
 id = "hello"
-source = "target/wasm32-wasi/release/simple_spin_rust.wasm"
+source = "target/wasm32-wasi/release/simple_spin_rust_test.wasm"
 files = [ { source = "assets", destination = "/" } ]
 [component.trigger]
 route = "/hello/..."


### PR DESCRIPTION
Fixes #1186.

This doesn't set up any infra to monitor for this happening again - it just clears the current set of warnings.