### PR TITLE
Rationalise `-f` and accept directory everywhere

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -42,14 +42,17 @@ const BINDLE_REGISTRY_URL_PATH: &str = "api/registry";
 #[derive(Parser, Debug)]
 #[clap(about = "Package and upload an application to the Fermyon Platform")]
 pub struct DeployCommand {
-    /// Path to spin.toml
+    /// The application to deploy. This may be a manifest (spin.toml) file, or a
+    /// directory containing a spin.toml file.
+    /// If omitted, it defaults to "spin.toml".
     #[clap(
         name = APP_MANIFEST_FILE_OPT,
         short = 'f',
-        long = "file",
-        default_value = "spin.toml"
+        long = "from",
+        alias = "file",
+        default_value = DEFAULT_MANIFEST_FILE
     )]
-    pub app: PathBuf,
+    pub app_source: PathBuf,
 
     /// Path to assemble the bindle before pushing (defaults to
     /// a temporary directory)
@@ -225,6 +228,10 @@ impl DeployCommand {
         }
     }
 
+    fn app(&self) -> anyhow::Result<PathBuf> {
+        crate::manifest::resolve_file_path(&self.app_source)
+    }
+
     // TODO: unify with login
     fn config_file_path(&self) -> Result<PathBuf> {
         let root = dirs::config_dir()
@@ -243,7 +250,7 @@ impl DeployCommand {
     }
 
     async fn deploy_hippo(self, login_connection: LoginConnection) -> Result<()> {
-        let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app).await?;
+        let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app()?).await?;
         let cfg = cfg_any.into_v1();
 
         ensure!(!cfg.components.is_empty(), "No components in spin.toml!");
@@ -371,7 +378,7 @@ impl DeployCommand {
 
         let client = CloudClient::new(connection_config.clone());
 
-        let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app).await?;
+        let cfg_any = spin_loader::local::raw_manifest_from_file(&self.app()?).await?;
         let cfg = cfg_any.into_v1();
 
         validate_cloud_app(&cfg)?;
@@ -510,8 +517,9 @@ impl DeployCommand {
     }
 
     async fn compute_buildinfo(&self, cfg: &RawAppManifest) -> Result<BuildMetadata> {
+        let app_file = self.app()?;
         let mut sha256 = Sha256::new();
-        let app_folder = parent_dir(&self.app)?;
+        let app_folder = parent_dir(&app_file)?;
 
         for x in cfg.components.iter() {
             match &x.source {
@@ -535,7 +543,7 @@ impl DeployCommand {
             }
         }
 
-        let mut r = File::open(&self.app)?;
+        let mut r = File::open(&app_file)?;
         copy(&mut r, &mut sha256)?;
 
         let mut final_digest = format!("q{:x}", sha256.finalize());
@@ -677,7 +685,7 @@ impl DeployCommand {
             Some(path) => path.as_path(),
         };
 
-        let bindle_id = spin_bindle::prepare_bindle(&self.app, buildinfo, dest_dir)
+        let bindle_id = spin_bindle::prepare_bindle(&self.app()?, buildinfo, dest_dir)
             .await
             .map_err(crate::wrap_prepare_bindle_error)?;
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -28,13 +28,17 @@ impl RegistryCommands {
 
 #[derive(Parser, Debug)]
 pub struct Push {
-    /// Path to spin.toml
+    /// The application to push. This may be a manifest (spin.toml) file, or a
+    /// directory containing a spin.toml file.
+    /// If omitted, it defaults to "spin.toml".
     #[clap(
         name = APP_MANIFEST_FILE_OPT,
         short = 'f',
-        long = "file",
+        long = "from",
+        alias = "file",
+        default_value = DEFAULT_MANIFEST_FILE
     )]
-    pub app: Option<PathBuf>,
+    pub app_source: PathBuf,
 
     /// Ignore server certificate errors
     #[clap(
@@ -52,10 +56,7 @@ pub struct Push {
 
 impl Push {
     pub async fn run(self) -> Result<()> {
-        let app_file = self
-            .app
-            .as_deref()
-            .unwrap_or_else(|| DEFAULT_MANIFEST_FILE.as_ref());
+        let app_file = crate::manifest::resolve_file_path(&self.app_source)?;
 
         let dir = tempfile::tempdir()?;
         let app = spin_loader::local::from_file(&app_file, Some(dir.path())).await?;

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -243,24 +243,9 @@ impl UpCommand {
     }
 
     fn infer_file_source(path: impl Into<PathBuf>) -> AppSource {
-        let path = path.into();
-        if path.is_file() {
-            AppSource::File(path)
-        } else if path.is_dir() {
-            let file_path = path.join(DEFAULT_MANIFEST_FILE);
-            if file_path.exists() && file_path.is_file() {
-                AppSource::File(file_path)
-            } else {
-                AppSource::unresolvable(format!(
-                    "Directory {} does not contain a file named 'spin.toml'",
-                    path.display()
-                ))
-            }
-        } else {
-            AppSource::unresolvable(format!(
-                "Path {} is neither a file nor a directory",
-                path.display()
-            ))
+        match crate::manifest::resolve_file_path(path.into()) {
+            Ok(file) => AppSource::File(file),
+            Err(e) => AppSource::Unresolvable(e.to_string()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod manifest;
 pub(crate) mod opts;
 mod watch_filter;
 mod watch_state;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,32 @@
+use anyhow::anyhow;
+use std::path::{Path, PathBuf};
+
+use crate::opts::DEFAULT_MANIFEST_FILE;
+
+/// Resolves a manifest path provided by a user, which may be a file or
+/// directory, to a path to a manifest file.
+pub(crate) fn resolve_file_path(provided_path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
+    let path = provided_path.as_ref();
+
+    if path.is_file() {
+        Ok(path.to_owned())
+    } else if path.is_dir() {
+        let file_path = path.join(DEFAULT_MANIFEST_FILE);
+        if file_path.is_file() {
+            Ok(file_path)
+        } else {
+            Err(anyhow!(
+                "Directory {} does not contain a file named 'spin.toml'",
+                path.display()
+            ))
+        }
+    } else {
+        let pd = path.display();
+        let err = match path.try_exists() {
+            Err(e) => anyhow!("Error accessing path {pd}: {e:#}"),
+            Ok(false) => anyhow!("No such file or directory '{pd}'"),
+            Ok(true) => anyhow!("Path {pd} is neither a file nor a directory"),
+        };
+        Err(err)
+    }
+}


### PR DESCRIPTION
At the moment, `spin up` allows you to pass a directory to `-f` e.g. `spin up -f myapp/`, but `build`, `deploy`, `registry push` and `watch` do not.  This rationalises the implementation of the `-f` option across those commands.  Please let me know if there's anywhere I've missed!

Note that `up` is still slightly different because it accepts registry references as well.  So I'd welcome feedback on whether changing the long form to be `--from` across all commands is reasonable or confusing.  (I have kept the `--file` alias so backward compatibility is maintained.)

cc @lann for `spin doctor`
