### PR TITLE
add `CachingStoreManager` to KV component and use it by default

### DIFF
--- a/crates/key-value/src/lib.rs
+++ b/crates/key-value/src/lib.rs
@@ -8,7 +8,7 @@ mod table;
 mod util;
 
 pub use host_component::{manager, KeyValueComponent};
-pub use util::{DelegatingStoreManager, EmptyStoreManager};
+pub use util::{CachingStoreManager, DelegatingStoreManager, EmptyStoreManager};
 
 wit_bindgen_wasmtime::export!({paths: ["../../wit/ephemeral/key-value.wit"], async: *});
 

--- a/crates/key-value/src/util.rs
+++ b/crates/key-value/src/util.rs
@@ -1,5 +1,13 @@
 use crate::{Error, Store, StoreManager};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap, HashSet},
+    future::Future,
+    sync::Arc,
+};
+use tokio::{
+    sync::Mutex as AsyncMutex,
+    task::{self, JoinHandle},
+};
 use wit_bindgen_wasmtime::async_trait;
 
 pub struct EmptyStoreManager;
@@ -29,5 +37,170 @@ impl StoreManager for DelegatingStoreManager {
             .ok_or(Error::NoSuchStore)?
             .get(name)
             .await
+    }
+}
+
+/// Wrap each `Store` produced by the inner `StoreManager` in an asynchronous, write-behind cache.
+///
+/// This serves two purposes:
+///
+/// - Improve performance with slow and/or distant stores
+///
+/// - Provide a relaxed consistency guarantee vs. what a fully synchronous store provides
+///
+/// The latter is intended to prevent guests from coming to rely on the synchronous consistency model of an
+/// existing implementation which may later be replaced with one providing a more relaxed, asynchronous
+/// (i.e. "eventual") consistency model.  See also https://www.hyrumslaw.com/ and https://xkcd.com/1172/.
+///
+/// This implementation provides a "read-your-writes", asynchronous consistency model such that values are
+/// immediately available for reading as soon as they are written as long as the read(s) hit the same cache as the
+/// write(s).  Reads and writes through separate caches (e.g. separate guest instances or separately-opened
+/// references to the same store within a single instance) are _not_ guaranteed to be consistent; not only is
+/// cross-cache consistency subject to scheduling and/or networking delays, a given tuple is never refreshed from
+/// the backing store once added to a cache since this implementation is intended for use only by short-lived guest
+/// instances.
+///
+/// Note that, because writes are asynchronous and return immediately, durability is _not_ guaranteed.  I/O errors
+/// may occur asyncronously after the write operation has returned control to the guest, which may result in the
+/// write being lost without the guest knowing.  In the future, a separate `write-durable` function could be added
+/// to key-value.wit to provide provide either synchronous or asynchronous feedback on durability for guests which
+/// need it.
+pub struct CachingStoreManager<T> {
+    inner: T,
+}
+
+impl<T> CachingStoreManager<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<T: StoreManager> StoreManager for CachingStoreManager<T> {
+    async fn get(&self, name: &str) -> Result<Arc<dyn Store>, Error> {
+        Ok(Arc::new(CachingStore {
+            inner: self.inner.get(name).await?,
+            state: AsyncMutex::new(CachingStoreState::default()),
+        }))
+    }
+}
+
+#[derive(Default)]
+struct CachingStoreState {
+    cache: HashMap<String, Option<Vec<u8>>>,
+    previous_task: Option<JoinHandle<Result<(), Error>>>,
+}
+
+impl CachingStoreState {
+    /// Wrap the specified task in an outer task which waits for `self.previous_task` before proceeding, and spawn
+    /// the result.  This ensures that write order is preserved.
+    fn spawn(&mut self, task: impl Future<Output = Result<(), Error>> + Send + 'static) {
+        let previous_task = self.previous_task.take();
+        self.previous_task = Some(task::spawn(async move {
+            if let Some(previous_task) = previous_task {
+                previous_task
+                    .await
+                    .map_err(|e| Error::Io(format!("{e:?}")))??
+            }
+
+            task.await
+        }))
+    }
+}
+
+struct CachingStore {
+    inner: Arc<dyn Store>,
+    state: AsyncMutex<CachingStoreState>,
+}
+
+#[async_trait]
+impl Store for CachingStore {
+    async fn get(&self, key: &str) -> Result<Vec<u8>, Error> {
+        // Retrieve the specified value from the cache, lazily populating the cache as necessary.
+
+        match self.state.lock().await.cache.entry(key.to_owned()) {
+            Entry::Vacant(e) => {
+                let value = match self.inner.get(key).await {
+                    Ok(value) => Some(value),
+                    Err(Error::NoSuchKey) => None,
+                    e => return e,
+                };
+
+                e.insert(value.clone());
+
+                value
+            }
+            Entry::Occupied(e) => e.get().clone(),
+        }
+        .ok_or(Error::NoSuchKey)
+    }
+
+    async fn set(&self, key: &str, value: &[u8]) -> Result<(), Error> {
+        // Update the cache and spawn a task to update the backing store asynchronously.
+
+        let mut state = self.state.lock().await;
+
+        state.cache.insert(key.to_owned(), Some(value.to_owned()));
+
+        let inner = self.inner.clone();
+        let key = key.to_owned();
+        let value = value.to_owned();
+        state.spawn(async move { inner.set(&key, &value).await });
+
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), Error> {
+        // Update the cache and spawn a task to update the backing store asynchronously.
+
+        let mut state = self.state.lock().await;
+
+        state.cache.insert(key.to_owned(), None);
+
+        let inner = self.inner.clone();
+        let key = key.to_owned();
+        state.spawn(async move { inner.delete(&key).await });
+
+        Ok(())
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, Error> {
+        match self.get(key).await {
+            Ok(_) => Ok(true),
+            Err(Error::NoSuchKey) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn get_keys(&self) -> Result<Vec<String>, Error> {
+        // Get the keys from the backing store, remove any which are `None` in the cache, and add any which are
+        // `Some` in the cache, returning the result.
+        //
+        // Note that we don't bother caching the result, since we expect this function won't be called more than
+        // once for a given store in normal usage, and maintaining consistency would be complicated.
+
+        let state = self.state.lock().await;
+
+        Ok(self
+            .inner
+            .get_keys()
+            .await?
+            .into_iter()
+            .filter(|k| {
+                state
+                    .cache
+                    .get(k)
+                    .map(|v| v.as_ref().is_some())
+                    .unwrap_or(true)
+            })
+            .chain(
+                state
+                    .cache
+                    .iter()
+                    .filter_map(|(k, v)| v.as_ref().map(|_| k.to_owned())),
+            )
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect())
     }
 }

--- a/crates/key-value/src/util.rs
+++ b/crates/key-value/src/util.rs
@@ -63,8 +63,7 @@ impl StoreManager for DelegatingStoreManager {
 /// Note that, because writes are asynchronous and return immediately, durability is _not_ guaranteed.  I/O errors
 /// may occur asyncronously after the write operation has returned control to the guest, which may result in the
 /// write being lost without the guest knowing.  In the future, a separate `write-durable` function could be added
-/// to key-value.wit to provide provide either synchronous or asynchronous feedback on durability for guests which
-/// need it.
+/// to key-value.wit to provide either synchronous or asynchronous feedback on durability for guests which need it.
 pub struct CachingStoreManager<T> {
     inner: T,
 }


### PR DESCRIPTION
From the doc comments:

> Wrap each `Store` produced by the inner `StoreManager` in an asynchronous, write-behind cache.
>
> This serves two purposes:
>
> - Improve performance with slow and/or distant stores
>
> - Provide a relaxed consistency guarantee vs. what a fully synchronous store provides
>
> The latter is intended to prevent guests from coming to rely on the synchronous consistency model of an
> existing implementation which may later be replaced with one providing a more relaxed, asynchronous
> (i.e. "eventual") consistency model.  See also https://www.hyrumslaw.com/ and https://xkcd.com/1172/.
>
> This implementation provides a "read-your-writes", asynchronous consistency model such that values are
> immediately available for reading as soon as they are written as long as the read(s) hit the same cache as the
> write(s).  Reads and writes through separate caches (e.g. separate guest instances or separately-opened
> references to the same store within a single instance) are _not_ guaranteed to be consistent; not only is
> cross-cache consistency subject to scheduling and/or networking delays, a given tuple is never refreshed from
> the backing store once added to a cache since this implementation is intended for use only by short-lived guest
> instances.
>
> Note that, because writes are asynchronous and return immediately, durability is _not_ guaranteed.  I/O errors
> may occur asyncronously after the write operation has returned control to the guest, which may result in the
> write being lost without the guest knowing.  In the future, a separate `write-durable` function could be added
> to key-value.wit to provide either synchronous or asynchronous feedback on durability for guests which need it.

I've also updated `spin-trigger` to use this by default.