### PR TITLE
remove `Clone` derive for `Store` in the Rust SDK

### DIFF
--- a/sdk/rust/src/key_value.rs
+++ b/sdk/rust/src/key_value.rs
@@ -12,7 +12,7 @@ use key_value::Store as RawStore;
 pub type Error = key_value::Error;
 
 /// Represents a store in which key value tuples may be placed
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Store(RawStore);
 
 impl Store {


### PR DESCRIPTION
It was a mistake to derive `Clone` for this type since its `Drop` implementation closes the inner store handle.  If there are multiple clones, the first one that gets dropped will close the handle, invalidating the others before they're dropped, too. :facepalm:

Apps that need to `Clone` `Store`s will need to wrap them in `Rc` or `Arc`.