### PR TITLE
[Backport v1.0] fix typo in error message /cannnot/cannot/

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -220,7 +220,7 @@ impl LoginCommand {
         let path = self.config_file_path()?;
         let data = fs::read_to_string(&path)
             .await
-            .context("Cannnot display login information")?;
+            .context("Cannot display login information")?;
         println!("{}", data);
         Ok(())
     }


### PR DESCRIPTION
Backporting #1308 to v1.0