### PR TITLE
Regenerate cargo vet exemptions

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -12,8 +12,30 @@ criteria = "safe-to-deploy"
 delta = "1.0.65 -> 1.0.68"
 notes = "CI and test updates plus minor Rust efficiency improvements."
 
+[[audits.oorandom]]
+who = "Radu Matei <radu.matei@fermyon.com>"
+criteria = "safe-to-run"
+version = "11.1.3"
+
+[[audits.plotters-svg]]
+who = "Radu Matei <radu.matei@fermyon.com>"
+criteria = "safe-to-run"
+version = "0.3.3"
+
 [[audits.regalloc2]]
 who = "Radu Matei <radu.matei@fermyon.com>"
 criteria = "safe-to-deploy"
 version = "0.3.1"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[audits.wasmtime-asm-macros]]
+who = "Radu Matei <radu.matei@fermyon.com>"
+criteria = "safe-to-deploy"
+delta = "5.0.0 -> 5.0.1"
+notes = "The version bump does not have any functional change for the wasmtime-asm-macros crate."
+
+[[audits.wasmtime-cache]]
+who = "Radu Matei <radu.matei@fermyon.com>"
+criteria = "safe-to-deploy"
+delta = "5.0.0 -> 5.0.1"
+notes = "The version bump does not have any functional change for the wasmtime-cache crate."

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,6 +1,9 @@
 
 # cargo-vet config file
 
+[cargo-vet]
+version = "0.5"
+
 [imports.bytecodealliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
 
@@ -69,16 +72,28 @@ criteria = "safe-to-deploy"
 version = "0.3.15"
 criteria = "safe-to-deploy"
 
+[[exemptions.async-priority-channel]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-recursion]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.async-stream]]
-version = "0.3.3"
+version = "0.3.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-stream-impl]]
-version = "0.3.3"
+version = "0.3.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-trait]]
-version = "0.1.64"
+version = "0.1.66"
+criteria = "safe-to-deploy"
+
+[[exemptions.atomic-take]]
+version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.base64]]
@@ -109,40 +124,44 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.block-buffer]]
+version = "0.10.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.blowfish]]
 version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.borsh]]
-version = "0.9.3"
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.borsh-derive]]
-version = "0.9.3"
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.borsh-derive-internal]]
-version = "0.9.3"
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.borsh-schema-derive-internal]]
-version = "0.9.3"
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.bstr]]
-version = "0.2.17"
-criteria = "safe-to-run"
+version = "1.4.0"
+criteria = "safe-to-deploy"
 
-[[exemptions.bumpalo]]
-version = "3.12.0"
+[[exemptions.btoi]]
+version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytecheck]]
-version = "0.6.9"
+version = "0.6.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytecheck_derive]]
-version = "0.6.9"
+version = "0.6.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.byteorder]]
@@ -193,6 +212,10 @@ criteria = "safe-to-deploy"
 version = "0.2.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.clearscreen]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.colored]]
 version = "2.0.0"
 criteria = "safe-to-deploy"
@@ -203,6 +226,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.comfy-table]]
 version = "5.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.command-group]]
+version = "2.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.console]]
@@ -226,39 +253,39 @@ version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-bforest]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-codegen]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-codegen-meta]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-codegen-shared]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-entity]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-frontend]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-isle]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-native]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cranelift-wasm]]
-version = "0.92.0"
+version = "0.92.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.crc32fast]]
@@ -278,23 +305,19 @@ version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-channel]]
-version = "0.5.6"
+version = "0.5.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-deque]]
-version = "0.8.2"
+version = "0.8.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-epoch]]
-version = "0.9.13"
-criteria = "safe-to-deploy"
-
-[[exemptions.crossbeam-queue]]
-version = "0.3.8"
+version = "0.9.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-utils]]
-version = "0.8.14"
+version = "0.8.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossterm]]
@@ -306,7 +329,7 @@ version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.csv]]
-version = "1.1.6"
+version = "1.2.1"
 criteria = "safe-to-run"
 
 [[exemptions.csv-core]]
