### PR TITLE
Remove unused 'namespace' field from ApplicationInformation

### DIFF
--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -152,14 +152,13 @@ async fn core(
 fn info(raw: &RawAppManifest, invoice: &Invoice, url: &str) -> ApplicationInformation {
     ApplicationInformation {
         // TODO
-        // Handle API version and namespace.
+        // Handle API version
         spin_version: SpinVersion::V1,
         name: invoice.bindle.id.name().to_string(),
         version: invoice.bindle.id.version_string(),
         description: invoice.bindle.description.clone(),
         authors: invoice.bindle.authors.clone().unwrap_or_default(),
         trigger: raw.trigger.clone(),
-        namespace: None,
         origin: ApplicationOrigin::Bindle {
             id: invoice.bindle.id.to_string(),
             server: url.to_string(),

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -93,7 +93,7 @@ pub struct RawAppInformation {
     pub authors: Option<Vec<String>>,
     /// Trigger for the application.
     pub trigger: ApplicationTrigger,
-    /// Namespace for the application.
+    /// Namespace for the application. (deprecated)
     pub namespace: Option<String>,
 }
 

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -436,7 +436,6 @@ fn info(raw: RawAppInformation, src: impl AsRef<Path>) -> ApplicationInformation
         description: raw.description,
         authors: raw.authors.unwrap_or_default(),
         trigger: raw.trigger,
-        namespace: raw.namespace,
         origin: ApplicationOrigin::File(src.as_ref().to_path_buf()),
     }
 }

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -68,8 +68,6 @@ pub struct ApplicationInformation {
     /// but for now, a component with a different trigger must be part of
     /// a separate application.
     pub trigger: ApplicationTrigger,
-    /// Namespace for grouping applications.
-    pub namespace: Option<String>,
     /// The location from which the application is loaded.
     pub origin: ApplicationOrigin,
 }


### PR DESCRIPTION
It appears that this field is no longer used. We leave the `namespace` fields in the "raw" structs as technically removing those fields could break users since we're using `deny_unknown_fields`.