### PR TITLE
update `spin-componentize` to address `spin-fileserver` issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "host"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize#df2c3ef7dc518cae7d0daedc2037aebf7ee718cb"
+source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize#df2c3ef7dc518cae7d0daedc2037aebf7ee718cb"
+source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6067,7 +6067,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize#df2c3ef7dc518cae7d0daedc2037aebf7ee718cb"
+source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6115,7 +6115,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize#df2c3ef7dc518cae7d0daedc2037aebf7ee718cb"
+source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -203,7 +203,7 @@ async fn run_core_wasi_test_engine<'a>(
     let component = Component::new(engine.as_ref(), &component)?;
     let instance_pre = engine.instantiate_pre(&component)?;
     let instance = instance_pre.instantiate_async(&mut store).await?;
-    let func = instance.get_typed_func::<(), (Result<(), ()>,)>(&mut store, "run")?;
+    let func = instance.get_typed_func::<(), (Result<(), ()>,)>(&mut store, "main")?;
 
     update_store(&mut store);
 


### PR DESCRIPTION
This includes
https://github.com/dicej/preview1.wasm/commit/b15b4defd14435706d268ac7ad6e6a28d1c8ea0b, which ensures `spin-fileserver` behaves the same way it did on WASI Preview 1.