### PR TITLE
Fix misleading error message if built-in app trigger was missing required parameter

### DIFF
--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -201,6 +201,21 @@ fn test_unknown_version_is_rejected() {
     );
 }
 
+#[tokio::test]
+async fn gives_correct_error_when_missing_app_trigger_field() -> Result<()> {
+    const MANIFEST: &str = "tests/missing-http-base.toml";
+
+    let app = raw_manifest_from_file(&PathBuf::from(MANIFEST)).await;
+
+    let e = format!("{:#}", app.unwrap_err());
+    assert!(
+        e.contains("missing field `base`"),
+        "Expected error to contain trigger field information but was '{e}'"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_wagi_executor_with_custom_entrypoint() -> Result<()> {
     const MANIFEST: &str = include_str!("../../tests/wagi-custom-entrypoint.toml");

--- a/crates/loader/tests/missing-http-base.toml
+++ b/crates/loader/tests/missing-http-base.toml
@@ -1,0 +1,12 @@
+spin_version = "1"
+authors = ["Gul Madred", "Edward Jellico", "JL"]
+description = "A HTTP application without a base"
+name = "missing-http-base"
+trigger = {type = "http"}
+version = "6.11.2"
+
+[[component]]
+id = "test"
+source = "nope/nope/nope"
+[component.trigger]
+route = "/test"


### PR DESCRIPTION
Fixes #1434.

```
$ spin up -f ./crates/loader/tests/missing-http-base.toml 
Error: Cannot read spin.toml manifest from "/home/ivan/github/spin/crates/loader/tests/missing-http-base.toml"

Caused by:
    could not load application trigger parameters: missing field `base` at line 11 column 1
```
