### PR TITLE
update release.yml so it can build `spin-componentize`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,12 +87,12 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.66
+          toolchain: 1.68
           default: true
           target: ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi --toolchain 1.66
+        run: rustup target add wasm32-wasi --toolchain 1.68 && rustup target add wasm32-unknown-unknown --toolchain 1.68
 
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
This updates to Rust 1.68 and adds the `wasm32-unknown-unknown` target, both of which are needed to build `spin-componentize`.