### PR TITLE
Better error if plugin URL 404s

### DIFF
--- a/crates/plugins/tests/nonexistent-url/nonexistent-url.json
+++ b/crates/plugins/tests/nonexistent-url/nonexistent-url.json
@@ -1,0 +1,14 @@
+{
+    "name": "nonexistent-url",
+    "version": "1.0.0",
+    "spinCompatibility": ">=1.0",
+    "license": "lol snort",
+    "packages": [
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "url": "http://example.com/402f926a-44e3-4d62-93c1-ecc39761afbe",
+            "sha256": "ho ho ho"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #1436 

```
$ spin plugins install --file ./crates/plugins/tests/nonexistent-url/nonexistent-url.json 
You're using a pre-release version of Spin (1.2.0-pre0). This plugin might not be compatible (supported: >=1.0). Continuing anyway.
Are you sure you want to install plugin 'nonexistent-url' with license lol snort from http://example.com/402f926a-44e3-4d62-93c1-ecc39761afbe? yes
Error: The download URL specified in the plugin manifest was not found (http://example.com/402f926a-44e3-4d62-93c1-ecc39761afbe returned HTTP error 404). Please contact the plugin author.
```
