### PR TITLE
ref(up): update default log dir

### DIFF
--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -25,7 +25,6 @@ use spin_config::{
 };
 use spin_core::{Config, Engine, EngineBuilder, Instance, InstancePre, Store, StoreBuilder};
 
-const SPIN_HOME: &str = ".spin";
 const SPIN_CONFIG_ENV_PREFIX: &str = "SPIN_APP";
 const DEFAULT_SQLITE_DB_DIRECTORY: &str = ".spin";
 const DEFAULT_SQLITE_DB_FILENAME: &str = "sqlite_key_value.db";


### PR DESCRIPTION
+ This change updates where the logs are stored for an app by default. Previously, they were being stored in a user's home directory under `.spin/<app-name>/logs`. This resulted in naming conflicts and a confusing user experience.
+ For a user running an app locally, logs are stored in the same directory as the spin.toml file: <app-dir>/.spin/logs
+ For a user running an app from a registry, logs are no longer stored by default. They are streamed to stdout.
+ The value of the log_dir flag takes precedence if set.