@@ -314,7 +337,7 @@ version = "0.1.10"
 criteria = "safe-to-run"
 
 [[exemptions.ctrlc]]
-version = "3.2.4"
+version = "3.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.curve25519-dalek]]
@@ -322,31 +345,31 @@ version = "3.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cxx]]
-version = "1.0.88"
+version = "1.0.92"
 criteria = "safe-to-deploy"
 
 [[exemptions.cxx-build]]
-version = "1.0.88"
+version = "1.0.92"
 criteria = "safe-to-deploy"
 
 [[exemptions.cxxbridge-flags]]
-version = "1.0.88"
+version = "1.0.92"
 criteria = "safe-to-deploy"
 
 [[exemptions.cxxbridge-macro]]
-version = "1.0.88"
+version = "1.0.92"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling]]
-version = "0.14.2"
+version = "0.14.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_core]]
-version = "0.14.2"
+version = "0.14.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.darling_macro]]
-version = "0.14.2"
+version = "0.14.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.derive_builder]]
@@ -430,11 +453,11 @@ version = "0.3.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.enum-iterator]]
-version = "1.2.0"
+version = "1.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.enum-iterator-derive]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.env_logger]]
@@ -449,6 +472,10 @@ criteria = "safe-to-deploy"
 version = "0.1.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.event-listener]]
+version = "2.5.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.fallible-iterator]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
@@ -457,16 +484,12 @@ criteria = "safe-to-deploy"
 version = "0.1.9"
 criteria = "safe-to-deploy"
 
-[[exemptions.fastrand]]
-version = "1.8.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.file-per-thread-logger]]
 version = "0.1.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.filetime]]
-version = "0.2.19"
+version = "0.2.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.flate2]]
@@ -510,7 +533,11 @@ version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.fs_extra]]
-version = "1.2.0"
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fsevent-sys]]
+version = "4.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.funty]]
@@ -574,15 +601,75 @@ version = "0.26.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.git2]]
-version = "0.15.0"
+version = "0.16.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-actor]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-config]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-config-value]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-date]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-features]]
+version = "0.28.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-glob]]
+version = "0.5.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-hash]]
+version = "0.10.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-lock]]
+version = "5.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-object]]
+version = "0.28.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-path]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-ref]]
+version = "0.27.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-sec]]
+version = "0.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-tempfile]]
+version = "5.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.gix-validate]]
+version = "0.7.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.glob]]
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.globset]]
+version = "0.4.10"
+criteria = "safe-to-deploy"
+
 [[exemptions.h2]]
-version = "0.3.15"
+version = "0.3.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.hashbrown]]
@@ -605,6 +692,10 @@ criteria = "safe-to-deploy"
 version = "0.1.19"
 criteria = "safe-to-deploy"
 
+[[exemptions.hermit-abi]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.hippo-openapi]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
@@ -614,7 +705,7 @@ version = "0.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.http]]
-version = "0.2.8"
+version = "0.2.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.http-auth]]
@@ -638,7 +729,7 @@ version = "2.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper]]
-version = "0.14.23"
+version = "0.14.25"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-rustls]]
@@ -661,8 +752,24 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.ignore]]
+version = "0.4.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.ignore-files]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.indexmap]]
 version = "1.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.inotify]]
+version = "0.9.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.inotify-sys]]
+version = "0.1.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.instant]]
@@ -670,7 +777,7 @@ version = "0.1.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.io-lifetimes]]
-version = "1.0.4"
+version = "1.0.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.ipnet]]
@@ -678,7 +785,7 @@ version = "2.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.is-terminal]]
-version = "0.4.2"
+version = "0.4.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
@@ -686,11 +793,7 @@ version = "0.10.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.itoa]]
-version = "0.4.8"
-criteria = "safe-to-run"
-
-[[exemptions.itoa]]
-version = "1.0.5"
+version = "1.0.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.ittapi]]
@@ -702,11 +805,11 @@ version = "0.3.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
-version = "0.1.25"
+version = "0.1.26"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
-version = "0.3.60"
+version = "0.3.61"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonwebtoken]]
@@ -715,6 +818,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.jwt]]
 version = "0.16.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.kqueue]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.kqueue-sys]]
