### PR TITLE
Fix duplicate package names causing warnings for Rust SDK consumers

### DIFF
--- a/examples/http-rust-router-macro/Cargo.toml
+++ b/examples/http-rust-router-macro/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http-rust-router"
+name = "http-rust-router-macro"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/http-rust-router-macro/spin.toml
+++ b/examples/http-rust-router-macro/spin.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 
 [[component]]
 id = "route"
-source = "target/wasm32-wasi/release/http_rust_router.wasm"
+source = "target/wasm32-wasi/release/http_rust_router_macro.wasm"
 description = "A component that internally routes HTTP requests."
 [component.trigger]
 route = "/..."

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -332,7 +332,9 @@ mod tests {
         assert_eq!(path_patterns.len(), 3);
         assert_eq!(
             path_patterns.get(0),
-            Some(&String::from("target/wasm32-wasi/release/http_rust.wasm"))
+            Some(&String::from(
+                "target/wasm32-wasi/release/http_rust_watch_test.wasm"
+            ))
         );
         assert_eq!(
             path_patterns.get(1),

--- a/tests/watch/http-rust/Cargo.toml
+++ b/tests/watch/http-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http-rust"
+name = "http-rust-watch-test"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/watch/http-rust/spin.toml
+++ b/tests/watch/http-rust/spin.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 
 [[component]]
 id = "hello"
-source = "target/wasm32-wasi/release/http_rust.wasm"
+source = "target/wasm32-wasi/release/http_rust_watch_test.wasm"
 description = "A simple component that returns hello."
 [component.trigger]
 route = "/hello"


### PR DESCRIPTION
WE GOTTA WRITE TESTS FOR THIS STUFF Y'ALL

and by 'we' I specifically mean 'someone else'