### PR TITLE
Exercise `spin up --key-value` in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6022,6 +6022,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
+ "getrandom 0.2.8",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ toml = "0.6"
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2.2"
-uuid = "^1.0"
+uuid = { version = "^1.0", features = ["v4"] }
 wasmtime = { workspace = true }
 watchexec = { git = "https://github.com/watchexec/watchexec.git", rev = "8e91d26ef6400c1e60b32a8314cbb144fa33f288" }
 subprocess = "0.2.9"

--- a/tests/testcases/key-value/Cargo.toml
+++ b/tests/testcases/key-value/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1"
 bytes = "1"
 # General-purpose crate with common HTTP types.
 http = "0.2"
+itertools = "0.10"
 spin-sdk = { path = "../../../sdk/rust"}
 # The wit-bindgen-rust dependency generates bindings for interfaces.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }

--- a/tests/testcases/key-value/Cargo.toml
+++ b/tests/testcases/key-value/Cargo.toml
@@ -14,6 +14,8 @@ bytes = "1"
 # General-purpose crate with common HTTP types.
 http = "0.2"
 itertools = "0.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_qs = "0.12"
 spin-sdk = { path = "../../../sdk/rust"}
 # The wit-bindgen-rust dependency generates bindings for interfaces.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }

--- a/tests/testcases/key-value/src/lib.rs
+++ b/tests/testcases/key-value/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::{ensure, Result};
+use itertools::sorted;
 use spin_sdk::{
     http::{Request, Response},
     http_component,
@@ -29,9 +30,16 @@ fn handle_request(_req: Request) -> Result<Response> {
 
     ensure!(b"wow" as &[_] == &store.get("bar")?);
 
-    ensure!(&["bar".to_owned()] as &[_] == &store.get_keys()?);
+    ensure!(b"initval" as &[_] == &store.get("initkey")?);
+
+    ensure!(
+        vec!["bar".to_owned(), "initkey".to_owned()] == sorted(store.get_keys()?).collect::<Vec<_>>(),
+        "Expected exectly keys 'bar' and 'initkey' but got '{:?}'",
+        &store.get_keys()?
+    );
 
     store.delete("bar")?;
+    store.delete("initkey")?;
 
     ensure!(&[] as &[String] == &store.get_keys()?);
 

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -40,6 +40,10 @@ pub mod all {
             .name("key-value".to_string())
             .appname(Some("key-value".to_string()))
             .template(None)
+            .deploy_args(vec![
+                "--key-value".to_string(),
+                "initkey=initval".to_string(),
+            ])
             .assertions(
                 |metadata: AppMetadata,
                  stdout_stream: Option<BufReader<ChildStdout>>,

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -20,13 +20,19 @@ pub mod all {
     pub async fn key_value_works(controller: &dyn Controller) {
         async fn checks(
             metadata: AppMetadata,
+            test_init_key: String,
+            test_init_value: String,
             // TODO: investigate why omitting these two next parameters does not
             // cause a compile time error but causes a runtime one
             _: Option<BufReader<ChildStdout>>,
             _: Option<BufReader<ChildStderr>>,
         ) -> Result<()> {
             assert_http_response(
-                get_url(metadata.base.as_str(), "/test").as_str(),
+                get_url(
+                    metadata.base.as_str(),
+                    &format!("/test?testkey={test_init_key}&testval={test_init_value}"),
+                )
+                .as_str(),
                 Method::GET,
                 "",
                 200,
@@ -36,19 +42,24 @@ pub mod all {
             .await
         }
 
+        let init_key = uuid::Uuid::new_v4().to_string();
+        let init_value = uuid::Uuid::new_v4().to_string();
+
         let tc = TestCaseBuilder::default()
             .name("key-value".to_string())
             .appname(Some("key-value".to_string()))
             .template(None)
             .deploy_args(vec![
                 "--key-value".to_string(),
-                "initkey=initval".to_string(),
+                format!("{init_key}={init_value}"),
             ])
             .assertions(
-                |metadata: AppMetadata,
-                 stdout_stream: Option<BufReader<ChildStdout>>,
-                 stderr_stream: Option<BufReader<ChildStderr>>| {
-                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                move |metadata: AppMetadata,
+                      stdout_stream: Option<BufReader<ChildStdout>>,
+                      stderr_stream: Option<BufReader<ChildStderr>>| {
+                    let ik = init_key.clone();
+                    let iv = init_value.clone();
+                    Box::pin(checks(metadata, ik, iv, stdout_stream, stderr_stream))
                 },
             )
             .build()


### PR DESCRIPTION
Main question is whether this should be covered in the existing KV test (as is done here) or broken out into a separate test.

(It would also be nice to generate a random init pair but at the moment it is a bit painful to tell the guest module what the random values are.)