### PR TITLE
chore(docs): bump spin version

### DIFF
--- a/deploy/publish-spin-docs.nomad
+++ b/deploy/publish-spin-docs.nomad
@@ -32,9 +32,9 @@ job "publish-spin-docs" {
       driver = "exec"
 
       artifact {
-        source = "https://github.com/fermyon/spin/releases/download/v0.8.0/spin-v0.8.0-linux-amd64.tar.gz"
+        source = "https://github.com/fermyon/spin/releases/download/v0.10.1/spin-v0.10.1-linux-amd64.tar.gz"
         options {
-          checksum = "sha256:0ef31fe6e2b4d34ddd089b01a1f88820f88c456276bfe4e1477836a6087654c1"
+          checksum = "sha256:105054335fd76b3d2a1b76a705dbdb3b83d7e4093b302a7816ce7f922893f29d"
         }
       }
 

--- a/deploy/spin-docs.nomad
+++ b/deploy/spin-docs.nomad
@@ -99,9 +99,9 @@ job "spin-docs" {
       driver = "exec"
 
       artifact {
-        source = "https://github.com/fermyon/spin/releases/download/v0.8.0/spin-v0.8.0-linux-amd64.tar.gz"
+        source =  "https://github.com/fermyon/spin/releases/download/v0.10.1/spin-v0.10.1-linux-amd64.tar.gz"
         options {
-          checksum = "sha256:0ef31fe6e2b4d34ddd089b01a1f88820f88c456276bfe4e1477836a6087654c1"
+          checksum = "sha256:105054335fd76b3d2a1b76a705dbdb3b83d7e4093b302a7816ce7f922893f29d"
         }
       }
 

--- a/docs/spin.toml
+++ b/docs/spin.toml
@@ -1,5 +1,5 @@
+spin_manifest_version = "1"
 name = "spin-docs"
-spin_version = "1"
 version = "0.1.0"
 description = "The Spin documentation website running on... Spin."
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]


### PR DESCRIPTION
Bump the version of Spin used by docs and fix a lingering `spin_version` -> `spin_manifest_version`