### PR TITLE
Add `spin up --key-value` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4976,6 +4976,7 @@ dependencies = [
  "spin-app",
  "spin-bindle",
  "spin-build",
+ "spin-common",
  "spin-config",
  "spin-key-value",
  "spin-key-value-sqlite",
@@ -5005,6 +5006,7 @@ dependencies = [
 name = "spin-common"
 version = "1.2.0-pre0"
 dependencies = [
+ "anyhow",
  "sha2 0.10.6",
  "tempfile",
 ]
@@ -5314,6 +5316,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-app",
+ "spin-common",
  "spin-componentize",
  "spin-config",
  "spin-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ sha2 = "0.10.2"
 spin-app = { path = "crates/app" }
 spin-bindle = { path = "crates/bindle" }
 spin-build = { path = "crates/build" }
+spin-common = { path = "crates/common" }
 spin-config = { path = "crates/config" }
 spin-trigger-http = { path = "crates/trigger-http" }
 spin-loader = { path = "crates/loader" }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -5,6 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = "1.0"
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/crates/common/src/arg_parser.rs
+++ b/crates/common/src/arg_parser.rs
@@ -1,0 +1,17 @@
+//! Command line argument parsers
+
+use anyhow::bail;
+
+/// Parse an argument in the form `key=value` into a pair of strings.
+/// The error message is specific to key-value arguments.
+pub fn parse_kv(s: &str) -> anyhow::Result<(String, String)> {
+    parse_eq_pair(s, "Key/Values must be of the form `key=value`")
+}
+
+fn parse_eq_pair(s: &str, err_msg: &str) -> anyhow::Result<(String, String)> {
+    if let Some((key, value)) = s.split_once('=') {
+        Ok((key.to_owned(), value.to_owned()))
+    } else {
+        bail!("{err_msg}");
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -8,4 +8,5 @@
 // - No dependencies on other Spin crates
 // - Code should have at least 2 dependents
 
+pub mod arg_parser;
 pub mod sha256;

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -17,7 +17,7 @@ use spin_app::{
     AppComponent, Loader,
 };
 use spin_core::{Component, StoreBuilder};
-use spin_trigger::{RuntimeConfig, TriggerExecutor, TriggerExecutorBuilder};
+use spin_trigger::{HostComponentInitData, RuntimeConfig, TriggerExecutor, TriggerExecutorBuilder};
 use spin_trigger_http::{HttpExecutorType, HttpTriggerConfig, WagiTriggerConfig};
 use tokio::fs;
 
@@ -105,7 +105,11 @@ impl HttpTestConfig {
         Executor::TriggerConfig: DeserializeOwned,
     {
         TriggerExecutorBuilder::new(self.build_loader())
-            .build(TEST_APP_URI.to_string(), RuntimeConfig::default())
+            .build(
+                TEST_APP_URI.to_string(),
+                RuntimeConfig::default(),
+                HostComponentInitData::default(),
+            )
             .await
             .unwrap()
     }
@@ -141,7 +145,11 @@ impl RedisTestConfig {
         self.redis_channel = channel.into();
 
         TriggerExecutorBuilder::new(self.build_loader())
-            .build(TEST_APP_URI.to_string(), RuntimeConfig::default())
+            .build(
+                TEST_APP_URI.to_string(),
+                RuntimeConfig::default(),
+                HostComponentInitData::default(),
+            )
             .await
             .unwrap()
     }

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -15,6 +15,7 @@ outbound-http = { path = "../outbound-http" }
 outbound-redis = { path = "../outbound-redis" }
 outbound-pg = { path = "../outbound-pg" }
 outbound-mysql = { path = "../outbound-mysql" }
+spin-common = { path = "../common" }
 spin-key-value = { path = "../key-value" }
 spin-key-value-redis = { path = "../key-value-redis" }
 spin-key-value-sqlite = { path = "../key-value-sqlite" }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -10,6 +10,7 @@ use hippo_openapi::models::ChannelRevisionSelectionStrategy;
 use rand::Rng;
 use semver::BuildMetadata;
 use sha2::{Digest, Sha256};
+use spin_common::arg_parser::parse_kv;
 use spin_loader::bindle::BindleConnectionInfo;
 use spin_loader::local::config::RawAppManifest;
 use spin_loader::local::{assets, config, parent_dir};
@@ -94,7 +95,8 @@ pub struct DeployCommand {
     )]
     pub deployment_env_id: Option<String>,
 
-    /// Pass a key/value (key=value) to all components of the application.
+    /// Set a key/value pair (key=value) in the deployed application's
+    /// default store. Any existing value will be overwritten.
     /// Can be used multiple times.
     #[clap(long = "key-value", parse(try_from_str = parse_kv))]
     pub key_values: Vec<(String, String)>,
@@ -870,13 +872,4 @@ fn has_expired(login_connection: &LoginConnection) -> Result<bool> {
         },
         None => Ok(false),
     }
-}
-
-// Parse the key/values passed in as `key=value` pairs.
-fn parse_kv(s: &str) -> Result<(String, String)> {
-    let parts: Vec<_> = s.splitn(2, '=').collect();
-    if parts.len() != 2 {
-        bail!("Key/Values must be of the form `key=value`");
-    }
-    Ok((parts[0].to_owned(), parts[1].to_owned()))
 }


### PR DESCRIPTION
Fixes #1404.

Note this currently assumes the answer to my questions there is "default store suffices."  The core logic is easy enough to extend to support non-default stores; the difficulty is only in the CLI syntax.

This PR contains (in `key-value/src/host_component.rs`) the greatest Rust crime I have ever committed.  @dicej it would be great to get your thoughts on the right way to do this.  The trouble I kept running into was that `StoreManagerManager` would only dispense a Store if you gave it an AppComponent.  My guess is I need to add a `get_for_app` method to `StoreManagerManager` but then we will not longer be able to implement it via a function...

Also @lann does the proposed entry point for carrying out before-run host component initialisation seem reasonable?  I was wondering about using `builder.hooks` to set an `app_loaded` hook.  The place where hooks are currently set didn't seem to have access to the host component itself, but would it be reasonable to set a hook where we instantiate and add the key/value DynamicHostComponent (`TriggerExecutorBuilder::build`)?

Or are these questions two sides of the same coin, and if I set the right hook in the right place then I wouldn't need to go through `StoreManagerManager` at all?