### PR TITLE
Fix direct mounts backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -1325,7 +1325,7 @@ checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "e2e-testing"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
@@ -4274,7 +4274,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-abi-conformance"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "spin-bindle"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bindle",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "indexmap",
  "serde",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/loader/src/local/assets.rs
+++ b/crates/loader/src/local/assets.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use futures::{future, stream, StreamExt};
+use path_absolutize::Absolutize;
 use spin_manifest::DirectoryMount;
 use std::{
     path::{Path, PathBuf},
@@ -72,7 +73,7 @@ fn prepare_component_with_direct_mounts(
                     .to_str()
                     .context("unable to parse mount destination as UTF-8")?
                     .to_owned(),
-                host: placement.source.clone(),
+                host: placement.source.absolutize()?.into(),
             }),
             RawFileMount::Pattern(_) => Err(anyhow!(
                 "this component cannot be run with `--direct-mount` because it uses file patterns"

--- a/tests/http/headers-env-routes-test/Cargo.lock
+++ b/tests/http/headers-env-routes-test/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.0.0-rc.1"
+version = "1.0.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Backport https://github.com/fermyon/spin/pull/1270

Also commit some `Cargo.lock`s that `rust-analyzer` really wanted to update.