### PR TITLE
Suggestion: allow SDK users to extract sender IP address and port

### DIFF
--- a/crates/abi-conformance/src/lib.rs
+++ b/crates/abi-conformance/src/lib.rs
@@ -207,6 +207,7 @@ fn run_command(
                             uri: "/",
                             headers: &[],
                             params: &[],
+                            client_addr: "",
                             body: Some(&serde_json::to_vec(arguments)?),
                         },
                     )

--- a/crates/abi-conformance/src/spin_http.rs
+++ b/crates/abi-conformance/src/spin_http.rs
@@ -17,6 +17,7 @@ pub(super) fn test(store: &mut Store<Context>, pre: &InstancePre<Context>) -> Re
                 uri: "/foo",
                 headers: &[("foo", "bar")],
                 params: &[],
+                client_addr: "",
                 body: Some(b"Hello, SpinHttp!"),
             },
         )?;

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -23,7 +23,7 @@ impl HttpExecutor for SpinHttpExecutor {
         base: &str,
         raw_route: &str,
         req: Request<Body>,
-        _client_addr: SocketAddr,
+        client_addr: SocketAddr,
     ) -> Result<Response<Body>> {
         tracing::trace!(
             "Executing request using the Spin executor for component {}",
@@ -32,7 +32,7 @@ impl HttpExecutor for SpinHttpExecutor {
 
         let (instance, store) = engine.prepare_instance(component_id).await?;
 
-        let resp = Self::execute_impl(store, instance, base, raw_route, req)
+        let resp = Self::execute_impl(store, instance, base, raw_route, req, client_addr)
             .await
             .map_err(contextualise_err)?;
 
@@ -51,6 +51,7 @@ impl SpinHttpExecutor {
         base: &str,
         raw_route: &str,
         req: Request<Body>,
+        client_addr: SocketAddr,
     ) -> Result<Response<Body>> {
         let headers;
         let mut req = req;
@@ -91,6 +92,7 @@ impl SpinHttpExecutor {
             uri: &uri,
             headers: &headers,
             params: &params,
+            client_addr: &client_addr.to_string(),
             body,
         };
 

--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -55,6 +55,11 @@ pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     .method(spin_req.method)
                     .uri(&spin_req.uri);
 
+                let client_addr = spin_req.client_addr.parse::<std::net::SocketAddr>().ok();
+                if let Some(extensions) = http_req.extensions_mut() {
+                    extensions.insert(client_addr);
+                }
+
                 append_request_headers(&mut http_req, &spin_req)?;
 
                 let body = match spin_req.body {

--- a/sdk/rust/macro/wit/spin-http.wit
+++ b/sdk/rust/macro/wit/spin-http.wit
@@ -41,6 +41,7 @@ record request {
     uri: uri,
     headers: headers,
     params: params,
+    client-addr: string,
     body: option<body>,
 }
 

--- a/sdk/rust/src/outbound_http.rs
+++ b/sdk/rust/src/outbound_http.rs
@@ -26,12 +26,19 @@ pub fn send_request(req: Request) -> Result<Response> {
         .map(try_header_to_strs)
         .collect::<Result<Vec<_>>>()?;
 
+    let client_addr = req
+        .extensions
+        .get::<std::net::SocketAddr>()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+
     let body = body.as_ref().map(|bytes| bytes.as_ref());
 
     let out_req = OutboundRequest {
         method,
         uri: &uri,
         params: &params,
+        client_addr: &client_addr,
         headers,
         body,
     };

--- a/wit/ephemeral/http-types.wit
+++ b/wit/ephemeral/http-types.wit
@@ -38,6 +38,7 @@ record request {
     uri: uri,
     headers: headers,
     params: params,
+    client-addr: string,
     body: option<body>,
 }
 


### PR DESCRIPTION
I looked for a way how to extract the sender IP via Spin SDK for my geolocation based demo (https://country-counter-spin-9h0lzjiq.fermyon.app/), and since I learned on your Discord it's not exposed yet, here's my humble suggestion to add it, in form of a pull request :innocent: The information about who sent the request is already there as an ignored parameter, so a fair part of this PR is just passing this parameter through all the layers.

With this PR, the SDK becomes aware that the request struct holds the sender's IP address as well.
The address is stored as `Option<std::net::SocketAddr>` and is kept in the request as an http::Request extension: https://docs.rs/http/0.2.9/http/struct.Extensions.html

It can be used in client code as follows:
```rust
fn handle_request(req: Request) -> Result<Response> {
    println!("Sender address: {:?}", req.extensions().get::<Option<std::net::SocketAddr>>());
    (...)
```
It probably makes sense to wrap `std::net::SocketAddr` in a spin-specific struct to make the API more self-descriptive, but I didn't want to touch the existing API at all, as I'm totally new in this codebase.

I tested the PR by rebuilding `spin` locally, and then using the modified SDK in my demo - and I observed that the sender's IP address was properly exposed.

Please let me know if it makes any sense, thanks! And note that I haven't touched the sdk/go part of your codebase, as I don't speak go.