### PR TITLE
Print digest on registry push

### DIFF
--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -42,8 +42,13 @@ impl Client {
         Ok(Self { oci: client, cache })
     }
 
-    /// Push a Spin application to an OCI registry.
-    pub async fn push(&mut self, app: &Application, reference: impl AsRef<str>) -> Result<()> {
+    /// Push a Spin application to an OCI registry and return the digest (or None
+    /// if the digest cannot be determined).
+    pub async fn push(
+        &mut self,
+        app: &Application,
+        reference: impl AsRef<str>,
+    ) -> Result<Option<String>> {
         let reference: Reference = reference
             .as_ref()
             .parse()
@@ -138,7 +143,8 @@ impl Client {
 
         tracing::info!("Pushed {:?}", response);
 
-        Ok(())
+        let digest = digest_from_url(&response);
+        Ok(digest)
     }
 
     /// Pull a Spin application from an OCI registry.
@@ -352,5 +358,32 @@ impl Client {
             protocol,
             ..Default::default()
         }
+    }
+}
+
+fn digest_from_url(manifest_url: &str) -> Option<String> {
+    // The URL is in the form "https://host/v2/refname/manifests/sha256:..."
+    let manifest_url = Url::parse(manifest_url).ok()?;
+    let segments = manifest_url.path_segments()?;
+    let last = segments.last()?;
+    if last.contains(':') {
+        Some(last.to_owned())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn can_parse_digest_from_manifest_url() {
+        let manifest_url = "https://ghcr.io/v2/itowlson/osf/manifests/sha256:0a867093096e0ef01ef749b12b6e7a90e4952eda107f89a676eeedce63a8361f";
+        let digest = digest_from_url(manifest_url).unwrap();
+        assert_eq!(
+            "sha256:0a867093096e0ef01ef749b12b6e7a90e4952eda107f89a676eeedce63a8361f",
+            digest
+        );
     }
 }

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -61,7 +61,13 @@ impl Push {
         let app = spin_loader::local::from_file(&app_file, Some(dir.path()), &None).await?;
 
         let mut client = spin_oci::Client::new(self.insecure, None).await?;
-        client.push(&app, &self.reference).await?;
+        let digest = client.push(&app, &self.reference).await?;
+
+        match digest {
+            Some(digest) => println!("Pushed with digest {digest}"),
+            None => println!("Pushed; the registry did not return the digest"),
+        };
+
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #1267.

```
$ spin registry push ghcr.io/itowlson/osf:v1.3
Pushed with digest sha256:05fe91ed63884099819ccd92e6d031999c62423fa7c2c8021b90d39d8adadfa1
```

@radu-matei Please confirm the logic is sound or if there is a better way! This was kind of me reverse engineering from the response...

![image](https://user-images.githubusercontent.com/865538/225195421-1177dfa9-008e-4c69-8bc4-28cbe0a55b3a.png)
