### PR TITLE
Add default HTTP client compatible with Spin SDK

### DIFF
--- a/sdk/go/http/http.go
+++ b/sdk/go/http/http.go
@@ -11,6 +11,11 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// Override the default HTTP client to be compatible with the Spin SDK.
+func init() {
+	http.DefaultClient = NewClient()
+}
+
 // Router is a http.Handler which can be used to dispatch requests to different
 // handler functions via configurable routes
 type Router = httprouter.Router


### PR DESCRIPTION
This commit adds an `init` function to the SDK's HTTP package that
overrides the default HTTP client to use the internals for sending an
outbound HTTP request compatible with Spin.

This has two implications:

* calls to `http.Get` or `http.Post` (i.e using the standard way of
  making HTTP requests in Go) should now work by default in Spin
  applications
* future updates to WASI and Go networking should mean fewer changes to
  applications that take this approach.

Note that this does not prevent passing a custom HTTP client to
libraries that support this.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>