### PR TITLE
Add KV to list of interfaces to provide SDK version warning

### DIFF
--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -323,13 +323,8 @@ pub fn decode_preinstantiation_error(e: anyhow::Error) -> anyhow::Error {
 
     if err_text.contains("unknown import") && err_text.contains("has not been defined") {
         // TODO: how to maintain this list?
-        let sdk_imported_interfaces = &[
-            "outbound-pg",
-            "outbound-redis",
-            "spin-config",
-            "wasi_experimental_http",
-            "wasi-outbound-http",
-        ];
+        let sdk_imported_interfaces =
+            &["config", "http", "key-value", "mysql", "postgres", "redis"];
 
         if sdk_imported_interfaces
             .iter()
@@ -337,7 +332,7 @@ pub fn decode_preinstantiation_error(e: anyhow::Error) -> anyhow::Error {
             .any(|s| err_text.contains(&s))
         {
             return anyhow!(
-                "{e}. Check that the component uses a SDK version that matches the Spin runtime."
+                "{e}. Check that the component uses a SDK or plugin version that matches the Spin runtime."
             );
         }
     }


### PR DESCRIPTION
There is a magic function deep in Spin that is meant to provide a more meaningful warning if someone uses certain mismatched SDKs (I _think_ it is new SDK on old Spin but have long since forgotten).  To do this it looks at the interface name in the import error message.  This PR adds the key-value interface to that list.

(We may want to revisit whether this function still has value - old SDK/new Spin seems much more likely now.  But this PR doesn't take a view on that.)