### PR TITLE
ref(sdk): use the macro the generate bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5076,8 +5076,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "wit-bindgen-gen-core 0.2.0 (git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba)",
- "wit-bindgen-gen-rust-wasm",
  "wit-bindgen-rust",
 ]
 

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -147,14 +147,12 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-gen-core",
- "wit-bindgen-gen-rust-wasm",
  "wit-bindgen-rust",
 ]
 
 [[package]]
 name = "spin-sdk"
-version = "0.10.0-pre0"
+version = "1.1.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/sdk/rust/macro/Cargo.toml
+++ b/sdk/rust/macro/Cargo.toml
@@ -14,6 +14,4 @@ http = "0.2"
 proc-macro2 = "1"
 quote = "1.0"
 syn = { version = "1.0", features = [ "full" ]}
-wit-bindgen-gen-rust-wasm = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
-wit-bindgen-gen-core = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }

--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -1,32 +1,20 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use wit_bindgen_gen_core::{wit_parser::Interface, Direction, Files, Generator};
-use wit_bindgen_gen_rust_wasm::RustWasm;
 
 /// The entrypoint to a Spin HTTP component written in Rust.
 #[proc_macro_attribute]
 pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    const HTTP_COMPONENT_WIT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/wit/spin-http.wit");
+    const HTTP_COMPONENT_WIT: &str =
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/wit/spin-http.wit"));
 
     let func = syn::parse_macro_input!(item as syn::ItemFn);
     let func_name = &func.sig.ident;
 
-    let iface = Interface::parse_file(HTTP_COMPONENT_WIT_PATH)
-        .expect("cannot parse Spin HTTP interface file");
-
-    let mut files = Files::default();
-    RustWasm::new().generate_one(&iface, Direction::Export, &mut files);
-    let (_, contents) = files.iter().next().unwrap();
-    let iface_tokens: TokenStream = std::str::from_utf8(contents)
-        .expect("cannot parse UTF-8 from Spin HTTP interface file")
-        .parse()
-        .expect("cannot parse Spin HTTP interface file");
-    let iface = syn::parse_macro_input!(iface_tokens as syn::ItemMod);
-
     quote!(
-        #iface
+        wit_bindgen_rust::export!({src["spin_http"]: #HTTP_COMPONENT_WIT});
 
         struct SpinHttp;
+
         impl spin_http::SpinHttp for SpinHttp {
             // Implement the `handler` entrypoint for Spin HTTP components.
             fn handle_http_request(req: spin_http::Request) -> spin_http::Response {

--- a/tests/http/headers-env-routes-test/Cargo.lock
+++ b/tests/http/headers-env-routes-test/Cargo.lock
@@ -140,8 +140,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-gen-core",
- "wit-bindgen-gen-rust-wasm",
  "wit-bindgen-rust",
 ]
 

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -147,8 +147,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-gen-core",
- "wit-bindgen-gen-rust-wasm",
  "wit-bindgen-rust",
 ]
 

--- a/tests/http/vault-config-test/Cargo.toml
+++ b/tests/http/vault-config-test/Cargo.toml
@@ -16,6 +16,6 @@ http = "0.2"
 # The Spin SDK.
 spin-sdk = { path = "../../../sdk/rust"}
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e9c7c0a3405845cecd3fe06f3c20ab413302fc73" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 
 [workspace]


### PR DESCRIPTION
NOTE: this fixes a test that was using an outdated rev of `wit-bindgen`