+version = "1.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.kstring]]
@@ -758,15 +869,15 @@ version = "0.8.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.139"
+version = "0.2.140"
 criteria = "safe-to-deploy"
 
 [[exemptions.libflate]]
-version = "1.2.0"
+version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libflate_lz77]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libgit2-sys]]
@@ -841,8 +952,20 @@ criteria = "safe-to-deploy"
 version = "2.5.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.memmap2]]
+version = "0.5.10"
+criteria = "safe-to-deploy"
+
 [[exemptions.memoffset]]
 version = "0.6.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.miette]]
+version = "5.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.miette-derive]]
+version = "5.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.mime]]
@@ -862,7 +985,7 @@ version = "0.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.mio]]
-version = "0.8.5"
+version = "0.8.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.mysql_async]]
@@ -886,11 +1009,23 @@ version = "0.26.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.nom]]
+version = "5.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.nom]]
 version = "7.1.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.nom8]]
 version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.normalize-path]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.notify]]
+version = "5.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.nu-ansi-term]]
@@ -899,6 +1034,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num_cpus]]
 version = "1.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.num_threads]]
+version = "0.1.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.oauth2]]
@@ -910,16 +1049,12 @@ version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.olpc-cjson]]
-version = "0.1.2"
+version = "0.1.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.once_cell]]
-version = "1.17.0"
+version = "1.12.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.oorandom]]
-version = "11.1.3"
-criteria = "safe-to-run"
 
 [[exemptions.openssl]]
 version = "0.10.45"
@@ -942,11 +1077,11 @@ version = "6.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ouroboros]]
-version = "0.15.5"
+version = "0.15.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.ouroboros_macro]]
-version = "0.15.5"
+version = "0.15.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.overload]]
@@ -966,11 +1101,11 @@ version = "0.8.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.parking_lot_core]]
-version = "0.9.6"
+version = "0.9.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.paste]]
-version = "1.0.11"
+version = "1.0.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.path-absolutize]]
@@ -985,31 +1120,35 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.peeking_take_while]]
-version = "0.1.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.pem]]
 version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest]]
-version = "2.5.4"
+version = "2.5.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest_derive]]
-version = "2.5.4"
+version = "2.5.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest_generator]]
-version = "2.5.4"
+version = "2.5.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.pest_meta]]
-version = "2.5.4"
+version = "2.5.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.phf]]
+version = "0.11.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_codegen]]
+version = "0.11.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_generator]]
 version = "0.11.1"
 criteria = "safe-to-deploy"
 
@@ -1045,10 +1184,6 @@ criteria = "safe-to-run"
 version = "0.3.4"
 criteria = "safe-to-run"
 
-[[exemptions.plotters-svg]]
-version = "0.3.3"
-criteria = "safe-to-run"
-
 [[exemptions.postgres-native-tls]]
 version = "0.5.0"
 criteria = "safe-to-deploy"
@@ -1082,7 +1217,7 @@ version = "0.5.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.proc-macro2]]
-version = "1.0.50"
+version = "1.0.53"
 criteria = "safe-to-deploy"
 
 [[exemptions.proc-quote]]
@@ -1091,6 +1226,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.proc-quote-impl]]
 version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.project-origins]]
+version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.psm]]
@@ -1103,6 +1242,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.ptr_meta_derive]]
 version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.quote]]
+version = "1.0.26"
 criteria = "safe-to-deploy"
 
 [[exemptions.radium]]
@@ -1161,12 +1304,8 @@ criteria = "safe-to-deploy"
 version = "0.6.27"
 criteria = "safe-to-deploy"
 
-[[exemptions.remove_dir_all]]
-version = "0.5.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.rend]]
-version = "0.3.6"
+version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.reqwest]]
@@ -1178,11 +1317,11 @@ version = "0.16.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.rkyv]]
-version = "0.7.39"
+version = "0.7.40"
 criteria = "safe-to-deploy"
 
 [[exemptions.rkyv_derive]]
