### PR TITLE
ci(release.yml): sign binaries with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,14 @@ on:
       - "v*"
 
 jobs:
-  build:
-    name: build release assets
+  build-and-sign:
+    name: build and sign release assets
     runs-on: ${{ matrix.config.os }}
+    permissions:
+      # cosign uses the GitHub OIDC token
+      id-token: write
+      # needed to upload artifacts to a GH release
+      contents: write
     strategy:
       matrix:
         config:
@@ -74,6 +79,11 @@ jobs:
           OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
           echo "RUNNER_OS=$OS" >> $GITHUB_ENV
 
+      - name: Install Cosign for signing Spin binary
+        uses: sigstore/cosign-installer@v3.0.1
+        with:
+          cosign-release: v2.0.0
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -98,22 +108,36 @@ jobs:
           command: build
           args: "--all-features --release ${{ matrix.config.extraArgs }}"
 
+      - name: Sign the binary with GitHub OIDC token
+        shell: bash
+        run: |
+          cosign sign-blob \
+            --yes \
+            --output-certificate crt.pem \
+            --output-signature spin.sig \
+            ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }}
+
       - name: package release assets
         if: runner.os != 'Windows'
+        shell: bash
         run: |
           mkdir _dist
-          cp README.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
+          cp crt.pem spin.sig README.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
           cd _dist
-          tar czf spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz README.md LICENSE spin${{ matrix.config.extension }}
+          tar czf \
+            spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz \
+            crt.pem spin.sig README.md LICENSE spin${{ matrix.config.extension }}
 
       - name: package release assets
         if: runner.os == 'Windows'
         shell: bash
         run: |
           mkdir _dist
-          cp README.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
+          cp crt.pem spin.sig README.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
           cd _dist
-          7z a -tzip spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip README.md LICENSE spin${{ matrix.config.extension }}
+          7z a -tzip \
+            spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip \
+            crt.pem spin.sig README.md LICENSE spin${{ matrix.config.extension }}
 
       - name: upload binary as GitHub artifact
         if: runner.os != 'Windows'
@@ -148,7 +172,7 @@ jobs:
   checksums:
     name: generate release checksums
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-and-sign
     steps:
       - name: set the release version (tag)
         if: startsWith(github.ref, 'refs/tags/v')
@@ -214,7 +238,7 @@ jobs:
   create-go-sdk-tag:
     name: create tag sdk/go/v*
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-and-sign
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v3
@@ -273,7 +297,7 @@ jobs:
   # This will run when the PR above is approved and merged into main via a merge commit
   push-templates-tag:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-and-sign
     if: github.event.commits[0].author.name == 'fermybot' && contains(github.event.commits[0].message, 'update sdk')
     steps:
       - uses: actions/checkout@v3

--- a/docs/content/release-process.md
+++ b/docs/content/release-process.md
@@ -39,6 +39,10 @@ To cut a release of Spin, you will need to do the following:
    that this tag may be force-pushed for all patch releases of a given minor release.)
 1. Go to the GitHub [tags page](https://github.com/fermyon/spin/releases),
    edit a release, add the release notes.
+1. Be sure to include instructions for
+   [verifying the signed Spin binary](./sips/012-signing-spin-releases.md). The
+   `--certificate-identity` value should match this release, e.g.
+   `https://github.com/fermyon/spin/.github/workflows/release.yml@refs/tags/0.11.0`.
 
 At this point, you can verify in the GitHub UI that the release was successful.
 


### PR DESCRIPTION
- implements signing spin binaries for a given release per [SIP 012](https://github.com/fermyon/spin/pull/1217)

In this approach, we sign only the spin binary as opposed to the entire archive.  In doing so, we can include the .sig and .pem files in the same archive.

A few sample test runs: main/`canary` [here](https://github.com/vdice/spin/actions/runs/4419263141) and a `v*` tag [here](https://github.com/vdice/spin/actions/runs/4420071754).