### PR TITLE
feat(sdk/go): add constants for Spin headers

### DIFF
--- a/sdk/go/http/http.go
+++ b/sdk/go/http/http.go
@@ -11,6 +11,24 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+const (
+	// The application base path.
+	HeaderBasePath = "spin-base-path"
+	// The component route pattern matched, _excluding_ any wildcard indicator.
+	HeaderComponentRoot = "spin-component-route"
+	// The full URL of the request. This includes full host and scheme information.
+	HeaderFullUrl = "spin-full-url"
+	// The part of the request path that was matched by the route (including
+	// the base and wildcard indicator if present).
+	HeaderMatchedRoute = "spin-matched-route"
+	// The request path relative to the component route (including any base).
+	HeaderPathInfo = "spin-path-info"
+	// The component route pattern matched, as written in the component
+	// manifest (that is, _excluding_ the base, but including the wildcard
+	// indicator if present).
+	HeaderRawComponentRoot = "spin-raw-component-route"
+)
+
 // Override the default HTTP client to be compatible with the Spin SDK.
 func init() {
 	http.DefaultClient = NewClient()


### PR DESCRIPTION
This commit adds constants for header names added by Spin.