### PR TITLE
Handle multi-component apps better in `spin watch`

### DIFF
--- a/tests/watch/http-rust/spin.toml
+++ b/tests/watch/http-rust/spin.toml
@@ -14,3 +14,14 @@ route = "/hello"
 [component.build]
 command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
+
+[[component]]
+id = "subcomponent"
+source = "subcomponent/main.wasm"
+allowed_http_hosts = []
+[component.trigger]
+route = "/..."
+[component.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+workdir = "subcomponent"
+watch = ["**/*.go", "go.mod"]

--- a/tests/watch/http-rust/subcomponent/.gitignore
+++ b/tests/watch/http-rust/subcomponent/.gitignore
@@ -1,0 +1,2 @@
+main.wasm
+.spin/

--- a/tests/watch/http-rust/subcomponent/go.mod
+++ b/tests/watch/http-rust/subcomponent/go.mod
@@ -1,0 +1,5 @@
+module github.com/subcomponent
+
+go 1.17
+
+require github.com/fermyon/spin/sdk/go v1.0.0

--- a/tests/watch/http-rust/subcomponent/main.go
+++ b/tests/watch/http-rust/subcomponent/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
+)
+
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, "Hello Fermyon!")
+	})
+}
+
+func main() {}


### PR DESCRIPTION
- Infer watch config prefix from `workdir`.
- Closes #1402.
- Avoiding refactoring `generate_path_patterns` until I take a crack at #1403 since that will require some major reworking.