### PR TITLE
chore: Refactor `spin up` OCI support

### DIFF
--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -121,7 +121,7 @@ impl Client {
             components.push(c);
         }
         locked.components = components;
-        locked.metadata.remove(&"origin".to_string());
+        locked.metadata.remove("origin");
 
         let oci_config = Config {
             data: serde_json::to_vec(&locked)?,

--- a/crates/oci/src/lib.rs
+++ b/crates/oci/src/lib.rs
@@ -3,8 +3,13 @@
 
 mod auth;
 mod client;
+mod loader;
 
 pub use client::Client;
+pub use loader::OciLoader;
+
+/// URL scheme used for the locked app "origin" metadata field for OCI-sourced apps.
+pub const ORIGIN_URL_SCHEME: &str = "vnd.fermyon.origin-oci";
 
 /// Applies heuristics to check if the given string "looks like" it may be
 /// an OCI reference.

--- a/crates/oci/src/loader.rs
+++ b/crates/oci/src/loader.rs
@@ -1,0 +1,126 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, ensure, Context, Result};
+use oci_distribution::Reference;
+use reqwest::Url;
+use spin_app::locked::{ContentPath, ContentRef, LockedApp, LockedComponent};
+use spin_loader::cache::Cache;
+
+use crate::{Client, ORIGIN_URL_SCHEME};
+
+/// OciLoader loads an OCI app in preparation for running with Spin.
+pub struct OciLoader {
+    working_dir: PathBuf,
+}
+
+impl OciLoader {
+    /// Creates a new OciLoader which builds temporary mount directory(s) in
+    /// the given working_dir.
+    pub fn new(working_dir: impl Into<PathBuf>) -> Self {
+        let working_dir = working_dir.into();
+        Self { working_dir }
+    }
+
+    /// Loads a LockedApp with the given OCI client and reference.
+    pub async fn load_app(&self, client: &mut Client, reference: &str) -> Result<LockedApp> {
+        // Fetch app
+        client.pull(reference).await.with_context(|| {
+            format!("cannot pull Spin application from registry reference {reference:?}")
+        })?;
+
+        // Read locked app
+        let lockfile_path = client
+            .lockfile_path(&reference)
+            .await
+            .context("cannot get path to spin.lock")?;
+        let locked_content = tokio::fs::read(&lockfile_path)
+            .await
+            .with_context(|| format!("failed to read from {lockfile_path:?}"))?;
+        let mut locked_app = LockedApp::from_json(&locked_content)
+            .with_context(|| format!("failed to decode locked app from {lockfile_path:?}"))?;
+
+        // Update origin metadata
+        let resolved_reference = Reference::try_from(reference).context("invalid reference")?;
+        let origin_uri = format!("{ORIGIN_URL_SCHEME}:{resolved_reference}");
+        locked_app
+            .metadata
+            .insert("origin".to_string(), origin_uri.into());
+
+        for component in &mut locked_app.components {
+            self.resolve_component_content_refs(component, &client.cache)
+                .await
+                .with_context(|| {
+                    format!("failed to resolve content for component {:?}", component.id)
+                })?;
+        }
+        Ok(locked_app)
+    }
+
+    async fn resolve_component_content_refs(
+        &self,
+        component: &mut LockedComponent,
+        cache: &Cache,
+    ) -> Result<()> {
+        // Update wasm content path
+        let wasm_digest = content_digest(&component.source.content)?;
+        let wasm_path = cache.wasm_file(wasm_digest)?;
+        component.source.content = content_ref(wasm_path)?;
+
+        if !component.files.is_empty() {
+            let mount_dir = self.working_dir.join(&component.id);
+            for file in &mut component.files {
+                let digest = content_digest(&file.content)?;
+                let content_path = cache.data_file(digest)?;
+
+                ensure!(is_safe_to_join(&file.path), "invalid file mount {file:?}");
+                let mount_path = mount_dir.join(&file.path);
+
+                // Create parent directory
+                let mount_parent = mount_path
+                    .parent()
+                    .with_context(|| format!("invalid mount path {mount_path:?}"))?;
+                tokio::fs::create_dir_all(mount_parent)
+                    .await
+                    .with_context(|| {
+                        format!("failed to create temporary mount path {mount_path:?}")
+                    })?;
+
+                // Copy content
+                // TODO: parallelize
+                tokio::fs::copy(&content_path, &mount_path)
+                    .await
+                    .with_context(|| format!("failed to copy {content_path:?}->{mount_path:?}"))?;
+            }
+
+            component.files = vec![ContentPath {
+                content: content_ref(mount_dir)?,
+                path: "/".into(),
+            }]
+        }
+
+        Ok(())
+    }
+}
+
+fn content_digest(content_ref: &ContentRef) -> Result<&str> {
+    content_ref
+        .digest
+        .as_deref()
+        .with_context(|| format!("content missing expected digest: {content_ref:?}"))
+}
+
+fn content_ref(path: impl AsRef<Path>) -> Result<ContentRef> {
+    let path = std::fs::canonicalize(path)?;
+    let url = Url::from_file_path(path).map_err(|_| anyhow!("couldn't build file URL"))?;
+    Ok(ContentRef {
+        source: Some(url.to_string()),
+        ..Default::default()
+    })
+}
+
+fn is_safe_to_join(path: impl AsRef<Path>) -> bool {
+    // This could be loosened, but currently should always be true
+    path.as_ref()
+        .components()
+        .all(|c| matches!(c, std::path::Component::Normal(_)))
+}

