### PR TITLE
[Backport v1.0] In `spin plugin list`, do not print prerelease warnings ahead of list

### DIFF
--- a/crates/plugins/src/manager.rs
+++ b/crates/plugins/src/manager.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::*,
     lookup::PluginLookup,
-    manifest::{check_supported_version, PluginManifest, PluginPackage},
+    manifest::{warn_unsupported_version, PluginManifest, PluginPackage},
     store::PluginStore,
     SPIN_INTERNAL_COMMANDS,
 };
@@ -130,7 +130,7 @@ impl PluginManager {
             }
         }
 
-        check_supported_version(plugin_manifest, spin_version, override_compatibility_check)?;
+        warn_unsupported_version(plugin_manifest, spin_version, override_compatibility_check)?;
 
         Ok(InstallAction::Continue)
     }

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -1,6 +1,6 @@
 use crate::opts::PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG;
 use anyhow::{anyhow, Result};
-use spin_plugins::{error::Error, manifest::check_supported_version, PluginStore};
+use spin_plugins::{error::Error, manifest::warn_unsupported_version, PluginStore};
 use std::{collections::HashMap, env, process};
 use tokio::process::Command;
 use tracing::log;
@@ -42,7 +42,7 @@ pub async fn execute_external_subcommand(
         Ok(manifest) => {
             let spin_version = env!("VERGEN_BUILD_SEMVER");
             if let Err(e) =
-                check_supported_version(&manifest, spin_version, override_compatibility_check)
+                warn_unsupported_version(&manifest, spin_version, override_compatibility_check)
             {
                 eprintln!("{e}");
                 process::exit(1);


### PR DESCRIPTION
Backporting #1264 to v1.0