### PR TITLE
Remove autobindle from recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,5 @@
     "recommendations": [
         "rust-lang.rust-analyzer",
         "serayuzgur.crates",
-        "fermyon.autobindle",
     ]
 }


### PR DESCRIPTION
It no longer seems like good value for money.
