### PR TITLE
Don't assume that the error can be dereferenced

### DIFF
--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -25,10 +25,10 @@ pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     Err(error) => {
                         let body = error.to_string();
                         eprintln!("Handler returned an error: {}", body);
-                        let mut error: &(dyn std::error::Error + 'static) = &*error;
-                        while let Some(source) = error.source() {
-                            eprintln!("  caused by: {}", source);
-                            error = source;
+                        let mut source = error.source();
+                        while let Some(s) = source {
+                            eprintln!("  caused by: {}", s);
+                            source = s.source();
                         }
                         spin_http::Response {
                             status: 500,


### PR DESCRIPTION
#1358 assumed that the error type returned from the HTTP handler could be dereferenced which is true for `anyhow::Error` but a bit restrictive. This refactors so that the only assumption is that the error implements `std::error::Error`.