### PR TITLE
[sdk]: Add options fn on HTTP router for Rust

### DIFF
--- a/sdk/rust/src/http/router.rs
+++ b/sdk/rust/src/http/router.rs
@@ -219,6 +219,9 @@ macro_rules! http_router {
     (@build $r:ident DELETE $path:literal => $h:expr) => {
         $r.delete($path, $h);
     };
+    (@build $r:ident OPTIONS $path:literal => $h:expr) => {
+        $r.options($path, $h);
+    };
     (@build $r:ident _ $path:literal => $h:expr) => {
         $r.any($path, $h);
     };

--- a/sdk/rust/src/http/router.rs
+++ b/sdk/rust/src/http/router.rs
@@ -158,6 +158,14 @@ impl Router {
         self.add(path, http_types::Method::PATCH, handler)
     }
 
+    /// Register a handler at the path for the HTTP OPTIONS method.
+    pub fn options<F>(&mut self, path: &str, handler: F)
+    where
+        F: Fn(Request, Params) -> Result<Response> + 'static,
+    {
+        self.add(path, http_types::Method::OPTIONS, handler)
+    }
+
     /// Construct a new Router.
     pub fn new() -> Self {
         Router {


### PR DESCRIPTION
This PR adds the `options` method for the `Router` struct provided by Spin SDK for Rust.

This allows users to quickly register handlers for incoming requests using the `OPTIONS` method:

## Usage example

```rust
fn handle_options(_r: Request, _params: Params) -> Result<Response> {
  Ok(http::Response::builder().status(http::StatusCode::OK).body(None)?)
}

#[http_component]
fn handle_foo(req: Request) -> Result<Response> {
  let mut router = Router::default();
  router.options("/foo", handle_options);
  router.handle(req)
}
```