### PR TITLE
ref(sdk/go): use `spin build` for building test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ ignored-assets
 main.wasm
 .parcel-cache
 .vscode/*.log
-go.sum
 tests/**/Cargo.lock
 crates/**/Cargo.lock
 examples/**/Cargo.lock

--- a/examples/config-tinygo/go.sum
+++ b/examples/config-tinygo/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/examples/http-tinygo-outbound-http/go.sum
+++ b/examples/http-tinygo-outbound-http/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/examples/http-tinygo/go.sum
+++ b/examples/http-tinygo/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/examples/tinygo-key-value/go.sum
+++ b/examples/tinygo-key-value/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/examples/tinygo-redis/go.sum
+++ b/examples/tinygo-redis/go.sum
@@ -1,0 +1,1 @@
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/sdk/go/http/testdata/http-tinygo/spin.toml
+++ b/sdk/go/http/testdata/http-tinygo/spin.toml
@@ -10,3 +10,5 @@ id = "http-tinygo-test"
 source = "main.wasm"
 [component.trigger]
 route = "/hello/..."
+[component.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"

--- a/sdk/go/http/testdata/spin-roundtrip/spin.toml
+++ b/sdk/go/http/testdata/spin-roundtrip/spin.toml
@@ -11,3 +11,5 @@ source = "main.wasm"
 allowed_http_hosts = ["example.com"]
 [component.trigger]
 route = "/hello/..."
+[component.build]
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"

--- a/sdk/go/integration_test.go
+++ b/sdk/go/integration_test.go
@@ -17,14 +17,14 @@ const spinBinary = "../../target/debug/spin"
 func retryGet(t *testing.T, url string) *http.Response {
 	t.Helper()
 
-	const maxTries = 24
+	const maxTries = 120 // (10min/5sec)
 	for i := 1; i < maxTries; i++ {
 		if res, err := http.Get(url); err != nil {
 			t.Log(err)
 		} else {
 			return res
 		}
-		time.Sleep(4 * time.Second)
+		time.Sleep(5 * time.Second)
 	}
 	t.Fatal("Get request timeout: ", url)
 	return nil
@@ -37,7 +37,8 @@ type testSpin struct {
 }
 
 func startSpin(t *testing.T, spinfile string) *testSpin {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	// long timeout because... ci
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 
 	url := getFreePort(t)
 


### PR DESCRIPTION
This commit changes test fixtures to be built using `spin build` rather than using TinyGo directly.