### PR TITLE
implement refresh token support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "cloud-openapi"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/cloud-openapi#6433f6c997cc214c598487bfa6271058c3c25df8"
+source = "git+https://github.com/fermyon/cloud-openapi?rev=1a7bc0316d2dd863d9090f201543215b36db7017#1a7bc0316d2dd863d9090f201543215b36db7017"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "1.1"
 chrono = "0.4"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 cloud = { path = "crates/cloud" }
-cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi" }
+cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi", rev = "1a7bc0316d2dd863d9090f201543215b36db7017" }
 comfy-table = "5.0"
 ctrlc = { version = "3.2", features = ["termination"] }
 dialoguer = "0.10"

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
-cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi" }
+cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi", rev = "1a7bc0316d2dd863d9090f201543215b36db7017" }
 mime_guess = { version = "2.0" }
 reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"

--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -3,6 +3,7 @@ use cloud_openapi::{
     apis::{
         self,
         apps_api::{api_apps_get, api_apps_id_delete, api_apps_post},
+        auth_tokens_api::api_auth_tokens_refresh_post,
         channels_api::{
             api_channels_get, api_channels_id_delete, api_channels_id_get,
             api_channels_id_logs_get, api_channels_post, ApiChannelsIdPatchError,
@@ -16,8 +17,8 @@ use cloud_openapi::{
     models::{
         AppItemPage, ChannelItem, ChannelItemPage, ChannelRevisionSelectionStrategy,
         CreateAppCommand, CreateChannelCommand, CreateDeviceCodeCommand, CreateKeyValuePairCommand,
-        DeviceCodeItem, GetChannelLogsVm, RegisterRevisionCommand, RevisionItemPage, TokenInfo,
-        UpdateEnvironmentVariableDto,
+        DeviceCodeItem, GetChannelLogsVm, RefreshTokenCommand, RegisterRevisionCommand,
+        RevisionItemPage, TokenInfo, UpdateEnvironmentVariableDto,
     },
 };
 use reqwest::header;
@@ -105,6 +106,19 @@ impl Client {
 
         serde_json::from_reader(response.bytes().await?.as_ref())
             .context("Failed to parse response")
+    }
+
+    pub async fn refresh_token(&self, token: String, refresh_token: String) -> Result<TokenInfo> {
+        api_auth_tokens_refresh_post(
+            &self.configuration,
+            RefreshTokenCommand {
+                token,
+                refresh_token,
+            },
+            None,
+        )
+        .await
+        .map_err(format_response_error)
     }
 
     pub async fn add_app(&self, name: &str, storage_id: &str) -> Result<Uuid> {

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -359,6 +359,7 @@ impl LoginCommand {
             url: self.hippo_server_url.clone(),
             danger_accept_invalid_certs: self.insecure,
             token: token.token.unwrap_or_default(),
+            refresh_token: None,
             expiration: token.expiration,
             bindle_url: Some(bindle_url),
             bindle_username,
@@ -371,6 +372,7 @@ impl LoginCommand {
             url: self.hippo_server_url.clone(),
             danger_accept_invalid_certs: self.insecure,
             token,
+            refresh_token: None,
             expiration: None,
             bindle_url: None,
             bindle_username: None,
@@ -383,6 +385,7 @@ impl LoginCommand {
             url: self.hippo_server_url.clone(),
             danger_accept_invalid_certs: self.insecure,
             token: token_info.token,
+            refresh_token: Some(token_info.refresh_token),
             expiration: Some(token_info.expiration),
             bindle_url: None,
             bindle_username: None,
@@ -525,6 +528,9 @@ pub struct LoginConnection {
     pub bindle_password: Option<String>,
     pub danger_accept_invalid_certs: bool,
     pub token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub refresh_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub expiration: Option<String>,


### PR DESCRIPTION
The Fermyon Cloud provides refresh token support to API clients.

By implementing refresh token support in the Spin CLI, we prevent the user from needing to run `spin login` as long as their refresh token is valid (6 months after date of issue). This also allows us to aggressively reduce the authentication token expiration date that Cloud issues to clients to prevent man-in-the-middle attacks.

In the event that the token and refresh token are stolen, we can revoke all refresh tokens for the user, forcing them to log back in.

As a side benefit: as long as you continue to use `spin deploy` once every 6 months, you should only need to perform the device code login mechanism once.