### PR TITLE
support explicit capacity limits for KV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,7 +249,7 @@ dependencies = [
  "futures",
  "hyper",
  "jsonwebtoken",
- "lru",
+ "lru 0.7.8",
  "mime",
  "mime_guess",
  "oauth2",
@@ -1836,7 +1847,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1845,7 +1856,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -2513,6 +2533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,7 +2663,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "lazy_static",
- "lru",
+ "lru 0.7.8",
  "mio",
  "mysql_common",
  "native-tls",
@@ -4452,6 +4481,7 @@ name = "spin-key-value"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "lru 0.9.0",
  "spin-app",
  "spin-core",
  "tokio",

--- a/crates/key-value/Cargo.toml
+++ b/crates/key-value/Cargo.toml
@@ -14,3 +14,4 @@ spin-core = { path = "../core" }
 spin-app = { path = "../app" }
 tracing = { workspace = true }
 wit-bindgen-wasmtime = { workspace = true }
+lru = "0.9.0"

--- a/crates/key-value/src/host_component.rs
+++ b/crates/key-value/src/host_component.rs
@@ -24,12 +24,18 @@ pub fn manager<F: for<'a> Fn(&'a AppComponent) -> Arc<dyn StoreManager>>(f: F) -
 }
 
 pub struct KeyValueComponent {
+    capacity: u32,
     manager: Box<dyn StoreManagerManager>,
 }
 
 impl KeyValueComponent {
     pub fn new(manager: impl StoreManagerManager + 'static) -> Self {
+        Self::new_with_capacity(u32::MAX, manager)
+    }
+
+    pub fn new_with_capacity(capacity: u32, manager: impl StoreManagerManager + 'static) -> Self {
         Self {
+            capacity,
             manager: Box::new(manager),
         }
     }
@@ -46,7 +52,7 @@ impl HostComponent for KeyValueComponent {
     }
 
     fn build_data(&self) -> Self::Data {
-        KeyValueDispatch::new()
+        KeyValueDispatch::new_with_capacity(self.capacity)
     }
 }
 

--- a/crates/key-value/src/lib.rs
+++ b/crates/key-value/src/lib.rs
@@ -10,6 +10,8 @@ mod util;
 pub use host_component::{manager, KeyValueComponent};
 pub use util::{CachingStoreManager, DelegatingStoreManager, EmptyStoreManager};
 
+const DEFAULT_STORE_TABLE_CAPACITY: u32 = 256;
+
 wit_bindgen_wasmtime::export!({paths: ["../../wit/ephemeral/key-value.wit"], async: *});
 
 pub use key_value::{Error, KeyValue, Store as StoreHandle};
@@ -48,10 +50,14 @@ pub struct KeyValueDispatch {
 
 impl KeyValueDispatch {
     pub fn new() -> Self {
+        Self::new_with_capacity(DEFAULT_STORE_TABLE_CAPACITY)
+    }
+
+    pub fn new_with_capacity(capacity: u32) -> Self {
         Self {
             allowed_stores: HashSet::new(),
             manager: Arc::new(EmptyStoreManager),
-            stores: Table::new(),
+            stores: Table::new(capacity),
         }
     }
 

--- a/crates/key-value/src/table.rs
+++ b/crates/key-value/src/table.rs
@@ -12,14 +12,16 @@ use std::collections::HashMap;
 /// how file handles work across the user-kernel boundary.
 ///
 pub struct Table<V> {
+    capacity: u32,
     next_key: u32,
     tuples: HashMap<u32, V>,
 }
 
 impl<V> Table<V> {
-    /// Create a new, empty table.
-    pub fn new() -> Self {
+    /// Create a new, empty table with the specified capacity.
+    pub fn new(capacity: u32) -> Self {
         Self {
+            capacity,
             next_key: 0,
             tuples: HashMap::new(),
         }
@@ -27,13 +29,13 @@ impl<V> Table<V> {
 
     /// Add the specified resource to this table.
     ///
-    /// If the table is full (i.e. there already are 2^32 resources inside), this returns `Err(())`.  Otherwise, a
-    /// new, unique identifier is allocated for the resource and returned.
+    /// If the table is full (i.e. there already are `self.capacity` resources inside), this returns `Err(())`.
+    /// Otherwise, a new, unique identifier is allocated for the resource and returned.
     ///
     /// This function will attempt to avoid reusing recently closed identifiers, but after 2^32 calls to this
     /// function they will start repeating.
     pub fn push(&mut self, value: V) -> Result<u32, ()> {
-        if self.tuples.len() == u32::MAX as usize {
+        if self.tuples.len() == self.capacity as usize {
             Err(())
         } else {
             loop {


### PR DESCRIPTION
This allows the host to apply specific limits to the store table size and the in-memory tuple cache size.