### PR TITLE
Remove dead dependency on wit-bindgen in Rust SDK macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "host"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
+source = "git+https://github.com/fermyon/spin-componentize#9e7ec95ccaf490c9b96c03af1c818e8197ccf855"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4960,11 +4960,11 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
+source = "git+https://github.com/fermyon/spin-componentize#9e7ec95ccaf490c9b96c03af1c818e8197ccf855"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.102.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.102.0",
  "wit-component",
 ]
 
@@ -5102,7 +5102,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -5871,7 +5870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -6064,7 +6063,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
+source = "git+https://github.com/fermyon/spin-componentize#9e7ec95ccaf490c9b96c03af1c818e8197ccf855"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6112,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize#fa4b72faf30173d9315091fce2979fa9a90c2610"
+source = "git+https://github.com/fermyon/spin-componentize#9e7ec95ccaf490c9b96c03af1c818e8197ccf855"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6253,21 +6252,21 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.25.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.3.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.4.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "anyhow",
  "indexmap",
  "serde",
- "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
- "wasmparser 0.102.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
+ "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855)",
+ "wasmparser 0.103.0",
 ]
 
 [[package]]
@@ -6305,8 +6304,8 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.103.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "indexmap",
  "url",
@@ -6319,7 +6318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc17ae63836d010a2bf001c26a5fedbb9a05e5f71117fb63e0ab878bfbe1ca3"
 dependencies = [
  "anyhow",
- "wasmparser 0.102.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.102.0",
 ]
 
 [[package]]
@@ -6397,7 +6396,7 @@ dependencies = [
  "syn 1.0.109",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-parser 0.6.4",
 ]
 
 [[package]]
@@ -6570,7 +6569,7 @@ checksum = "fd2cf93f3c8a6f443d8a9098fddc5fd887783c0fe725dc10c54ca9280546421d"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "wit-parser 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-parser 0.6.4",
 ]
 
 [[package]]
@@ -6980,18 +6979,18 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.7.4"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.8.1"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
  "indexmap",
  "log",
  "url",
- "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
+ "wasm-encoder 0.25.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855)",
  "wasm-metadata",
- "wasmparser 0.102.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
- "wit-parser 0.6.4 (git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24)",
+ "wasmparser 0.103.0",
+ "wit-parser 0.7.0",
 ]
 
 [[package]]
@@ -7035,8 +7034,8 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.6.4"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=1e0052974277b3cce6c3703386e4e90291da2b24#1e0052974277b3cce6c3703386e4e90291da2b24"
+version = "0.7.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=016838279808be4d257f1b58b9942420f0a09855#016838279808be4d257f1b58b9942420f0a09855"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/sdk/rust/macro/Cargo.toml
+++ b/sdk/rust/macro/Cargo.toml
@@ -14,4 +14,3 @@ http = "0.2"
 proc-macro2 = "1"
 quote = "1.0"
 syn = { version = "1.0", features = [ "full" ]}
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }

--- a/tests/http/headers-env-routes-test/Cargo.lock
+++ b/tests/http/headers-env-routes-test/Cargo.lock
@@ -176,7 +176,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-rust",
 ]
 
 [[package]]

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -183,7 +183,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-rust",
 ]
 
 [[package]]


### PR DESCRIPTION
We aren't actually using this dependency. 