### PR TITLE
feat(sdk/rust): add optional feature for serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -4614,13 +4614,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -4634,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -5282,6 +5282,8 @@ dependencies = [
  "form_urlencoded",
  "http",
  "routefinder",
+ "serde",
+ "serde_json",
  "spin-macro",
  "thiserror",
  "wit-bindgen-rust",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -17,7 +17,10 @@ spin-macro = { path = "macro" }
 thiserror = "1.0.37"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 routefinder = "0.5.3"
+serde_json = {version = "1.0.96", optional = true}
+serde = {version = "1.0.163", optional = true}
 
 [features]
-default = [ "export-sdk-language" ]
+default = ["export-sdk-language"]
 export-sdk-language = []
+json = ["dep:serde", "dep:serde_json"]


### PR DESCRIPTION
This commit updates the Rust SDK to include two new functions that integrates key/value with serde. Specifically:

- `set_json`: this function takes a key and a struct that can be serialized by serde into JSON, and that representation is added to the store
- `get_json`: this function takes a key, reads the key/value pair from the store, then deserializes it into the specified type

Considering that storing serialized state in Spin's key/value store is one of the popular use cases for the API, these convenience functions shoudl simplify that operation.

This functionality is added as an optional feature in the SDK, so it doesn't add to the binary size of the resulting component unless needed.