### PR TITLE
Validate components are not granted access to undefined  k/v stores

### DIFF
--- a/crates/key-value/src/util.rs
+++ b/crates/key-value/src/util.rs
@@ -34,6 +34,12 @@ impl DelegatingStoreManager {
     }
 }
 
+impl DelegatingStoreManager {
+    pub fn store_names(&self) -> Vec<String> {
+        self.delegates.keys().cloned().collect()
+    }
+}
+
 #[async_trait]
 impl StoreManager for DelegatingStoreManager {
     async fn get(&self, name: &str) -> Result<Arc<dyn Store>, Error> {

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -114,14 +114,15 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
                 builder.add_host_component(outbound_redis::OutboundRedisComponent)?;
                 builder.add_host_component(outbound_pg::OutboundPg::default())?;
                 builder.add_host_component(outbound_mysql::OutboundMysql::default())?;
-                self.loader.add_dynamic_host_component(
-                    &mut builder,
+                let (kv_component, kv_hooks) =
                     runtime_config::key_value::build_key_value_component(
                         &runtime_config,
                         &init_data.kv,
                     )
-                    .await?,
-                )?;
+                    .await?;
+                self.loader
+                    .add_dynamic_host_component(&mut builder, kv_component)?;
+                self.hooks(kv_hooks);
                 self.loader.add_dynamic_host_component(
                     &mut builder,
                     outbound_http::OutboundHttpComponent,


### PR DESCRIPTION
@lann Once again I'd appreciate your insight into how you envisaged this working.  Your suggestion in #1371 was to add a "validate app" function to DynamicHostComponent, which fits nicely with a general sense of "components do the things they need at the right points in the lifecycle," but it seemed tricky getting the host component and the app around at the same time (the loader consumes the host components, then the app consumes the loader, so by the time the app exists, the host components are gone).

So this kind of special-cases it using the TriggerHooks mechanism - which has a convenient "called when app is loaded" entry point - and, as the previous PR ended up doing, making `build_key_value_component` aware of the component's needs in this regard.  It would be great to get your feedback if you had a more elegant way of doing it in mind.