### PR TITLE
feat(plugins): show description and homepage of installed plugin

### DIFF
--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -45,11 +45,7 @@ impl PluginManifest {
     }
 
     pub fn homepage_url(&self) -> Option<Url> {
-        self.homepage
-            .as_deref()
-            .into_iter()
-            .flat_map(Url::parse)
-            .next()
+        Url::parse(&self.homepage?).ok()
     }
 
     pub fn has_compatible_package(&self) -> bool {

--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -45,7 +45,7 @@ impl PluginManifest {
     }
 
     pub fn homepage_url(&self) -> Option<Url> {
-        Url::parse(&self.homepage).ok()
+        Url::parse(self.homepage.as_deref()?).ok()
     }
 
     pub fn has_compatible_package(&self) -> bool {

--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::PluginStore;
 
@@ -38,6 +39,19 @@ impl PluginManifest {
     pub fn license(&self) -> &str {
         self.license.as_ref()
     }
+
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    pub fn homepage_url(&self) -> Option<Url> {
+        self.homepage
+            .as_deref()
+            .into_iter()
+            .flat_map(Url::parse)
+            .next()
+    }
+
     pub fn has_compatible_package(&self) -> bool {
         self.packages.iter().any(|p| p.matches_current_os_arch())
     }

--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -45,7 +45,7 @@ impl PluginManifest {
     }
 
     pub fn homepage_url(&self) -> Option<Url> {
-        Url::parse(&self.homepage?).ok()
+        Url::parse(&self.homepage).ok()
     }
 
     pub fn has_compatible_package(&self) -> bool {

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -467,6 +467,17 @@ async fn try_install(
     if continue_to_install(manifest, package, yes_to_all)? {
         let installed = manager.install(manifest, package).await?;
         println!("Plugin '{installed}' was installed successfully!");
+
+        if let Some(description) = manifest.description() {
+            println!("\nDescription:");
+            println!("\t{description}");
+        }
+
+        if let Some(homepage) = manifest.homepage_url().filter(|h| h.scheme() == "https") {
+            println!("\nHomepage:");
+            println!("\t{homepage}");
+        }
+
         Ok(true)
     } else {
         Ok(false)


### PR DESCRIPTION
It would be nice to give plugins a chance to display something once they're installed such as instructions or notices.

Showing the description would be a good start.

I also included the homepage (if it's HTTPS) as a good place to link to some documentation.