### PR TITLE
In `spin plugin list`, do not print prerelease warnings ahead of list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -1325,7 +1325,7 @@ checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "e2e-testing"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
@@ -4274,7 +4274,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-abi-conformance"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "spin-bindle"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bindle",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "indexmap",
  "serde",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/plugins/src/manager.rs
+++ b/crates/plugins/src/manager.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::*,
     lookup::PluginLookup,
-    manifest::{check_supported_version, PluginManifest, PluginPackage},
+    manifest::{warn_unsupported_version, PluginManifest, PluginPackage},
     store::PluginStore,
     SPIN_INTERNAL_COMMANDS,
 };
@@ -130,7 +130,7 @@ impl PluginManager {
             }
         }
 
-        check_supported_version(plugin_manifest, spin_version, override_compatibility_check)?;
+        warn_unsupported_version(plugin_manifest, spin_version, override_compatibility_check)?;
 
         Ok(InstallAction::Continue)
     }

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -1,6 +1,6 @@
 use crate::opts::PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG;
 use anyhow::{anyhow, Result};
-use spin_plugins::{error::Error, manifest::check_supported_version, PluginStore};
+use spin_plugins::{error::Error, manifest::warn_unsupported_version, PluginStore};
 use std::{collections::HashMap, env, process};
 use tokio::process::Command;
 use tracing::log;
@@ -42,7 +42,7 @@ pub async fn execute_external_subcommand(
         Ok(manifest) => {
             let spin_version = env!("VERGEN_BUILD_SEMVER");
             if let Err(e) =
-                check_supported_version(&manifest, spin_version, override_compatibility_check)
+                warn_unsupported_version(&manifest, spin_version, override_compatibility_check)
             {
                 eprintln!("{e}");
                 process::exit(1);


### PR DESCRIPTION
Fixes #1263.

The output with a prerelease is now:

```
# Catalogue
$ spin plugins list
arm-only 0.1.0 [incompatible]
js2wasm 0.1.0
js2wasm 0.2.0
js2wasm 0.3.0 [installed]
js2wasm 0.4.0
not-spin-ver 9.1.0 [incompatible]
not-spin-ver 10.2.0
py2wasm 0.1.0 [installed]
trigger-armstuff 0.1.0 [incompatible]
trigger-madeup 0.1.0
windows-only 0.1.0 [incompatible]

# Installed
$ spin plugins list --installed
js2wasm 0.3.0 [installed]
pluginify 0.3 [installed]
py2wasm 0.1.0 [installed]
timer 0.1.0 [installed]
trigger-composite 0.3 [installed]
trigger-sqs 0.2 [installed]
trigger-timer 0.1.0 [installed]

# Making sure we still get a warning when actually executing a plugin
$ spin js2wasm
You're using a pre-release version of Spin (1.0.0-pre0). This plugin might not be compatible (supported: >=0.7). Continuing anyway.
error: The following required arguments were not provided:
    <input>

USAGE:
    js2wasm <input> -o <output>
```

Note that the compatibility status errs on the side of liberal. As the check function allows any plugin to run on a prerelease, the list treats it as "everything is compatible."  We could be strict - the downside then is that pretty much _every_ plugin would then say `[requires other Spin version]` which is a bit discouraging.  Happy to discuss or change though!

Also: I renamed some existing functions to make it clearer that they were about interactively _warning_ about version compatibility, not just about _checking_ it.