### PR TITLE
Validate components are not granted access to undefined k/v stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-spin-up:
 
 .PHONY: test-kv
 test-kv:
-	RUST_LOG=$(LOG_LEVEL) cargo test --test spinup_tests --features e2e-tests --no-fail-fast -- spinup_tests::key_value_works --nocapture
+	RUST_LOG=$(LOG_LEVEL) cargo test --test spinup_tests --features e2e-tests --no-fail-fast -- spinup_tests::key_value --nocapture
 
 .PHONY: test-outbound-redis
 test-outbound-redis:

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -102,7 +102,7 @@ impl AppLoader {
         };
         self.dynamic_host_components
             .validate_app(&app)
-            .map_err(Error::HostComponentError)?;
+            .map_err(Error::ValidationError)?;
         Ok(app)
     }
 
@@ -378,4 +378,7 @@ pub enum Error {
     /// An error indicating failed JSON (de)serialization.
     #[error("json error: {0}")]
     JsonError(#[from] serde_json::Error),
+    /// A validation error that can be presented directly to the user.
+    #[error(transparent)]
+    ValidationError(anyhow::Error),
 }

--- a/crates/key-value-redis/src/lib.rs
+++ b/crates/key-value-redis/src/lib.rs
@@ -41,6 +41,10 @@ impl StoreManager for KeyValueRedis {
             connection: connection.clone(),
         }))
     }
+
+    fn is_defined(&self, _store_name: &str) -> bool {
+        true
+    }
 }
 
 struct RedisStore {

--- a/crates/key-value-sqlite/src/lib.rs
+++ b/crates/key-value-sqlite/src/lib.rs
@@ -61,6 +61,10 @@ impl StoreManager for KeyValueSqlite {
             connection: connection.clone(),
         }))
     }
+
+    fn is_defined(&self, _store_name: &str) -> bool {
+        true
+    }
 }
 
 struct SqliteStore {

--- a/crates/key-value/src/lib.rs
+++ b/crates/key-value/src/lib.rs
@@ -21,6 +21,7 @@ pub use key_value::{Error, Store as StoreHandle};
 #[async_trait]
 pub trait StoreManager: Sync + Send {
     async fn get(&self, name: &str) -> Result<Arc<dyn Store>, Error>;
+    fn is_defined(&self, store_name: &str) -> bool;
 }
 
 #[async_trait]

--- a/crates/key-value/src/util.rs
+++ b/crates/key-value/src/util.rs
@@ -21,6 +21,10 @@ impl StoreManager for EmptyStoreManager {
     async fn get(&self, _name: &str) -> Result<Arc<dyn Store>, Error> {
         Err(Error::NoSuchStore)
     }
+
+    fn is_defined(&self, _store_name: &str) -> bool {
+        false
+    }
 }
 
 pub struct DelegatingStoreManager {
@@ -42,6 +46,10 @@ impl StoreManager for DelegatingStoreManager {
             .ok_or(Error::NoSuchStore)?
             .get(name)
             .await
+    }
+
+    fn is_defined(&self, store_name: &str) -> bool {
+        self.delegates.contains_key(store_name)
     }
 }
 
@@ -94,6 +102,10 @@ impl<T: StoreManager> StoreManager for CachingStoreManager<T> {
                 previous_task: None,
             }),
         }))
+    }
+
+    fn is_defined(&self, store_name: &str) -> bool {
+        self.inner.is_defined(store_name)
     }
 }
 

--- a/tests/spinup_tests.rs
+++ b/tests/spinup_tests.rs
@@ -16,6 +16,11 @@ mod spinup_tests {
     }
 
     #[tokio::test]
+    async fn key_value_validation_works() {
+        testcases::all::key_value_validation_works(CONTROLLER).await
+    }
+
+    #[tokio::test]
     async fn http_go_works() {
         testcases::all::http_go_works(CONTROLLER).await
     }

