### PR TITLE
fix(cli): Rename --key-values to --key-value on deploy command

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -95,7 +95,8 @@ pub struct DeployCommand {
     pub deployment_env_id: Option<String>,
 
     /// Pass a key/value (key=value) to all components of the application.
-    #[clap(long, parse(try_from_str = parse_kv))]
+    /// Can be used multiple times.
+    #[clap(long = "key-value", parse(try_from_str = parse_kv))]
     pub key_values: Vec<(String, String)>,
 }
 


### PR DESCRIPTION
The flag `--key-values` only accepts a single key/value but can be used multiple times.  This changes the flag name and adds help text.