### PR TITLE
chore(release.yml): bump delete-tag-and-release action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
           name: spin
 
       - name: Delete canary tag
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The action we currently use to delete a tag and release (for updating canary) has removed all previous releases save this latest [v0.2.1](https://github.com/dev-drprasad/delete-tag-and-release/releases/tag/v0.2.1) version ☹️

My gut reaction was that something shifty was going on but the commits look fine...

Very open to suggestions for replacement.  As it stands, bumping to v0.2.1 should unblock updating canary.