### PR TITLE
Add 'spin-world' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,6 +3496,7 @@ dependencies = [
  "reqwest",
  "spin-app",
  "spin-core",
+ "spin-world",
  "tracing",
  "url",
  "wit-bindgen-wasmtime",
@@ -3509,6 +3510,7 @@ dependencies = [
  "mysql_async",
  "mysql_common",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "url",
@@ -3523,6 +3525,7 @@ dependencies = [
  "native-tls",
  "postgres-native-tls",
  "spin-core",
+ "spin-world",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -3536,6 +3539,7 @@ dependencies = [
  "anyhow",
  "redis",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
@@ -5034,6 +5038,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-core",
+ "spin-world",
  "thiserror",
  "tokio",
  "toml 0.5.11",
@@ -5086,6 +5091,7 @@ dependencies = [
  "lru 0.9.0",
  "spin-app",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
@@ -5099,6 +5105,7 @@ dependencies = [
  "redis",
  "spin-core",
  "spin-key-value",
+ "spin-world",
  "tokio",
  "url",
 ]
@@ -5112,6 +5119,7 @@ dependencies = [
  "rusqlite",
  "spin-core",
  "spin-key-value",
+ "spin-world",
  "tokio",
 ]
 
@@ -5227,6 +5235,7 @@ dependencies = [
  "spin-core",
  "spin-testing",
  "spin-trigger",
+ "spin-world",
  "tracing",
  "wit-bindgen-wasmtime",
 ]
@@ -5357,6 +5366,7 @@ dependencies = [
  "spin-http",
  "spin-testing",
  "spin-trigger",
+ "spin-world",
  "tls-listener",
  "tokio",
  "tokio-rustls",
@@ -5365,6 +5375,13 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-wasmtime",
+]
+
+[[package]]
+name = "spin-world"
+version = "1.2.0-pre0"
+dependencies = [
+ "wasmtime",
 ]
 
 [[package]]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -11,6 +11,7 @@ dotenvy = "0.15"
 once_cell = "1"
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
+spin-world = { path = "../world" }
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 vaultrs = "0.6.2"

--- a/crates/config/src/host_component.rs
+++ b/crates/config/src/host_component.rs
@@ -3,7 +3,8 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use once_cell::sync::OnceCell;
 use spin_app::{AppComponent, DynamicHostComponent};
-use spin_core::{async_trait, config, HostComponent};
+use spin_core::{async_trait, HostComponent};
+use spin_world::config;
 
 use crate::{Error, Key, Provider, Resolver};
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -31,17 +31,6 @@ pub use host_component::{HostComponent, HostComponentDataHandle, HostComponentsD
 pub use io::OutputBuffer;
 pub use store::{Store, StoreBuilder, Wasi};
 
-#[allow(missing_docs)]
-mod bindgen {
-    wasmtime::component::bindgen!({
-        path: "../../wit/preview2",
-        world: "reactor",
-        async: true
-    });
-}
-
-pub use bindgen::*;
-
 /// The default [`EngineBuilder::epoch_tick_interval`].
 pub const DEFAULT_EPOCH_TICK_INTERVAL: Duration = Duration::from_millis(10);
 

--- a/crates/key-value-redis/Cargo.toml
+++ b/crates/key-value-redis/Cargo.toml
@@ -8,5 +8,6 @@ anyhow = "1"
 redis = { version = "0.21", features = ["tokio-comp", "tokio-native-tls-comp"] }
 spin-key-value = { path = "../key-value" }
 spin-core = { path = "../core" }
+spin-world = { path = "../world" }
 tokio = "1"
 url = "2"

--- a/crates/key-value-redis/src/lib.rs
+++ b/crates/key-value-redis/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use redis::{aio::Connection, parse_redis_url, AsyncCommands};
-use spin_core::{async_trait, key_value::Error};
-use spin_key_value::{log_error, Store, StoreManager};
+use spin_core::async_trait;
+use spin_key_value::{log_error, Error, Store, StoreManager};
 use std::sync::Arc;
 use tokio::sync::{Mutex, OnceCell};
 use url::Url;

--- a/crates/key-value-sqlite/Cargo.toml
+++ b/crates/key-value-sqlite/Cargo.toml
@@ -10,3 +10,4 @@ rusqlite = { version = "0.29.0", features = [ "bundled" ] }
 tokio = "1"
 spin-key-value = { path = "../key-value" }
 spin-core = { path = "../core" }
+spin-world = { path = "../world" }

--- a/crates/key-value-sqlite/src/lib.rs
+++ b/crates/key-value-sqlite/src/lib.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use once_cell::sync::OnceCell;
 use rusqlite::Connection;
-use spin_core::{async_trait, key_value::Error};
-use spin_key_value::{log_error, Store, StoreManager};
+use spin_core::async_trait;
+use spin_key_value::{log_error, Error, Store, StoreManager};
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -140,8 +140,8 @@ impl Store for SqliteStore {
 #[cfg(test)]
 mod test {
     use super::*;
-    use spin_core::key_value::Host;
     use spin_key_value::{DelegatingStoreManager, KeyValueDispatch};
+    use spin_world::key_value::Host;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn all() -> Result<()> {

--- a/crates/key-value/Cargo.toml
+++ b/crates/key-value/Cargo.toml
@@ -10,8 +10,9 @@ doctest = false
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "1", features = [ "macros" ] }
-spin-core = { path = "../core" }
 spin-app = { path = "../app" }
+spin-core = { path = "../core" }
+spin-world = { path = "../world" }
 tracing = { workspace = true }
 wit-bindgen-wasmtime = { workspace = true }
 lru = "0.9.0"

--- a/crates/key-value/src/lib.rs
+++ b/crates/key-value/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use spin_app::MetadataKey;
-use spin_core::{async_trait, key_value};
+use spin_core::async_trait;
+use spin_world::key_value;
 use std::{collections::HashSet, sync::Arc};
 use table::Table;
 

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -13,6 +13,7 @@ http = "0.2"
 reqwest = { version = "0.11", features = ["gzip"] }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
+spin-world = { path = "../world" }
 tracing = { workspace = true }
 url = "2.2.1"
 wit-bindgen-wasmtime = { workspace = true }

--- a/crates/outbound-http/src/host_component.rs
+++ b/crates/outbound-http/src/host_component.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 
 use spin_app::DynamicHostComponent;
-use spin_core::{http, Data, HostComponent, Linker};
+use spin_core::{Data, HostComponent, Linker};
+use spin_world::http;
 
 use crate::{allowed_http_hosts::parse_allowed_http_hosts, OutboundHttp};
 

--- a/crates/outbound-http/src/lib.rs
+++ b/crates/outbound-http/src/lib.rs
@@ -7,8 +7,9 @@ use anyhow::Result;
 use http::HeaderMap;
 use reqwest::{Client, Url};
 use spin_app::MetadataKey;
-use spin_core::{
-    async_trait, http as outbound_http,
+use spin_core::async_trait;
+use spin_world::{
+    http as outbound_http,
     http_types::{HeadersParam, HttpError, Method, RequestResult, Response},
 };
 

--- a/crates/outbound-mysql/Cargo.toml
+++ b/crates/outbound-mysql/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 mysql_async = "0.30.0"
 mysql_common = "0.29.1"
 spin-core = { path = "../core" }
+spin-world = { path = "../world" }
 tokio = { version = "1", features = [ "rt-multi-thread" ] }
 tracing = { version = "0.1", features = [ "log" ] }
 url = "2.3.1"

--- a/crates/outbound-mysql/src/lib.rs
+++ b/crates/outbound-mysql/src/lib.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
 pub use mysql::add_to_linker;
 use mysql_async::{consts::ColumnType, from_value_opt, prelude::*, Opts, OptsBuilder, SslOpts};
-use spin_core::{
-    async_trait,
+use spin_core::{async_trait, HostComponent};
+use spin_world::{
     mysql::{self, MysqlError},
     rdbms_types::{Column, DbDataType, DbValue, ParameterValue, RowSet},
-    HostComponent,
 };
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/outbound-pg/Cargo.toml
+++ b/crates/outbound-pg/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 native-tls = "0.2.11"
 postgres-native-tls = "0.5.0"
 spin-core = { path = "../core" }
+spin-world = { path = "../world" }
 tokio = { version = "1", features = [ "rt-multi-thread" ] }
 tokio-postgres = { version = "0.7.7" }
 tracing = { workspace = true }

--- a/crates/outbound-pg/src/lib.rs
+++ b/crates/outbound-pg/src/lib.rs
@@ -1,11 +1,10 @@
 use anyhow::{anyhow, Result};
 use native_tls::TlsConnector;
 use postgres_native_tls::MakeTlsConnector;
-use spin_core::{
-    async_trait,
+use spin_core::{async_trait, HostComponent};
+use spin_world::{
     postgres::{self, PgError},
     rdbms_types::{Column, DbDataType, DbValue, ParameterValue, RowSet},
-    HostComponent,
 };
 use std::collections::HashMap;
 use tokio_postgres::{

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 anyhow = "1.0"
 redis = { version = "0.21", features = ["tokio-comp", "tokio-native-tls-comp"] }
 spin-core = { path = "../core" }
+spin-world = { path = "../world" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }
 wit-bindgen-wasmtime = { workspace = true }

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -4,8 +4,9 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use anyhow::Result;
 use redis::{aio::Connection, AsyncCommands, FromRedisValue, Value};
-use spin_core::{
-    async_trait, redis as outbound_redis,
+use spin_core::async_trait;
+use spin_world::{
+    redis as outbound_redis,
     redis_types::{Error, RedisParameter, RedisResult},
 };
 

--- a/crates/redis/Cargo.toml
+++ b/crates/redis/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1"
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-trigger = { path = "../trigger" }
+spin-world = { path = "../world" }
 redis = { version = "0.21", features = [ "tokio-comp" ] }
 tracing = { workspace = true }
 wit-bindgen-wasmtime = { workspace = true }

--- a/crates/redis/src/spin.rs
+++ b/crates/redis/src/spin.rs
@@ -1,10 +1,8 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use spin_core::{
-    redis_types::{Error, PayloadParam},
-    Instance,
-};
+use spin_core::Instance;
 use spin_trigger::{EitherInstance, TriggerAppEngine};
+use spin_world::redis_types::{Error, PayloadParam};
 
 use crate::{RedisExecutor, RedisTrigger, Store};
 

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -22,8 +22,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
-spin-trigger = { path = "../trigger" }
 spin-http = { path = "../http" }
+spin-trigger = { path = "../trigger" }
+spin-world = { path = "../world" }
 tls-listener = { version = "0.4.0", features = [
     "rustls",
     "hyper-h1",

--- a/crates/trigger-http/src/spin.rs
+++ b/crates/trigger-http/src/spin.rs
@@ -4,11 +4,9 @@ use crate::{HttpExecutor, HttpTrigger, Store};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use hyper::{Body, Request, Response};
-use spin_core::{
-    http_types::{self, Method, RequestParam},
-    Instance,
-};
+use spin_core::Instance;
 use spin_trigger::{EitherInstance, TriggerAppEngine};
+use spin_world::http_types::{self, Method, RequestParam};
 
 #[derive(Clone)]
 pub struct SpinHttpExecutor;

--- a/crates/world/Cargo.toml
+++ b/crates/world/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spin-world"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+wasmtime = { workspace = true }

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -1,0 +1,7 @@
+#![allow(missing_docs)]
+
+wasmtime::component::bindgen!({
+    path: "../../wit/preview2",
+    world: "reactor",
+    async: true
+});

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
  "reqwest",
  "spin-app",
  "spin-core",
+ "spin-world",
  "tracing",
  "url",
  "wit-bindgen-wasmtime",
@@ -2387,6 +2388,7 @@ dependencies = [
  "mysql_async",
  "mysql_common",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "url",
@@ -2401,6 +2403,7 @@ dependencies = [
  "native-tls",
  "postgres-native-tls",
  "spin-core",
+ "spin-world",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -2414,6 +2417,7 @@ dependencies = [
  "anyhow",
  "redis",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
@@ -3428,6 +3432,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-common"
+version = "1.2.0-pre0"
+dependencies = [
+ "anyhow",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "spin-componentize"
 version = "0.1.0"
 source = "git+https://github.com/fermyon/spin-componentize?rev=51c3fade751c4e364142719e42130943fd8b0a76#51c3fade751c4e364142719e42130943fd8b0a76"
@@ -3449,6 +3461,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-core",
+ "spin-world",
  "thiserror",
  "tokio",
  "vaultrs",
@@ -3481,6 +3494,7 @@ dependencies = [
  "lru 0.9.0",
  "spin-app",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
@@ -3494,6 +3508,7 @@ dependencies = [
  "redis",
  "spin-core",
  "spin-key-value",
+ "spin-world",
  "tokio",
  "url",
 ]
@@ -3507,6 +3522,7 @@ dependencies = [
  "rusqlite",
  "spin-core",
  "spin-key-value",
+ "spin-world",
  "tokio",
 ]
 
@@ -3532,7 +3548,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "spin-common",
  "spin-manifest",
  "tempfile",
  "tokio",
@@ -3570,6 +3586,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-app",
+ "spin-common",
  "spin-componentize",
  "spin-config",
  "spin-core",
@@ -3582,6 +3599,13 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "wasmtime",
+]
+
+[[package]]
+name = "spin-world"
+version = "1.2.0-pre0"
+dependencies = [
  "wasmtime",
 ]
 


### PR DESCRIPTION
This moves generated WIT bindings from 'spin-core' to a new 'spin-world' crate.