### PR TITLE
ensure deterministic component iteration order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5352,6 +5352,7 @@ dependencies = [
  "ctrlc",
  "dirs 4.0.0",
  "futures",
+ "indexmap",
  "outbound-http",
  "outbound-mysql",
  "outbound-pg",

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "3.1.15", features = ["derive", "env"] }
 ctrlc = { version = "3.2", features = ["termination"] }
 dirs = "4"
 futures = "0.3"
+indexmap = "1"
 outbound-http = { path = "../outbound-http" }
 outbound-redis = { path = "../outbound-redis" }
 outbound-pg = { path = "../outbound-pg" }

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -8,6 +8,7 @@ use std::{collections::HashMap, marker::PhantomData, path::PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 pub use async_trait::async_trait;
+use indexmap::IndexMap;
 use serde::de::DeserializeOwned;
 
 use spin_app::{App, AppComponent, AppLoader, AppTrigger, Loader, OwnedApp};
@@ -194,7 +195,7 @@ impl<Executor: TriggerExecutor> TriggerAppEngine<Executor> {
                     })?,
                 ))
             })
-            .collect::<Result<HashMap<_, _>>>()?;
+            .collect::<Result<IndexMap<_, _>>>()?;
 
         let mut component_instance_pres = HashMap::default();
         for component in app.borrowed().components() {

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -3437,6 +3437,7 @@ version = "1.2.0-pre0"
 dependencies = [
  "anyhow",
  "sha2 0.10.6",
+ "tokio",
 ]
 
 [[package]]
@@ -3578,6 +3579,7 @@ dependencies = [
  "ctrlc",
  "dirs",
  "futures",
+ "indexmap",
  "outbound-http",
  "outbound-mysql",
  "outbound-pg",


### PR DESCRIPTION
This regressed due to changes I made to `TriggerAppEngine::new` to support components.  I used a `HashMap` without realizing the iteration order of triggers (and their configs) matters.

Fixes #1469