### PR TITLE
Use the version of `cargo vet` that works with the audit config

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -2,13 +2,14 @@ name: Run Rust audits
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 jobs:
   cargo-vet:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'fermyon' }}
     env:
-      CARGO_VET_VERSION: 0.4.0
+      CARGO_VET_VERSION: 0.5.0
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust


### PR DESCRIPTION
Audits have been failing for a couple of months now, with a variety of errors.  The current error is "your cargo vet store has consistency errors" which I _think_ means that the config file specifies cargo-vet 0.5 but the workflow uses 0.4.

Updating cargo-vet seems to fix the consistency error (at least locally) but this will uncover an "unvetted dependencies" error that will still need addressing.

I also added a `workflow_dispatch` trigger so that when we have a candidate fix for the unvetted dependencies we can get feedback without waiting for the cron job _grin_