### PR TITLE
Improve error when the component wasm does not exist

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -366,8 +366,8 @@ pub enum Error {
     #[error("host component error: {0:#}")]
     HostComponentError(#[source] anyhow::Error),
     /// An error from a [`Loader`] implementation.
-    #[error("loader error: {0:#}")]
-    LoaderError(#[source] anyhow::Error),
+    #[error(transparent)]
+    LoaderError(anyhow::Error),
     /// An error indicating missing or unexpected metadata.
     #[error("metadata error: {0}")]
     MetadataError(String),

--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -51,7 +51,14 @@ impl Loader for TriggerLoader {
         let path = parse_file_url(source)?;
         spin_core::Component::new(
             engine,
-            spin_componentize::componentize_if_necessary(&fs::read(&path).await?)?,
+            spin_componentize::componentize_if_necessary(&fs::read(&path).await.with_context(
+                || {
+                    format!(
+                        "failed to read component source from disk at path '{}'",
+                        path.display()
+                    )
+                },
+            )?)?,
         )
         .with_context(|| format!("loading module {path:?}"))
     }


### PR DESCRIPTION
We should probably be validating the component source path when we parse the spin.toml file, but this at least makes sure that the error from spin trigger is more understandable when the wasm component does not exist.

**Before**

```
Error: Failed to instantiate component 'todo'

Caused by:
    0: loader error: No such file or directory (os error 2)
    1: No such file or directory (os error 2)
```

**After**

```
Error: Failed to instantiate component 'todo'

Caused by:
    0: failed to read component source from disk at path '/Users/rylev/Code/fermyon/todo/target/wam32-wasi/release/todo.wasm'
    1: No such file or directory (os error 2)
```