### PR TITLE
Add 'a' as short argumet for --accept-defaults

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -49,7 +49,7 @@ pub struct TemplateNewCommandCore {
 
     /// An optional argument that allows to skip prompts for the manifest file
     /// by accepting the defaults if available on the template
-    #[clap(long = "accept-defaults", takes_value = false)]
+    #[clap(short = 'a', long = "accept-defaults", takes_value = false)]
     pub accept_defaults: bool,
 }
 


### PR DESCRIPTION
Implements #1473 

Not sure if `-a` is the better option for this? Maybe `-d`?

Marking this as a draft, since the issue was create simultaneously.