### PR TITLE
[sdk]: Custom Display implementation for Router

### DIFF
--- a/sdk/rust/src/http/router.rs
+++ b/sdk/rust/src/http/router.rs
@@ -327,7 +327,7 @@ mod tests {
     fn test_wildcard_last_segment() {
         let mut router = Router::default();
         router.get("/:x/*", echo_param);
-        
+
         let req = make_request(http_types::Method::GET, "/foo/bar");
         let res = router.handle(req).unwrap();
         assert_eq!(res.into_body().unwrap(), "foo".to_string());
@@ -337,13 +337,13 @@ mod tests {
     fn test_router_display() {
         let mut router = Router::default();
         router.get("/:x", echo_param);
-        
+
         let expected = "Registered routes:\n- GET: /:x\n";
         let actual = format!("{}", router);
-        
+
         assert_eq!(actual.as_str(), expected);
     }
-    
+
     #[test]
     fn test_ambiguous_wildcard_vs_star() {
         fn h1(_req: Request, _params: Params) -> Result<Response> {

--- a/sdk/rust/src/http/router.rs
+++ b/sdk/rust/src/http/router.rs
@@ -21,11 +21,11 @@ impl Default for Router {
 
 impl Display for Router {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Registered routes:\n")?;
+        writeln!(f, "Registered routes:")?;
         for (method, router) in &self.methods_map {
-            router.iter().for_each(|route| {
-                f.write_fmt(format_args!("- {}: {}\n", method, route.0)).unwrap();
-            });
+            for route in router.iter() {
+                writeln!(f, "- {}: {}", method, route.0)?;
+            }
         }
         Ok(())
     }
@@ -327,7 +327,7 @@ mod tests {
     fn test_wildcard_last_segment() {
         let mut router = Router::default();
         router.get("/:x/*", echo_param);
-
+        
         let req = make_request(http_types::Method::GET, "/foo/bar");
         let res = router.handle(req).unwrap();
         assert_eq!(res.into_body().unwrap(), "foo".to_string());
@@ -340,8 +340,10 @@ mod tests {
         
         let expected = "Registered routes:\n- GET: /:x\n";
         let actual = format!("{}", router);
-        assert_eq!(actual, expected.to_string());
+        
+        assert_eq!(actual.as_str(), expected);
     }
+    
     #[test]
     fn test_ambiguous_wildcard_vs_star() {
         fn h1(_req: Request, _params: Params) -> Result<Response> {

--- a/sdk/rust/src/http/router.rs
+++ b/sdk/rust/src/http/router.rs
@@ -1,6 +1,6 @@
 use super::{Request, Response, Result};
 use routefinder::{Captures, Router as MethodRouter};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 type Handler = dyn Fn(Request, Params) -> Result<Response>;
 
@@ -16,6 +16,18 @@ pub struct Router {
 impl Default for Router {
     fn default() -> Router {
         Router::new()
+    }
+}
+
+impl Display for Router {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Registered routes:\n")?;
+        for (method, router) in &self.methods_map {
+            router.iter().for_each(|route| {
+                f.write_fmt(format_args!("- {}: {}\n", method, route.0)).unwrap();
+            });
+        }
+        Ok(())
     }
 }
 
@@ -321,6 +333,15 @@ mod tests {
         assert_eq!(res.into_body().unwrap(), "foo".to_string());
     }
 
+    #[test]
+    fn test_router_display() {
+        let mut router = Router::default();
+        router.get("/:x", echo_param);
+        
+        let expected = "Registered routes:\n- GET: /:x\n";
+        let actual = format!("{}", router);
+        assert_eq!(actual, expected.to_string());
+    }
     #[test]
     fn test_ambiguous_wildcard_vs_star() {
         fn h1(_req: Request, _params: Params) -> Result<Response> {


### PR DESCRIPTION
This PR contains a custom implementation for the `Display` trait. This allows users of the HTTP router to print all registered routes at once.

### Usage
```rust
let mut router = Router::default();
router.get("/:x", echo_param);
router.post("/", echo_param);

print!("{}", router);
```

This would print the following to stdout:

```
Registered routes:
- GET: /:x
- POST: /
```