### PR TITLE
[Backport v1.0] fix(cli): Rename --key-values to --key-value on deploy command

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -95,7 +95,8 @@ pub struct DeployCommand {
     pub deployment_env_id: Option<String>,
 
     /// Pass a key/value (key=value) to all components of the application.
-    #[clap(long, parse(try_from_str = parse_kv))]
+    /// Can be used multiple times.
+    #[clap(long = "key-value", parse(try_from_str = parse_kv))]
     pub key_values: Vec<(String, String)>,
 }
 


### PR DESCRIPTION
Backporting #1295 to v1.0