--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -5,12 +5,10 @@ use std::path::PathBuf;
 use anyhow::{ensure, Context, Result};
 use async_trait::async_trait;
 use spin_app::{
-    locked::{ContentRef, LockedApp, LockedComponentSource},
+    locked::{LockedApp, LockedComponentSource},
     AppComponent, Loader,
 };
 use spin_core::StoreBuilder;
-use spin_loader::cache::Cache;
-use url::Url;
 
 use crate::parse_file_url;
 
@@ -77,122 +75,6 @@ impl Loader for TriggerLoader {
                 store_builder.read_only_preopened_dir(source_path, guest_path)?;
             }
         }
-        Ok(())
-    }
-}
-
-pub struct OciTriggerLoader {
-    working_dir: PathBuf,
-    allow_transient_write: bool,
-    cache: Cache,
-}
-
-impl OciTriggerLoader {
-    // TODO: support a different cache root directory
-    pub async fn new(
-        working_dir: impl Into<PathBuf>,
-        allow_transient_write: bool,
-        cache_root: Option<PathBuf>,
-    ) -> Result<Self> {
-        Ok(Self {
-            working_dir: working_dir.into(),
-            allow_transient_write,
-            cache: Cache::new(cache_root).await?,
-        })
-    }
-}
-
-#[async_trait]
-impl Loader for OciTriggerLoader {
-    // Read the locked app from the OCI cache and update the module source for each
-    // component with the path to the Wasm modules from the OCI cache.
-    async fn load_app(&self, url: &str) -> Result<LockedApp> {
-        let path = parse_file_url(url)?;
-        let contents =
-            std::fs::read(&path).with_context(|| format!("failed to read manifest at {path:?}"))?;
-
-        let app: LockedApp =
-            serde_json::from_slice(&contents).context("failed to parse app lock file JSON")?;
-
-        let mut res = app;
-        let mut components = Vec::new();
-
-        for mut c in res.components {
-            let digest =
-                c.clone().source.content.digest.expect(
-                    "locked application from OCI cache should have a digest for the source",
-                );
-
-            let url = Url::from_file_path(self.cache.wasm_file(digest)?.to_str().unwrap())
-                .expect("cannot crate file url from path for module source");
-
-            c.source.content = ContentRef {
-                digest: None,
-                source: Some(url.to_string()),
-            };
-
-            components.push(c);
-        }
-
-        res.components = components;
-
-        Ok(res)
-    }
-
-    async fn load_module(
-        &self,
-        engine: &spin_core::wasmtime::Engine,
-        source: &LockedComponentSource,
-    ) -> Result<spin_core::Module> {
-        let source = source
-            .content
-            .source
-            .as_ref()
-            .context("LockedComponentSource missing source field")?;
-        let path = parse_file_url(source)?;
-        spin_core::Module::from_file(engine, &path)
-            .with_context(|| format!("loading module {path:?}"))
-    }
-
-    // Copy static assets from the locked application into a temporary mount directory.
-    async fn mount_files(
-        &self,
-        store_builder: &mut StoreBuilder,
-        component: &AppComponent,
-    ) -> Result<()> {
-        let temp_mount = self.working_dir.join("files");
-        tokio::fs::create_dir_all(&temp_mount)
-            .await
-            .context("cannot create temporary mount directory")?;
-
-        for f in component.files() {
-            let src = self
-                .cache
-                .data_file(f.clone().content.digest.context(format!(
-                    "static asset {:?} from OCI cache must have a digest",
-                    f
-                ))?)?;
-            let dst = temp_mount.join(&f.path);
-            let parent = dst.parent().context(format!(
-                "path for static asset mount path {:?} must have a parent directory",
-                dst
-            ))?;
-
-            tokio::fs::create_dir_all(&parent)
-                .await
-                .context("cannot create directory structure for temporary mounts")?;
-            tracing::trace!("Attempting to copy {:?}->{:?}", src, dst);
-            tokio::fs::copy(&src, &dst)
-                .await
-                .context("cannot copy file mount")?;
-        }
-
-        if self.allow_transient_write {
-            store_builder.read_write_preopened_dir(temp_mount, "/".into())?;
-        } else {
-            store_builder.read_only_preopened_dir(temp_mount, "/".into())?
-        }
-
         Ok(())
     }
 }


### PR DESCRIPTION
The main change here is to prepare the file mounts before calling the trigger executor, like local and bindle apps do.