-version = "0.7.39"
+version = "0.7.40"
 criteria = "safe-to-deploy"
 
 [[exemptions.rle-decode-fast]]
@@ -1202,7 +1341,7 @@ version = "0.27.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rust_decimal]]
-version = "1.28.0"
+version = "1.24.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustify]]
@@ -1211,6 +1350,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rustify_derive]]
 version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustix]]
+version = "0.36.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
@@ -1226,11 +1369,11 @@ version = "1.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustversion]]
-version = "1.0.11"
+version = "1.0.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.ryu]]
-version = "1.0.11"
+version = "1.0.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.same-file]]
@@ -1254,7 +1397,7 @@ version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.scratch]]
-version = "1.0.3"
+version = "1.0.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sct]]
@@ -1302,7 +1445,7 @@ version = "1.0.91"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_path_to_error]]
-version = "0.1.9"
+version = "0.1.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]
@@ -1311,6 +1454,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.serde_urlencoded]]
 version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_with]]
+version = "2.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_with_macros]]
+version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha1]]
@@ -1346,7 +1497,7 @@ version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.signal-hook]]
-version = "0.3.14"
+version = "0.3.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.signal-hook-mio]]
@@ -1354,11 +1505,15 @@ version = "0.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.signal-hook-registry]]
-version = "1.4.0"
+version = "1.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.signature]]
 version = "1.6.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.simdutf8]]
+version = "0.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.simple_asn1]]
@@ -1386,7 +1541,7 @@ version = "1.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
-version = "0.4.7"
+version = "0.4.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
@@ -1426,7 +1581,11 @@ version = "2.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
-version = "1.0.107"
+version = "1.0.109"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "2.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.tap]]
@@ -1438,15 +1597,19 @@ version = "0.4.38"
 criteria = "safe-to-deploy"
 
 [[exemptions.target-lexicon]]
-version = "0.12.5"
+version = "0.12.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
-version = "3.3.0"
+version = "3.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.termcolor]]
 version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.terminfo]]
+version = "0.7.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.textwrap]]
@@ -1462,7 +1625,7 @@ version = "1.0.38"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread_local]]
-version = "1.1.4"
+version = "1.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]
@@ -1470,7 +1633,7 @@ version = "0.1.44"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]
-version = "0.3.17"
+version = "0.3.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.time-core]]
@@ -1478,19 +1641,23 @@ version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.time-macros]]
-version = "0.2.6"
+version = "0.2.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinytemplate]]
 version = "1.2.1"
 criteria = "safe-to-run"
 
+[[exemptions.tinyvec_macros]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.tls-listener]]
 version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.25.0"
+version = "1.26.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
@@ -1498,7 +1665,7 @@ version = "1.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-native-tls]]
-version = "0.3.0"
+version = "0.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-postgres]]
@@ -1510,7 +1677,7 @@ version = "0.23.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-stream]]
-version = "0.1.11"
+version = "0.1.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-tar]]
@@ -1522,7 +1689,7 @@ version = "0.6.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-util]]
-version = "0.7.4"
+version = "0.7.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
@@ -1586,11 +1753,15 @@ version = "0.1.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.unicode-bidi]]
-version = "0.3.10"
+version = "0.3.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-bom]]
+version = "1.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.unicode-ident]]
-version = "1.0.6"
+version = "1.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.unicode-segmentation]]
@@ -1622,11 +1793,7 @@ version = "0.2.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.vergen]]
-version = "7.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.version_check]]
-version = "0.9.4"
+version = "7.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]
@@ -1650,35 +1817,39 @@ version = "0.11.0+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi-cap-std-sync]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi-common]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi-tokio]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.83"
+version = "0.2.84"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-backend]]
-version = "0.2.83"
+version = "0.2.84"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.33"
+version = "0.4.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.83"
+version = "0.2.84"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.83"
+version = "0.2.84"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.84"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-streams]]
@@ -1686,7 +1857,7 @@ version = "0.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-asm-macros]]
@@ -1698,55 +1869,67 @@ version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-component-macro]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-component-util]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-cranelift]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-environ]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-fiber]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-jit]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-jit-debug]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-jit-icache-coherence]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-runtime]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-types]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-wasi]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime-wit-bindgen]]
-version = "5.0.0"
+version = "5.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.watchexec]]
+version = "2.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.watchexec-events]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.watchexec-signals]]
+version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
-version = "0.3.60"
+version = "0.3.61"
 criteria = "safe-to-deploy"
 
 [[exemptions.webpki]]
