### PR TITLE
http: add spin-client-addr header

### DIFF
--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -111,7 +111,9 @@ impl HttpExecutor for WagiHttpExecutor {
         // This sets the current environment variables Wagi expects (such as
         // `PATH_INFO`, or `X_FULL_URL`).
         // Note that this overrides any existing headers previously set by Wagi.
-        for (keys, val) in crate::compute_default_headers(&parts.uri, raw_route, base, host)? {
+        for (keys, val) in
+            crate::compute_default_headers(&parts.uri, raw_route, base, host, client_addr)?
+        {
             headers.insert(keys[1].to_string(), val);
         }
 


### PR DESCRIPTION
Inspired by the outcome of #1297, this commit adds a `spin-client-addr` header, which exposes the sender's IP address of a request to SDK users.