### PR TITLE
Validate allowed key-value stores

### DIFF
--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cache;
 mod common;
 pub mod digest;
 pub mod local;
+mod validation;
 
 /// Load a Spin application configuration from a spin.toml manifest file.
 pub use local::from_file;

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -28,7 +28,10 @@ use spin_manifest::{
 };
 use tokio::{fs::File, io::AsyncReadExt};
 
-use crate::{bindle::BindleConnectionInfo, cache::Cache, digest::bytes_sha256_string};
+use crate::{
+    bindle::BindleConnectionInfo, cache::Cache, digest::bytes_sha256_string,
+    validation::validate_key_value_stores,
+};
 use config::{
     FileComponentUrlSource, RawAppInformation, RawAppManifest, RawAppManifestAnyVersion,
     RawAppManifestAnyVersionPartial, RawComponentManifest, RawComponentManifestPartial,
@@ -126,6 +129,10 @@ pub fn validate_raw_app_manifest(raw: &RawAppManifestAnyVersion) -> Result<()> {
         .components
         .iter()
         .try_for_each(|c| validate_allowed_http_hosts(&c.wasm.allowed_http_hosts))?;
+    manifest
+        .components
+        .iter()
+        .try_for_each(|c| validate_key_value_stores(&c.wasm.key_value_stores))?;
 
     if raw
         .as_v1()

--- a/crates/loader/src/validation.rs
+++ b/crates/loader/src/validation.rs
@@ -1,0 +1,48 @@
+use anyhow::{anyhow, Result};
+
+const ONLY_ALLOWED_KV_STORE: &str = "default";
+
+pub(crate) fn validate_key_value_stores(key_value_stores: &Option<Vec<String>>) -> Result<()> {
+    match key_value_stores
+        .iter()
+        .flatten()
+        .find(|id| *id != ONLY_ALLOWED_KV_STORE)
+    {
+        None => Ok(()),
+        Some(invalid) => {
+            let err = anyhow!("Invalid key-value store '{invalid}'. This version of Spin supports only the '{ONLY_ALLOWED_KV_STORE}' store.");
+            Err(err)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn kv_empty_list_is_allowed() {
+        validate_key_value_stores(&None).expect("None should be valid");
+        validate_key_value_stores(&Some(vec![])).expect("Empty vector should be valid");
+    }
+
+    #[test]
+    fn default_store_is_allowed() {
+        validate_key_value_stores(&Some(vec!["default".to_owned()]))
+            .expect("Default store should be valid");
+        validate_key_value_stores(&Some(vec!["default".to_owned(), "default".to_owned()]))
+            .expect("Default store twice should be valid");
+    }
+
+    #[test]
+    fn non_default_store_is_not_allowed() {
+        validate_key_value_stores(&Some(vec!["hello".to_owned()]))
+            .expect_err("'hello' store should be invalid");
+    }
+
+    #[test]
+    fn no_sneaky_hiding_non_default_store_behind_default_one() {
+        validate_key_value_stores(&Some(vec!["default".to_owned(), "hello".to_owned()]))
+            .expect_err("'hello' store should be invalid");
+    }
+}

--- a/tests/testcases/key-value/spin.toml
+++ b/tests/testcases/key-value/spin.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 
 [[component]]
 id = "hello"
-key_value_stores = ["default", "foo"]
+key_value_stores = ["default"]
 source = "target/wasm32-wasi/release/key_value.wasm"
 [component.trigger]
 route = "/..."

--- a/tests/testcases/key-value/src/lib.rs
+++ b/tests/testcases/key-value/src/lib.rs
@@ -7,7 +7,8 @@ use spin_sdk::{
 
 #[http_component]
 fn handle_request(_req: Request) -> Result<Response> {
-    ensure!(matches!(Store::open("foo"), Err(Error::NoSuchStore)));
+    // TODO: once we allow users to pass non-default stores, test that opening
+    // an allowed-but-non-existent one returns Error::NoSuchStore
     ensure!(matches!(Store::open("forbidden"), Err(Error::AccessDenied)));
 
     let store = Store::open_default()?;


### PR DESCRIPTION
Fixes #1232.

```
$ spin up
Error: Invalid key-value store 'hello'. This version of Spin supports only the 'default' store.

$ spin deploy
Error: Invalid key-value store 'hello'. This version of Spin supports only the 'default' store.

Learn more at https://developer.fermyon.com/cloud/faq
```

Unlike `allowed_http_hosts`, this implementation puts the validation logic in the loader, rather than putting it with the `key-value` component and adding a crate reference.  I did this solely to avoid making `loader` dependent on EVEN MOAR things.  It does risk a maintenance burden; if we ever need more sophisticated parsing and validation logic for these IDs, then it's probably worth doing it in the host component and taking the dependency.  Happy to do that now if people feel it's better.