### PR TITLE
Print deprecation message on Bindle features

### DIFF
--- a/crates/loader/src/bindle/deprecation.rs
+++ b/crates/loader/src/bindle/deprecation.rs
@@ -1,0 +1,13 @@
+use std::sync::Once;
+
+/// Prints a notice that Bindle support is deprecated.
+pub fn print_bindle_deprecation() {
+    static PRINT: Once = Once::new();
+
+    PRINT.call_once(|| {
+        eprintln!("WARNING: Bindle support is deprecated and will be removed in a future version.");
+        eprintln!("For remote applications, please use registry commands and features instead.");
+        eprintln!("See https://developer.fermyon.com/spin/spin-oci for more details");
+        eprintln!();
+    });
+}

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -7,6 +7,8 @@ mod assets;
 /// Configuration representation for a Spin application in Bindle.
 pub mod config;
 mod connection;
+/// Functions relating to Bindle deprecation.
+pub mod deprecation;
 /// Bindle helper functions.
 mod utils;
 

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -126,6 +126,16 @@ pub fn validate_raw_app_manifest(raw: &RawAppManifestAnyVersion) -> Result<()> {
         .components
         .iter()
         .try_for_each(|c| validate_allowed_http_hosts(&c.wasm.allowed_http_hosts))?;
+
+    if raw
+        .as_v1()
+        .components
+        .iter()
+        .any(|c| matches!(c.source, config::RawModuleSource::Bindle(_)))
+    {
+        crate::bindle::deprecation::print_bindle_deprecation();
+    }
+
     Ok(())
 }
 

--- a/src/commands/bindle.rs
+++ b/src/commands/bindle.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use semver::BuildMetadata;
-use spin_loader::bindle::BindleConnectionInfo;
+use spin_loader::bindle::{deprecation::print_bindle_deprecation, BindleConnectionInfo};
 
 use crate::{opts::*, parse_buildinfo, sloth::warn_if_slow_response};
 
@@ -120,6 +120,8 @@ pub struct Push {
 
 impl Prepare {
     pub async fn run(self) -> Result<()> {
+        print_bindle_deprecation();
+
         let app_file = self
             .app
             .as_deref()
@@ -143,6 +145,8 @@ impl Prepare {
 
 impl Push {
     pub async fn run(self) -> Result<()> {
+        print_bindle_deprecation();
+
         let app_file = self
             .app
             .as_deref()

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::{CommandFactory, Parser};
 use reqwest::Url;
 use spin_app::locked::LockedApp;
-use spin_loader::bindle::BindleConnectionInfo;
+use spin_loader::bindle::{deprecation::print_bindle_deprecation, BindleConnectionInfo};
 use spin_manifest::{Application, ApplicationTrigger};
 use spin_trigger::cli::{SPIN_LOCKED_URL, SPIN_WORKING_DIR};
 use tempfile::TempDir;
@@ -261,6 +261,10 @@ impl UpCommand {
                     TriggerExecOpts::NoApp,
                 )
                 .await;
+        }
+
+        if matches!(app_source, AppSource::Bindle(_)) {
+            print_bindle_deprecation();
         }
 
         let working_dir_holder = match &self.tmp {


### PR DESCRIPTION
Fixes #1156 and #1207.

The cases picked up in this are:

* `spin bindle push`
* `spin bindle run`
* `spin up --bindle`
* `spin up` from a local file with a parcel as a module source

**Reviewers please flag if you can think of any other paths that could result in us interacting with Bindle.**

An example of how it looks:

```
$ spin bindle push -f ./examples/http-rust/spin.toml --bindle-server http://localhost:8080/v1 --insecure
WARNING: Bindle support is deprecated and will be removed in a future version.
For remote applications, please use registry commands and features instead.
See https://developer.fermyon.com/spin/spin-oci for more details

pushed: spin-hello-world/1.2.3
```

The cases _should_ be exclusive, but the warning is guarded to print at most once _just in case_.  Because computers.