@@ -1759,18 +1942,18 @@ criteria = "safe-to-deploy"
 
 [[exemptions.which]]
 version = "4.4.0"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.wiggle]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wiggle-generate]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wiggle-macro]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.winapi]]
@@ -1787,6 +1970,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows]]
+version = "0.43.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.winreg]]
@@ -1822,5 +2009,5 @@ version = "5.0.2+zstd.1.5.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zstd-sys]]
-version = "2.0.6+zstd.1.5.2"
+version = "2.0.7+zstd.1.5.4"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,20 @@
 
 # cargo-vet imports lock
 
+[[publisher.bumpalo]]
+version = "3.12.0"
+when = "2023-01-17"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[audits.bytecodealliance.wildcard-audits.bumpalo]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696
+start = "2019-03-16"
+end = "2024-03-10"
+
 [[audits.bytecodealliance.audits.arrayvec]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
@@ -25,11 +39,6 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.21.0"
 notes = "This crate has no dependencies, no build.rs, and contains no unsafe code."
-
-[[audits.bytecodealliance.audits.block-buffer]]
-who = "Benjamin Bouvier <public@benj.me>"
-criteria = "safe-to-deploy"
-delta = "0.9.0 -> 0.10.2"
 
 [[audits.bytecodealliance.audits.cap-fs-ext]]
 who = "Dan Gohman <dev@sunfishcode.online>"
@@ -185,6 +194,18 @@ The only changes from 0.6.1 were from my own PR which updated memfd to newer
 dependencies.
 """
 
+[[audits.bytecodealliance.audits.memoffset]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.8.0"
+notes = "This was a small update to the crate which has to do with Rust language features and compiler versions, no substantial changes."
+
+[[audits.bytecodealliance.audits.peeking_take_while]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "I am the author of this crate."
+
 [[audits.bytecodealliance.audits.percent-encoding]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -247,12 +268,6 @@ criteria = "safe-to-deploy"
 version = "0.1.21"
 notes = "I am the author of this crate."
 
-[[audits.bytecodealliance.audits.rustix]]
-who = "Dan Gohman <dev@sunfishcode.online>"
-criteria = "safe-to-deploy"
-version = "0.36.7"
-notes = "The Bytecode Alliance is the author of this crate."
-
 [[audits.bytecodealliance.audits.sha2]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"
@@ -279,16 +294,6 @@ notes = """
 This crate, while it implements collections, does so without `std::*` APIs and
 without `unsafe`. Skimming the crate everything looks reasonable and what one
 would expect from idiomatic safe collections in Rust.
-"""
-
-[[audits.bytecodealliance.audits.tinyvec_macros]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
-notes = """
-This is a trivial crate which only contains a singular macro definition which is
-intended to multiplex across the internal representation of a tinyvec,
-presumably. This trivially doesn't contain anything bad.
 """
 
 [[audits.bytecodealliance.audits.unicase]]
@@ -328,7 +333,7 @@ nothing suspicious and it's everything you'd expect a Rust URL parser to be.
 [[audits.bytecodealliance.audits.wasm-encoder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.22.0"
+version = "0.25.0"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[audits.bytecodealliance.audits.wasmparser]]
@@ -346,13 +351,13 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[audits.bytecodealliance.audits.wast]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "52.0.2"
+version = "55.0.0"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[audits.bytecodealliance.audits.wat]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "1.0.56"
+version = "1.0.61"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[audits.bytecodealliance.audits.windows-sys]]
@@ -475,71 +480,39 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 notes = "The Bytecode Alliance is the author of this crate."
 
-[audits.chromeos.criteria.crypto-safe]
-description = """
-All crypto algorithms in this crate have been reviewed by a relevant expert.
-
-**Note**: If a crate does not implement crypto, use `does-not-implement-crypto`,
-which implies `crypto-safe`, but does not require expert review in order to
-audit for."""
-
-[audits.chromeos.criteria.does-not-implement-crypto]
-description = """
-Inspection reveals that the crate in question does not attempt to implement any
-cryptographic algorithms on its own.
-
-Note that certification of this does not require an expert on all forms of
-cryptography: it's expected for crates we import to be \"good enough\" citizens,
-so they'll at least be forthcoming if they try to implement something
-cryptographic. When in doubt, please ask an expert."""
-implies = "crypto-safe"
-
-[audits.chromeos.criteria.rule-of-two-safe-to-deploy]
-description = """
-This is a stronger requirement than the built-in safe-to-deploy criteria,
-motivated by Chromium's rule-of-two related requirements:
-https://chromium.googlesource.com/chromium/src/+/master/docs/security/rule-of-2.md#unsafe-code-in-safe-languages
-
-This crate will not introduce a serious security vulnerability to production
-software exposed to untrusted input.
-
-Auditors are not required to perform a full logic review of the entire crate.
-Rather, they must review enough to fully reason about the behavior of all unsafe
-blocks and usage of powerful imports. For any reasonable usage of the crate in
-real-world software, an attacker must not be able to manipulate the runtime
-behavior of these sections in an exploitable or surprising way.
-
-Ideally, ambient capabilities (e.g. filesystem access) are hardened against
-manipulation and consistent with the advertised behavior of the crate. However,
-some discretion is permitted. In such cases, the nature of the discretion should
-be recorded in the `notes` field of the audit record.
-
-Any unsafe code in this crate must, in general, be kept well-contained, and
-documentation must exist to describe how Rust's invariants are being upheld
-despite the unsafe block(s). Nontrivial uses of unsafe must be reviewed by an
-expert in Rust's unsafety guarantees/non-guarantees.
-
-For crates which generate deployed code (e.g. build dependencies or procedural
-macros), reasonable usage of the crate should output code which meets the above
-criteria."""
-implies = "safe-to-deploy"
-
 [[audits.chromeos.audits.clap]]
 who = "George Burgess IV <gbiv@google.com>"
-criteria = ["safe-to-run", "does-not-implement-crypto"]
+criteria = "safe-to-run"
 version = "2.34.0"
 
 [[audits.chromeos.audits.cmake]]
 who = "George Burgess IV <gbiv@google.com>"
-criteria = ["does-not-implement-crypto", "rule-of-two-safe-to-deploy"]
+criteria = "safe-to-deploy"
 version = "0.1.49"
+
+[[audits.chromeos.audits.fastrand]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.9.0"
+notes = """
+`does-not-implement-crypto` is certified because this crate explicitly says
+that the RNG here is not cryptographically secure.
+"""
 
 [[audits.chromeos.audits.textwrap]]
 who = "Android Legacy"
 criteria = "safe-to-run"
 version = "0.11.0"
 
-[audits.embark-studios.audits]
+[[audits.chromeos.audits.version_check]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.9.4"
+
+[[audits.embark-studios.audits.anyhow]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.58"
 
 [[audits.isrg.audits.block-buffer]]
 who = "David Cook <dcook@divviup.org>"
@@ -551,15 +524,55 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
 
+[[audits.isrg.audits.rayon]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.6.1 -> 1.7.0"
+
+[[audits.isrg.audits.rayon-core]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.10.2 -> 1.11.0"
+
+[[audits.isrg.audits.serde]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.152 -> 1.0.153"
+
+[[audits.isrg.audits.serde]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.153 -> 1.0.154"
+
+[[audits.isrg.audits.serde_derive]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.152 -> 1.0.153"
+
+[[audits.isrg.audits.serde_derive]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.153 -> 1.0.154"
+
+[[audits.isrg.audits.serde_json]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.93 -> 1.0.94"
+
+[[audits.isrg.audits.thiserror]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.38 -> 1.0.39"
+
+[[audits.isrg.audits.thiserror-impl]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.38 -> 1.0.39"
+
 [[audits.isrg.audits.untrusted]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.7.1"
-
-[[audits.isrg.audits.wasm-bindgen-shared]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-version = "0.2.83"
 
 [[audits.mozilla.audits.android_system_properties]]
 who = "Nicolas Silva <nical@fastmail.com>"
@@ -578,6 +591,37 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.4 -> 0.1.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.57 -> 1.0.61"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.58 -> 1.0.57"
+notes = "No functional differences, just CI config and docs."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.61 -> 1.0.62"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.62 -> 1.0.68"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.68 -> 1.0.69"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.autocfg]]
@@ -600,10 +644,16 @@ version = "0.59.2"
 notes = "I'm the primary author and maintainer of the crate."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.block-buffer]]
+[[audits.mozilla.audits.clang-sys]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
-delta = "0.10.2 -> 0.10.3"
+delta = "1.4.0 -> 1.6.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-queue]]
+who = "Matthew Gregan <kinetik@flim.org>"
+criteria = "safe-to-deploy"
+version = "0.3.8"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crypto-common]]
@@ -663,6 +713,12 @@ version = "0.8.31"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.encoding_rs]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.8.31 -> 0.8.32"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.env_logger]]
 who = "Nicolas Silva <nical@fastmail.com>"
 criteria = "safe-to-deploy"
@@ -713,10 +769,22 @@ version = "0.12.3"
 notes = "This version is used in rust's libstd, so effectively we're already trusting it"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.heck]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.hermit-abi]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.19 -> 0.2.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.indexmap]]
@@ -765,10 +833,35 @@ version = "0.2.15"
 notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.once_cell]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.12.0 -> 1.13.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.13.1 -> 1.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.16.0 -> 1.17.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.os_str_bytes]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "6.3.0 -> 6.4.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.peeking_take_while]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 0.1.2"
+notes = "Small refactor of some simple iterator logic, no unsafe code or capabilities."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.pkg-config]]
@@ -787,34 +880,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.5.19 -> 0.5.20+deprecated"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-version = "1.0.18"
-notes = """
-`quote` is a utility crate used by proc-macros to generate TokenStreams
-conveniently from source code. The bulk of the logic is some complex
-interlocking `macro_rules!` macros which are used to parse and build the
-`TokenStream` within the proc-macro.
-
-This crate contains no unsafe code, and the internal logic, while difficult to
-read, is generally straightforward. I have audited the the quote macros, ident
-formatter, and runtime logic.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.18 -> 1.0.21"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.21 -> 1.0.23"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rayon]]
@@ -855,17 +920,35 @@ criteria = "safe-to-deploy"
 delta = "0.6.27 -> 0.6.28"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.rust_decimal]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.24.0 -> 1.25.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rust_decimal]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.25.0 -> 1.26.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rust_decimal]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.26.1 -> 1.27.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rust_decimal]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.27.0 -> 1.28.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.rustc-hash]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.1.0"
 notes = "Straightforward crate with no unsafe code, does what it says on the tin."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.ryu]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.11 -> 1.0.12"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.serde_cbor]]
@@ -880,10 +963,22 @@ criteria = "safe-to-deploy"
 delta = "0.11.1 -> 0.11.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.serde_json]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.91 -> 1.0.93"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.sha2]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.2 -> 0.10.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.slab]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.7 -> 0.4.8"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.synstructure]]


### PR DESCRIPTION
This PR regenerates the `cargo vet` exemptions table and adds audits for a few more crates and diffs.

I would like to keep removing crates from the exemptions list and perform audits, at least in the beginning for version bumps.