### PR TITLE
parallelize oci pulls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,9 +3347,11 @@ dependencies = [
 
 [[package]]
 name = "oci-distribution"
-version = "0.9.3"
-source = "git+https://github.com/radu-matei/oci-distribution?branch=update-dockerhub-default-registry#f2cdd28637609009ee565b9410fc0b6eaa83e822"
+version = "0.10.0"
+source = "git+https://github.com/krustlet/oci-distribution?rev=64986855ef0d692df3b270d23c4bee8c41d97c27#64986855ef0d692df3b270d23c4bee8c41d97c27"
 dependencies = [
+ "chrono",
+ "futures",
  "futures-util",
  "http",
  "http-auth",
@@ -3363,6 +3365,7 @@ dependencies = [
  "sha2 0.10.6",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.7",
  "tracing",
  "unicase",
 ]
@@ -5128,6 +5131,7 @@ dependencies = [
  "dirs 4.0.0",
  "dkregistry",
  "docker_credential",
+ "futures-util",
  "oci-distribution",
  "reqwest",
  "serde",
@@ -5734,6 +5738,7 @@ checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -10,7 +10,8 @@ base64 = "0.21"
 dkregistry = { git = "https://github.com/camallo/dkregistry-rs", rev = "37acecb4b8139dd1b1cc83795442f94f90e1ffc5" }
 docker_credential = "1.0"
 dirs = "4.0"
-oci-distribution = { git = "https://github.com/radu-matei/oci-distribution", branch = "update-dockerhub-default-registry" }
+futures-util = "0.3"
+oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "64986855ef0d692df3b270d23c4bee8c41d97c27" }
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This PR switches the source for `oci-distribution` to a fork that implements parallelized push as well. This PR also deals with the issue of writing errors in the OCI cache.