### PR TITLE
chore: Use clap group for spin up source flags

### DIFF
--- a/src/commands/bindle.rs
+++ b/src/commands/bindle.rs
@@ -31,7 +31,7 @@ impl BindleCommands {
 pub struct Prepare {
     /// Path to spin.toml
     #[clap(
-        name = APP_CONFIG_FILE_OPT,
+        name = APP_MANIFEST_FILE_OPT,
         short = 'f',
         long = "file",
     )]
@@ -59,7 +59,7 @@ pub struct Prepare {
 pub struct Push {
     /// Path to spin.toml
     #[clap(
-        name = APP_CONFIG_FILE_OPT,
+        name = APP_MANIFEST_FILE_OPT,
         short = 'f',
         long = "file",
     )]

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsString, path::PathBuf};
 use anyhow::Result;
 use clap::Parser;
 
-use crate::opts::{APP_CONFIG_FILE_OPT, BUILD_UP_OPT, DEFAULT_MANIFEST_FILE};
+use crate::opts::{APP_MANIFEST_FILE_OPT, BUILD_UP_OPT, DEFAULT_MANIFEST_FILE};
 
 use super::up::UpCommand;
 
@@ -13,7 +13,7 @@ use super::up::UpCommand;
 pub struct BuildCommand {
     /// Path to application manifest. The default is "spin.toml".
     #[clap(
-        name = APP_CONFIG_FILE_OPT,
+        name = APP_MANIFEST_FILE_OPT,
         short = 'f',
         long = "from",
         alias = "file",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -44,7 +44,7 @@ const BINDLE_REGISTRY_URL_PATH: &str = "api/registry";
 pub struct DeployCommand {
     /// Path to spin.toml
     #[clap(
-        name = APP_CONFIG_FILE_OPT,
+        name = APP_MANIFEST_FILE_OPT,
         short = 'f',
         long = "file",
         default_value = "spin.toml"

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -12,7 +12,7 @@ use tokio;
 use spin_loader::local::absolutize;
 use spin_templates::{RunOptions, Template, TemplateManager, TemplateVariantInfo};
 
-use crate::opts::{APP_CONFIG_FILE_OPT, DEFAULT_MANIFEST_FILE};
+use crate::opts::{APP_MANIFEST_FILE_OPT, DEFAULT_MANIFEST_FILE};
 
 /// Scaffold a new application based on a template.
 #[derive(Parser, Debug)]
@@ -68,7 +68,7 @@ pub struct AddCommand {
 
     /// Path to spin.toml.
     #[clap(
-        name = APP_CONFIG_FILE_OPT,
+        name = APP_MANIFEST_FILE_OPT,
         short = 'f',
         long = "file",
     )]

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -33,7 +33,7 @@ impl RegistryCommands {
 pub struct Push {
     /// Path to spin.toml
     #[clap(
-        name = APP_CONFIG_FILE_OPT,
+        name = APP_MANIFEST_FILE_OPT,
         short = 'f',
         long = "file",
     )]

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -35,6 +35,7 @@ pub struct UpCommand {
         name = APPLICATION_OPT,
         short = 'f',
         long = "from",
+        group = "source",
     )]
     pub app_source: Option<String>,
 
@@ -42,12 +43,10 @@ pub struct UpCommand {
     /// application to be interpreted as a file or directory path.
     #[clap(
         hide = true,
-        name = APP_CONFIG_FILE_OPT,
+        name = APP_MANIFEST_FILE_OPT,
         long = "from-file",
         alias = "file",
-        conflicts_with = BINDLE_ID_OPT,
-        conflicts_with = FROM_REGISTRY_OPT,
-        conflicts_with = APPLICATION_OPT,
+        group = "source",
     )]
     pub file_source: Option<PathBuf>,
 
@@ -59,9 +58,7 @@ pub struct UpCommand {
         short = 'b',
         long = "bindle",
         alias = "from-bindle",
-        conflicts_with = APP_CONFIG_FILE_OPT,
-        conflicts_with = FROM_REGISTRY_OPT,
-        conflicts_with = APPLICATION_OPT,
+        group = "source",
         requires = BINDLE_SERVER_URL_OPT,
     )]
     pub bindle_source: Option<String>,
@@ -101,9 +98,7 @@ pub struct UpCommand {
         hide = true,
         name = FROM_REGISTRY_OPT,
         long = "from-registry",
-        conflicts_with = BINDLE_ID_OPT,
-        conflicts_with = APP_CONFIG_FILE_OPT,
-        conflicts_with = APPLICATION_OPT,
+        group = "source",
     )]
     pub registry_source: Option<String>,
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,5 +1,5 @@
 pub const DEFAULT_MANIFEST_FILE: &str = "spin.toml";
-pub const APP_CONFIG_FILE_OPT: &str = "APP_CONFIG_FILE";
+pub const APP_MANIFEST_FILE_OPT: &str = "APP_MANIFEST_FILE";
 pub const BINDLE_ID_OPT: &str = "BINDLE_ID";
 pub const BINDLE_SERVER_URL_OPT: &str = "BINDLE_SERVER_URL";
 pub const BINDLE_URL_ENV: &str = "BINDLE_URL";


### PR DESCRIPTION
This has the same effect as multiple "conflicts_with"s.

Also slightly nicer usage example on error, though the extra source flags are still hidden by default:

```
$ spin up --from foo --from-file bar
error: The argument '--from <APPLICATION>' cannot be used with '--from-file <APP_MANIFEST_FILE>'

USAGE:
    spin up <--from <APPLICATION>|--from-file <APP_MANIFEST_FILE>|--bindle <BINDLE_ID>|--from-registry <REGISTRY_REFERENCE>>
```