--- a/tests/testcases/key-value-undefined-store/.cargo/config.toml
+++ b/tests/testcases/key-value-undefined-store/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/tests/testcases/key-value-undefined-store/Cargo.toml
+++ b/tests/testcases/key-value-undefined-store/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name    = "key-value-undefined-store"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# General-purpose crate with common HTTP types.
+http = "0.2"
+itertools = "0.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_qs = "0.12"
+spin-sdk = { path = "../../../sdk/rust"}
+# The wit-bindgen-rust dependency generates bindings for interfaces.
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[workspace]

--- a/tests/testcases/key-value-undefined-store/spin.toml
+++ b/tests/testcases/key-value-undefined-store/spin.toml
@@ -1,0 +1,16 @@
+spin_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that requests access to an undefined key/value store."
+name = "key-value"
+trigger = {type = "http", base = "/test"}
+version = "1.0.0"
+
+[[component]]
+id = "hello"
+# intentionally use undefined ~words~ stores
+key_value_stores = ["default", "anaspeptic", "pericombobulations"]
+source = "target/wasm32-wasi/release/key_value_undefined_store.wasm"
+[component.trigger]
+route = "/..."
+[component.build]
+command = "cargo build --release --target wasm32-wasi"

--- a/tests/testcases/key-value-undefined-store/src/lib.rs
+++ b/tests/testcases/key-value-undefined-store/src/lib.rs
@@ -1,0 +1,61 @@
+use anyhow::{ensure, Result};
+use itertools::sorted;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    key_value::{Error, Store},
+};
+
+#[http_component]
+fn handle_request(req: Request) -> Result<Response> {
+    // TODO: once we allow users to pass non-default stores, test that opening
+    // an allowed-but-non-existent one returns Error::NoSuchStore
+    ensure!(matches!(Store::open("forbidden"), Err(Error::AccessDenied)));
+
+    let query = req.uri().query().expect("Should have a testkey query string");
+    let query: std::collections::HashMap::<String, String> = serde_qs::from_str(query)?;
+    let init_key = query.get("testkey").expect("Should have a testkey query string");
+    let init_val = query.get("testval").expect("Should have a testval query string");
+
+    let store = Store::open_default()?;
+
+    store.delete("bar")?;
+
+    ensure!(!store.exists("bar")?);
+
+    ensure!(matches!(store.get("bar"), Err(Error::NoSuchKey)));
+
+    store.set("bar", b"baz")?;
+
+    ensure!(store.exists("bar")?);
+
+    ensure!(b"baz" as &[_] == &store.get("bar")?);
+
+    store.set("bar", b"wow")?;
+
+    ensure!(b"wow" as &[_] == &store.get("bar")?);
+
+    ensure!(
+        init_val.as_bytes() == &store.get(&init_key)?,
+        "Expected to look up {init_key} and get {init_val} but actually got {}",
+        String::from_utf8_lossy(&store.get(&init_key)?)
+    );
+
+    ensure!(
+        sorted(vec!["bar".to_owned(), init_key.to_owned()]).collect::<Vec<_>>() == sorted(store.get_keys()?).collect::<Vec<_>>(),
+        "Expected exectly keys 'bar' and '{}' but got '{:?}'",
+        init_key,
+        &store.get_keys()?
+    );
+
+    store.delete("bar")?;
+    store.delete(&init_key)?;
+
+    ensure!(&[] as &[String] == &store.get_keys()?);
+
+    ensure!(!store.exists("bar")?);
+
+    ensure!(matches!(store.get("bar"), Err(Error::NoSuchKey)));
+
+    Ok(http::Response::builder().status(200).body(None)?)
+}

