### PR TITLE
Updating static-fileserver template to use 0.0.2

### DIFF
--- a/templates/static-fileserver/content/spin.toml
+++ b/templates/static-fileserver/content/spin.toml
@@ -6,7 +6,7 @@ trigger = { type = "http", base = "{{http-base}}" }
 version = "0.1.0"
 
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.2/spin_static_fs.wasm", digest = "sha256:65456bf4e84cf81b62075e761b2b0afaffaef2d0aeda521b245150f76b96421b" }
 id = "{{ project-name }}"
 files = [ { source = "{{ files-path }}", destination = "/" } ]
 [component.trigger]

--- a/templates/static-fileserver/metadata/snippets/component.txt
+++ b/templates/static-fileserver/metadata/snippets/component.txt
@@ -1,5 +1,5 @@
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.2/spin_static_fs.wasm", digest = "sha256:65456bf4e84cf81b62075e761b2b0afaffaef2d0aeda521b245150f76b96421b" }
 id = "{{ project-name }}"
 files = [ { source = "{{ files-path }}", destination = "/" } ]
 [component.trigger]


### PR DESCRIPTION
Static fileserver was released in version 0.0.2. This PR updated the template to use the newest version.