### PR TITLE
 ci: Add backport workflow 

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,32 @@
+name: Backport pull request
+on:
+  pull_request_target:
+    types: [closed]
+  issue_comment:
+    types: [created]
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+
+    # Only run when pull request is merged
+    # or when a comment containing `/backport` is created by someone other than the 
+    # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
+    # own PAT as `github_token`, that you should replace this id with yours.
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 97796249 &&
+        contains(github.event.comment.body, '/backport')
+      )
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v1


### PR DESCRIPTION
This will allow merged PRs to be automatically backported to a release
branch via either a label (before the original PR is merged) or a
comment.

Uses:
https://github.com/marketplace/actions/backport-merged-pull-requests-to-selected-branches