### PR TITLE
export SDK version and language functions per SIP 011

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,7 @@ jobs:
       - name: setup dependencies
         uses: ./.github/actions/spin-ci-dependencies
         with:
+          rust: true
           bindle: true
           golang: true
           tinygo: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -1325,7 +1325,7 @@ checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "e2e-testing"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
@@ -4274,7 +4274,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-abi-conformance"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "spin-bindle"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "bindle",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "indexmap",
  "serde",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 rust-version = "1.64"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0-pre0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 

--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -138,7 +138,7 @@ fn inner_check_supported_version(
     let version = Version::parse(spin_version)?;
     if !comparator.matches(&version) {
         if !version.pre.is_empty() {
-            eprintln!("You're using a pre-release version of Spin ({spin_version}). This plugin might not be compatible (supported: {supported_on}).  Continuing anyway.");
+            eprintln!("You're using a pre-release version of Spin ({spin_version}). This plugin might not be compatible (supported: {supported_on}). Continuing anyway.");
         } else if override_compatibility_check {
             eprintln!("Plugin is not compatible with this version of Spin (supported: {supported_on}, actual: {spin_version}). Check overridden ... continuing to install or execute plugin.");
         } else {

--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -137,7 +137,9 @@ fn inner_check_supported_version(
     })?;
     let version = Version::parse(spin_version)?;
     if !comparator.matches(&version) {
-        if override_compatibility_check {
+        if !version.pre.is_empty() {
+            eprintln!("You're using a pre-release version of Spin ({spin_version}). This plugin might not be compatible (supported: {supported_on}).  Continuing anyway.");
+        } else if override_compatibility_check {
             eprintln!("Plugin is not compatible with this version of Spin (supported: {supported_on}, actual: {spin_version}). Check overridden ... continuing to install or execute plugin.");
         } else {
             return Err(anyhow!(

--- a/docs/content/release-process.md
+++ b/docs/content/release-process.md
@@ -9,7 +9,8 @@ url = "https://github.com/fermyon/spin/blob/main/docs/content/release-process.md
 To cut a release of Spin, you will need to do the following:
 
 1. Create a pull request that changes the version number for your new version
-   (e.g. `0.9.0` becomes `0.9.1`)
+   (e.g. `0.10.0-pre0` could become either `0.9.1` for a patch release or
+   `0.10.0` for a "major" release)
    - Bump the version in Spin's `Cargo.toml`
    - Update SDK_VERSION in `templates/Makefile`
    - Check the docs for hard-coded version strings
@@ -18,6 +19,11 @@ To cut a release of Spin, you will need to do the following:
 1. Before proceeding, verify that the merge commit on `main` intended to be
    tagged is green, i.e. CI is successful
 1. Create a new tag with a `v` and then the version number (`v0.9.1`)
+1. Update the `Cargo.toml` and `templates/Makefile` versions again, this
+   time to e.g. `0.11.0-pre0` if `0.11.0` is the next anticipated release.
+   - PR this to main
+   - See [sips/011-component-versioning.md](sips/011-component-versioning.md)
+     for details
 1. The Go SDK tag `sdk/go/v0.9.1` will be created in the [release action].
 1. When the [release action] completes, binary artifacts and checksums will be
    automatically uploaded to the GitHub release.

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.8.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/sdk/go/.gitignore
+++ b/sdk/go/.gitignore
@@ -1,0 +1,1 @@
+*/sdk-version-go.c

--- a/sdk/go/sdk_version/sdk-version-go-template.c
+++ b/sdk/go/sdk_version/sdk-version-go-template.c
@@ -1,0 +1,14 @@
+__attribute__((weak, export_name("spin-sdk-version-{{VERSION}}")))
+void __spin_sdk_version(void) {
+
+}
+
+__attribute__((weak, export_name("spin-sdk-language-go")))
+void __spin_sdk_language(void) {
+
+}
+
+__attribute__((weak, export_name("spin-sdk-commit-{{COMMIT}}")))
+void __spin_sdk_commit(void) {
+
+}

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -16,3 +16,7 @@ http = "0.2"
 spin-macro = { path = "macro" }
 thiserror = "1.0.37"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[features]
+default = [ "export-sdk-language" ]
+export-sdk-language = []

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn main() {
+    let pre = env!("CARGO_PKG_VERSION_PRE");
+    let pre = if pre.is_empty() {
+        String::new()
+    } else {
+        format!("-{pre}")
+    };
+
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .expect("failed to execute `git`");
+
+    let commit = if output.status.success() {
+        String::from_utf8(output.stdout).unwrap()
+    } else {
+        panic!("`git` failed: {}", String::from_utf8_lossy(&output.stderr));
+    };
+
+    let commit = commit.trim();
+
+    println!(
+        "cargo:rustc-env=SDK_VERSION={}-{}{pre}",
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        env!("CARGO_PKG_VERSION_MINOR"),
+    );
+    println!("cargo:rustc-env=SDK_COMMIT={commit}");
+}

--- a/sdk/rust/src/bin/version.rs
+++ b/sdk/rust/src/bin/version.rs
@@ -1,0 +1,3 @@
+fn main() {
+    print!("{}", env!("SDK_VERSION"));
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -11,6 +11,16 @@ pub mod key_value;
 /// Exports the procedural macros for writing handlers for Spin components.
 pub use spin_macro::*;
 
+#[export_name = concat!("spin-sdk-version-", env!("SDK_VERSION"))]
+extern "C" fn __spin_sdk_version() {}
+
+#[cfg(feature = "export-sdk-language")]
+#[export_name = "spin-sdk-language-rust"]
+extern "C" fn __spin_sdk_language() {}
+
+#[export_name = concat!("spin-sdk-commit-", env!("SDK_COMMIT"))]
+extern "C" fn __spin_sdk_hash() {}
+
 /// Helpers for building Spin HTTP components.
 /// These are convenience helpers, and the types in this module are
 /// based on the [`http`](https://crates.io/crates) crate.

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,4 +1,4 @@
-SDK_VERSION ?= v0.9.0
+SDK_VERSION ?= v0.10.0-pre0
 
 bump-versions: bump-go-versions bump-rust-versions
 

--- a/tests/http/headers-env-routes-test/Cargo.lock
+++ b/tests/http/headers-env-routes-test/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.9.0"
+version = "0.10.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Per https://github.com/fermyon/spin/blob/main/docs/content/sips/011-component-versioning.md, this commit adds `spin-sdk-version-0-10-pre0`, `spin-sdk-language-$LANGUAGE`, and `spin-sdk-commit-$COMMIT` exports to any module using the Rust or Go SDKs.

Regarding the version, we'll want to update it before and after every Spin release _and_ each time the ABI or API changes.  See the SIP for details.

Note that the `spin-sdk-language-$LANGUAGE` export is gated on a default-enabled feature for the Rust SDK, since the JS and Python SDKs will want to override it.