--- a/tests/testcases/key-value-undefined-store/src/lib.rs
+++ b/tests/testcases/key-value-undefined-store/src/lib.rs
@@ -8,54 +8,7 @@ use spin_sdk::{
 
 #[http_component]
 fn handle_request(req: Request) -> Result<Response> {
-    // TODO: once we allow users to pass non-default stores, test that opening
-    // an allowed-but-non-existent one returns Error::NoSuchStore
-    ensure!(matches!(Store::open("forbidden"), Err(Error::AccessDenied)));
-
-    let query = req.uri().query().expect("Should have a testkey query string");
-    let query: std::collections::HashMap::<String, String> = serde_qs::from_str(query)?;
-    let init_key = query.get("testkey").expect("Should have a testkey query string");
-    let init_val = query.get("testval").expect("Should have a testval query string");
-
-    let store = Store::open_default()?;
-
-    store.delete("bar")?;
-
-    ensure!(!store.exists("bar")?);
-
-    ensure!(matches!(store.get("bar"), Err(Error::NoSuchKey)));
-
-    store.set("bar", b"baz")?;
-
-    ensure!(store.exists("bar")?);
-
-    ensure!(b"baz" as &[_] == &store.get("bar")?);
-
-    store.set("bar", b"wow")?;
-
-    ensure!(b"wow" as &[_] == &store.get("bar")?);
-
-    ensure!(
-        init_val.as_bytes() == &store.get(&init_key)?,
-        "Expected to look up {init_key} and get {init_val} but actually got {}",
-        String::from_utf8_lossy(&store.get(&init_key)?)
-    );
-
-    ensure!(
-        sorted(vec!["bar".to_owned(), init_key.to_owned()]).collect::<Vec<_>>() == sorted(store.get_keys()?).collect::<Vec<_>>(),
-        "Expected exectly keys 'bar' and '{}' but got '{:?}'",
-        init_key,
-        &store.get_keys()?
-    );
-
-    store.delete("bar")?;
-    store.delete(&init_key)?;
-
-    ensure!(&[] as &[String] == &store.get_keys()?);
-
-    ensure!(!store.exists("bar")?);
-
-    ensure!(matches!(store.get("bar"), Err(Error::NoSuchKey)));
-
+    // We don't need to do anything here: it should never get called because
+    // spin up should fail at K/V validation.
     Ok(http::Response::builder().status(200).body(None)?)
 }

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -68,6 +68,45 @@ pub mod all {
         tc.run(controller).await.unwrap()
     }
 
+    pub async fn key_value_validation_works(controller: &dyn Controller) {
+        async fn checks(
+            _: AppMetadata,
+            _: Option<BufReader<ChildStdout>>,
+            _: Option<BufReader<ChildStderr>>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        let tc = TestCaseBuilder::default()
+            .name("key-value-undefined-store".to_string())
+            .appname(Some("key-value-undefined-store".to_string()))
+            .template(None)
+            .assertions(
+                |metadata: AppMetadata,
+                 stdout_stream: Option<BufReader<ChildStdout>>,
+                 stderr_stream: Option<BufReader<ChildStderr>>| {
+                    Box::pin(checks(metadata, stdout_stream, stderr_stream))
+                },
+            )
+            .build()
+            .unwrap();
+
+        let e = tc.run(controller).await.unwrap_err();
+        let err_text = format!("{e:#}");
+
+        let expected1 = "Component hello uses store 'anaspeptic'";
+        let expected2 = "Component hello uses store 'pericombobulations'";
+
+        assert!(
+            err_text.contains(expected1),
+            "Expected error containing '{expected1}' but got '{err_text}'"
+        );
+        assert!(
+            err_text.contains(expected2),
+            "Expected error containing '{expected2}' but got '{err_text}'"
+        );
+    }
+
     pub async fn http_python_works(controller: &dyn Controller) {
         async fn checks(
             metadata: AppMetadata,


### PR DESCRIPTION
```
ivan@hecate:~/testing/kvmadness$ spin up
Error: host component error: Component kvmadness is granted access to key-value store 'bibblybobbly', which is not defined

Caused by:
    Component kvmadness is granted access to key-value store 'bibblybobbly', which is not defined
Error: exit status: 1
ivan@hecate:~/testing/kvmadness$ spin up --runtime-config-file runtime-config.toml
Logging component stdio to ".spin/logs/"
Storing default key-value data to ".spin/my_super_duper_store.db"

Serving http://127.0.0.1:3000
Available Routes:
  kvmadness: http://127.0.0.1:3000 (wildcard)
```

(I'm not mad keen on the "host component error" string or the duplicated text, but this is a "should rarely happen" error so I'm wary of changing things that might break existing error paths.)