### PR TITLE
add spin sdk based http client

### DIFF
--- a/sdk/go/http/http.go
+++ b/sdk/go/http/http.go
@@ -34,6 +34,26 @@ func NewRouter() *Router {
 	return httprouter.New()
 }
 
+// NewTransport returns http.RoundTripper backed by Spin SDK
+func NewTransport() http.RoundTripper {
+	return &Transport{}
+}
+
+// Transport implements http.RoundTripper
+type Transport struct{}
+
+// RoundTrip makes roundtrip using Spin SDK
+func (r *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return Send(req)
+}
+
+// NewClient returns a new HTTP client compatible with the Spin SDK
+func NewClient() *http.Client {
+	return &http.Client{
+		Transport: &Transport{},
+	}
+}
+
 // handler is the function that will be called by the http trigger in Spin.
 var handler = defaultHandler
 

--- a/sdk/go/http/testdata/spin-roundtrip/Makefile
+++ b/sdk/go/http/testdata/spin-roundtrip/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	tinygo build -target=wasi -gc=leaking -o main.wasm main.go

--- a/sdk/go/http/testdata/spin-roundtrip/main.go
+++ b/sdk/go/http/testdata/spin-roundtrip/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		transport := spinhttp.NewTransport()
+
+		// or you can also do client := spinhttp.NewClient()
+		client := &http.Client{
+			Transport: transport,
+		}
+
+		resp, err := client.Get("https://example.com")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(resp.StatusCode)
+		w.Header().Set("spin-path-info", r.Header.Get("spin-path-info"))
+		w.Header().Set("foo", "bar")
+		fmt.Fprintln(w, "Hello world!")
+	})
+}
+
+func main() {}

--- a/sdk/go/http/testdata/spin-roundtrip/spin.toml
+++ b/sdk/go/http/testdata/spin-roundtrip/spin.toml
@@ -1,0 +1,13 @@
+spin_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple Spin application written in (Tiny)Go."
+name = "spin-roundtrip-test"
+trigger = { type = "http", base = "/" }
+version = "1.0.0"
+
+[[component]]
+id = "http-roundtrip-test"
+source = "main.wasm"
+allowed_http_hosts = ["example.com"]
+[component.trigger]
+route = "/hello/..."

--- a/sdk/go/integration_test.go
+++ b/sdk/go/integration_test.go
@@ -78,6 +78,31 @@ func buildTinyGo(t *testing.T, dir string) {
 	}
 }
 
+func TestSpinRoundTrip(t *testing.T) {
+	buildTinyGo(t, "http/testdata/spin-roundtrip")
+	spin := startSpin(t, "http/testdata/spin-roundtrip/spin.toml")
+	defer spin.cancel()
+
+	resp := retryGet(t, spin.url+"/hello")
+	spin.cancel()
+	if resp.Body == nil {
+		t.Fatal("body is nil")
+	}
+	t.Log(resp.Status)
+	b, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert response body
+	want := "Hello world!\n"
+	got := string(b)
+	if want != got {
+		t.Fatalf("body is not equal: want = %q got = %q", want, got)
+	}
+}
+
 func TestHTTPTriger(t *testing.T) {
 	buildTinyGo(t, "http/testdata/http-tinygo")
 	spin := startSpin(t, "http/testdata/http-tinygo/spin.toml")


### PR DESCRIPTION
This PR helps setting up a `http.Client` backed by spin-sdk. We can then pass this to any 3rd party lib, which will make use of the `RoundTrip` provided by the transport in this client.

e.g. to make use of existing Twitter sdk, I could do following:

```go
package main

import (
	"context"
	"fmt"
	"net/http"

	"github.com/dghubble/go-twitter/twitter"
	"github.com/dghubble/oauth1"

	spinhttp "github.com/fermyon/spin/sdk/go/http"
)

func init() {
	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
		config := oauth1.NewConfig("consumerKey", "consumerToken")
		token := oauth1.NewToken("token", "tokenSecret")
		
		spinhttpclient := spinhttp.NewClient()
		ctx := context.WithValue(oauth1.NoContext, oauth1.HTTPClient, spinhttpclient)
		httpclient := config.Client(ctx, token)
		client := twitter.NewClient(httpclient)

		_, _, err := client.Statuses.Update("test tweet, pls ignore !", nil)
		if err != nil {
			http.Error(w, err.Error(), http.StatusInternalServerError)
			return
		}

		w.Header().Set("Content-Type", "text/plain")
		fmt.Fprintln(w, "Hello Fermyon!")
	})
}

```