### PR TITLE
feat(plugins): provide additional build info to plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,26 +1488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-iterator"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,18 +1885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,19 +1893,6 @@ dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "git2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "libgit2-sys",
- "log",
- "url",
 ]
 
 [[package]]
@@ -2815,18 +2770,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,7 +2797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -6115,17 +6057,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "c1b86a8af1dedf089b1c78338678e4c7492b6045649042d94faf19690499d236"
 dependencies = [
  "anyhow",
- "cfg-if",
- "enum-iterator",
- "getset",
- "git2",
  "rustversion",
- "thiserror",
  "time 0.3.20",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,9 +85,11 @@ e2e-testing = { path = "crates/e2e-testing" }
 
 [build-dependencies]
 cargo-target-dep = { git = "https://github.com/fermyon/cargo-target-dep", rev = "b7b1989fe0984c0f7c4966398304c6538e52fe49" }
-vergen = { version = "7", default-features = false, features = [
+vergen = { version = "8", default-features = false, features = [
   "build",
   "git",
+  "gitcl",
+  "cargo",
 ] }
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -14,10 +14,18 @@ const RUST_OUTBOUND_REDIS_INTEGRATION_TEST: &str = "tests/outbound-redis/http-ru
 const TIMER_TRIGGER_INTEGRATION_TEST: &str = "examples/spin-timer/app-example";
 
 fn main() {
-    let mut config = vergen::Config::default();
-    *config.git_mut().sha_kind_mut() = vergen::ShaKind::Short;
-    *config.git_mut().commit_timestamp_kind_mut() = vergen::TimestampKind::DateOnly;
-    vergen::vergen(config).expect("failed to extract build information");
+    vergen::EmitBuilder::builder()
+        .build_date()
+        .build_timestamp()
+        .cargo_target_triple()
+        .cargo_debug()
+        .git_branch()
+        .git_commit_date()
+        .git_commit_timestamp()
+        .git_sha(true)
+        .fail_on_error()
+        .emit()
+        .expect("failed to extract build information");
 
     let build_spin_tests = env::var("BUILD_SPIN_EXAMPLES")
         .map(|v| v == "1")

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -2,6 +2,7 @@ use anyhow::Error;
 use clap::{CommandFactory, Parser, Subcommand};
 use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
+use spin_cli::build_info::*;
 use spin_cli::commands::{
     build::BuildCommand,
     cloud::CloudCommands,
@@ -46,7 +47,7 @@ fn version() -> &'static str {
 #[derive(Parser)]
 #[clap(
     name = "spin",
-    version = version(),
+    version = version()
 )]
 enum SpinApp {
     #[clap(subcommand, alias = "template")]
@@ -105,10 +106,5 @@ impl SpinApp {
 
 /// Returns build information, similar to: 0.1.0 (2be4034 2022-03-31).
 fn build_info() -> String {
-    format!(
-        "{} ({} {})",
-        env!("VERGEN_BUILD_SEMVER"),
-        env!("VERGEN_GIT_SHA_SHORT"),
-        env!("VERGEN_GIT_COMMIT_DATE")
-    )
+    format!("{SPIN_VERSION} ({SPIN_COMMIT_SHA} {SPIN_COMMIT_DATE})")
 }

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,24 @@
+//! Build information for the Spin CLI.
+
+/// The version of the Spin CLI.
+pub const SPIN_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// The major version of the Spin CLI.
+pub const SPIN_VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
+/// The minor version of the Spin CLI.
+pub const SPIN_VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
+/// The patch version of the Spin CLI.
+pub const SPIN_VERSION_PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
+/// The pre-release version of the Spin CLI.
+pub const SPIN_VERSION_PRE: &str = env!("CARGO_PKG_VERSION_PRE");
+/// The build date of the Spin CLI.
+pub const SPIN_BUILD_DATE: &str = env!("VERGEN_BUILD_DATE");
+/// The commit hash of the Spin CLI.
+pub const SPIN_COMMIT_SHA: &str = env!("VERGEN_GIT_SHA");
+/// The commit date of the Spin CLI.
+pub const SPIN_COMMIT_DATE: &str = env!("VERGEN_GIT_COMMIT_DATE");
+/// The branch of the Spin CLI.
+pub const SPIN_BRANCH: &str = env!("VERGEN_GIT_BRANCH");
+/// The target triple of the Spin CLI.
+pub const SPIN_TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
+/// The profile of the Spin CLI.
+pub const SPIN_DEBUG: &str = env!("VERGEN_CARGO_DEBUG");

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -1,3 +1,4 @@
+use crate::build_info::*;
 use crate::opts::PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG;
 use anyhow::{anyhow, Result};
 use spin_plugins::{error::Error, manifest::warn_unsupported_version, PluginStore};
@@ -40,9 +41,8 @@ pub async fn execute_external_subcommand(
     let plugin_store = PluginStore::try_default()?;
     match plugin_store.read_plugin_manifest(&plugin_name) {
         Ok(manifest) => {
-            let spin_version = env!("VERGEN_BUILD_SEMVER");
             if let Err(e) =
-                warn_unsupported_version(&manifest, spin_version, override_compatibility_check)
+                warn_unsupported_version(&manifest, SPIN_VERSION, override_compatibility_check)
             {
                 eprintln!("{e}");
                 process::exit(1);
@@ -102,19 +102,26 @@ fn similar_commands(app: clap::App, target: &str) -> Vec<String> {
 
 fn get_env_vars_map() -> Result<HashMap<String, String>> {
     let map: HashMap<String, String> = vec![
+        ("SPIN_VERSION", SPIN_VERSION),
+        ("SPIN_VERSION_MAJOR", SPIN_VERSION_MAJOR),
+        ("SPIN_VERSION_MINOR", SPIN_VERSION_MINOR),
+        ("SPIN_VERSION_PATCH", SPIN_VERSION_PATCH),
+        ("SPIN_VERSION_PRE", SPIN_VERSION_PRE),
+        ("SPIN_COMMIT_SHA", SPIN_COMMIT_SHA),
+        ("SPIN_COMMIT_DATE", SPIN_COMMIT_DATE),
+        ("SPIN_BRANCH", SPIN_BRANCH),
+        ("SPIN_BUILD_DATE", SPIN_BUILD_DATE),
+        ("SPIN_TARGET_TRIPLE", SPIN_TARGET_TRIPLE),
+        ("SPIN_DEBUG", SPIN_DEBUG),
         (
-            "SPIN_VERSION".to_string(),
-            env!("VERGEN_BUILD_SEMVER").to_owned(),
-        ),
-        (
-            "SPIN_BIN_PATH".to_string(),
+            "SPIN_BIN_PATH",
             env::current_exe()?
                 .to_str()
-                .ok_or_else(|| anyhow!("Could not convert binary path to string"))?
-                .to_string(),
+                .ok_or_else(|| anyhow!("Could not convert binary path to string"))?,
         ),
     ]
     .into_iter()
+    .map(|(k, v)| (k.to_string(), v.to_string()))
     .collect();
     Ok(map)
 }

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use tracing::log;
 use url::Url;
 
+use crate::build_info::*;
 use crate::opts::*;
 
 /// Install/uninstall Spin plugins.
@@ -373,7 +374,7 @@ pub(crate) enum PluginCompatibility {
 impl PluginCompatibility {
     pub(crate) fn for_current(manifest: &PluginManifest) -> Self {
         if manifest.has_compatible_package() {
-            let spin_version = env!("VERGEN_BUILD_SEMVER");
+            let spin_version = SPIN_VERSION;
             if manifest.is_compatible_spin_version(spin_version) {
                 Self::Compatible
             } else {
@@ -450,10 +451,9 @@ async fn try_install(
     override_compatibility_check: bool,
     downgrade: bool,
 ) -> Result<bool> {
-    let spin_version = env!("VERGEN_BUILD_SEMVER");
     let install_action = manager.check_manifest(
         manifest,
-        spin_version,
+        SPIN_VERSION,
         override_compatibility_check,
         downgrade,
     )?;

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -11,6 +11,8 @@ use spin_templates::{
     SkippedReason, Template, TemplateManager, TemplateSource,
 };
 
+use crate::build_info::*;
+
 const INSTALL_FROM_DIR_OPT: &str = "FROM_DIR";
 const INSTALL_FROM_GIT_OPT: &str = "FROM_GIT";
 const UPGRADE_ONLY: &str = "GIT_URL";
@@ -117,9 +119,7 @@ impl Install {
         let template_manager = TemplateManager::try_default()
             .context("Failed to construct template directory path")?;
         let source = match (&self.git, &self.dir) {
-            (Some(git), None) => {
-                TemplateSource::try_from_git(git, &self.branch, env!("VERGEN_BUILD_SEMVER"))?
-            }
+            (Some(git), None) => TemplateSource::try_from_git(git, &self.branch, SPIN_VERSION)?,
             (None, Some(dir)) => {
                 let abs_dir = dir.absolutize().map(|d| d.to_path_buf());
                 TemplateSource::File(abs_dir.unwrap_or_else(|_| dir.clone()))
@@ -364,8 +364,7 @@ struct RepoSelection {
 
 impl RepoSelection {
     async fn from_repo(repo: &str) -> Option<Self> {
-        let template_source =
-            TemplateSource::try_from_git(repo, &None, env!("VERGEN_BUILD_SEMVER")).ok()?;
+        let template_source = TemplateSource::try_from_git(repo, &None, SPIN_VERSION).ok()?;
         let resolved_tag = template_source.resolved_tag().await;
         Some(Self {
             repo: repo.to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod build_info;
 pub mod commands;
 pub mod manifest;
 pub(crate) mod opts;


### PR DESCRIPTION
I'm building a plugin that manages spin versions. It would be useful to understand where the build comes from, so it can be upgraded/downgraded/recovered safely.

I had to update vergen to version 8 and did some cleaning up on the way.

The additional info is sent to the plugin child process envs:

```
SPIN_BIN_PATH=/Users/cardoso/.cargo/bin/spin
SPIN_BRANCH=feat/more_build_info
SPIN_BUILD_DATE=2023-05-15
SPIN_COMMIT_DATE=2023-05-15
SPIN_COMMIT_SHA=49fb11b
SPIN_DEBUG=false
SPIN_TARGET_TRIPLE=aarch64-apple-darwin
SPIN_VERSION=1.2.0-pre0
SPIN_VERSION_MAJOR=1
SPIN_VERSION_MINOR=2
SPIN_VERSION_PRE=pre0
```