### PR TITLE
Change base path for key value example app

### DIFF
--- a/examples/rust-key-value/spin.toml
+++ b/examples/rust-key-value/spin.toml
@@ -2,7 +2,7 @@ spin_version = "1"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 description = "A simple application that exercises key-value storage."
 name = "spin-key-value"
-trigger = {type = "http", base = "/test"}
+trigger = { type = "http", base = "/" }
 version = "1.0.0"
 
 [[component]]


### PR DESCRIPTION
Changes this to set base of the path to `/`. Previously was `/test` possibly due to similar implementation as integration test app. Also, makes it so not all keys are prefixed with `/test` since they are pulled from the URL path.