### PR TITLE
Conditionally use Homebrew location for Spin plugins and templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,6 +5116,7 @@ name = "spin-common"
 version = "1.3.0-pre0"
 dependencies = [
  "anyhow",
+ "dirs 4.0.0",
  "sha2 0.10.6",
  "tempfile",
  "tokio",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
+dirs = "4.0"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "time"] }
 

--- a/crates/common/src/data_dir.rs
+++ b/crates/common/src/data_dir.rs
@@ -1,0 +1,29 @@
+//! Resolves Spin's default data directory paths
+
+use anyhow::{anyhow, Result};
+use std::path::{Path, PathBuf};
+
+/// Return the default data directory for Spin
+pub fn default_data_dir() -> Result<PathBuf> {
+    if let Some(pkg_mgr_dir) = package_manager_data_dir() {
+        return Ok(pkg_mgr_dir);
+    }
+
+    let data_dir = dirs::data_local_dir()
+        .or_else(|| dirs::home_dir().map(|p| p.join(".spin")))
+        .ok_or_else(|| anyhow!("Unable to get local data directory or home directory"))?;
+    Ok(data_dir.join("spin"))
+}
+
+/// Get the package manager specific data directory
+fn package_manager_data_dir() -> Option<PathBuf> {
+    if let Ok(brew_prefix) = std::env::var("HOMEBREW_PREFIX") {
+        let data_dir = Path::new(&brew_prefix).join("var").join("spin");
+
+        if data_dir.is_dir() {
+            return Some(data_dir);
+            // TODO: check if they also have plugins in non-brew default dir and warn
+        }
+    }
+    None
+}

--- a/crates/common/src/data_dir.rs
+++ b/crates/common/src/data_dir.rs
@@ -18,11 +18,12 @@ pub fn default_data_dir() -> Result<PathBuf> {
 /// Get the package manager specific data directory
 fn package_manager_data_dir() -> Option<PathBuf> {
     if let Ok(brew_prefix) = std::env::var("HOMEBREW_PREFIX") {
-        let data_dir = Path::new(&brew_prefix).join("var").join("spin");
-
-        if data_dir.is_dir() {
+        if std::env::current_exe()
+            .map(|p| p.starts_with(&brew_prefix))
+            .unwrap_or(false)
+        {
+            let data_dir = Path::new(&brew_prefix).join("etc").join("fermyon-spin");
             return Some(data_dir);
-            // TODO: check if they also have plugins in non-brew default dir and warn
         }
     }
     None

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -9,5 +9,6 @@
 // - Code should have at least 2 dependents
 
 pub mod arg_parser;
+pub mod data_dir;
 pub mod sha256;
 pub mod sloth;

--- a/crates/plugins/src/store.rs
+++ b/crates/plugins/src/store.rs
@@ -25,10 +25,12 @@ impl PluginStore {
     }
 
     pub fn try_default() -> Result<Self> {
-        if let Ok(test_dir) = std::env::var("TEST_PLUGINS_DIRECTORY") {
-            return Ok(Self::new(PathBuf::from(test_dir)));
-        }
-        Ok(Self::new(default_data_dir()?.join("plugins")))
+        let data_dir = if let Ok(test_dir) = std::env::var("TEST_PLUGINS_DIRECTORY") {
+            PathBuf::from(test_dir).join("spin")
+        } else {
+            default_data_dir()?
+        };
+        Ok(Self::new(data_dir.join("plugins")))
     }
 
     /// Gets the path to where Spin plugin are installed.

--- a/crates/plugins/src/store.rs
+++ b/crates/plugins/src/store.rs
@@ -24,6 +24,17 @@ impl PluginStore {
     }
 
     pub fn try_default() -> Result<Self> {
+        if let Ok(brew_prefix) = std::env::var("HOMEBREW_PREFIX") {
+            let plugins_dir = Path::new(&brew_prefix)
+                .join("var")
+                .join("spin")
+                .join("plugins");
+
+            if plugins_dir.is_dir() {
+                return Ok(Self::new(plugins_dir));
+                // TODO: check if they also have plugins in non-brew default dir and warn
+            }
+        }
         let data_dir = match std::env::var("TEST_PLUGINS_DIRECTORY") {
             Ok(test_dir) => PathBuf::from(test_dir),
             Err(_) => dirs::data_local_dir()

--- a/crates/templates/src/store.rs
+++ b/crates/templates/src/store.rs
@@ -20,6 +20,18 @@ impl TemplateStore {
     }
 
     pub(crate) fn try_default() -> anyhow::Result<Self> {
+        if let Ok(brew_prefix) = std::env::var("HOMEBREW_PREFIX") {
+            let templates_dir = Path::new(&brew_prefix)
+                .join("var")
+                .join("spin")
+                .join("templates");
+
+            if templates_dir.is_dir() {
+                return Ok(Self::new(templates_dir));
+                // TODO: check if they also have templates in non-brew default dir and warn
+            }
+        }
+
         let data_dir = dirs::data_local_dir()
             .or_else(|| dirs::home_dir().map(|p| p.join(".spin")))
             .ok_or_else(|| anyhow!("Unable to get local data directory or home directory"))?;

--- a/crates/templates/src/store.rs
+++ b/crates/templates/src/store.rs
@@ -1,6 +1,6 @@
+use anyhow::Context;
+use spin_common::data_dir::default_data_dir;
 use std::path::{Path, PathBuf};
-
-use anyhow::{anyhow, Context};
 
 use crate::directory::subdirectories;
 
@@ -20,23 +20,7 @@ impl TemplateStore {
     }
 
     pub(crate) fn try_default() -> anyhow::Result<Self> {
-        if let Ok(brew_prefix) = std::env::var("HOMEBREW_PREFIX") {
-            let templates_dir = Path::new(&brew_prefix)
-                .join("var")
-                .join("spin")
-                .join("templates");
-
-            if templates_dir.is_dir() {
-                return Ok(Self::new(templates_dir));
-                // TODO: check if they also have templates in non-brew default dir and warn
-            }
-        }
-
-        let data_dir = dirs::data_local_dir()
-            .or_else(|| dirs::home_dir().map(|p| p.join(".spin")))
-            .ok_or_else(|| anyhow!("Unable to get local data directory or home directory"))?;
-        let templates_dir = data_dir.join("spin").join("templates");
-        Ok(Self::new(templates_dir))
+        Ok(Self::new(default_data_dir()?.join("templates")))
     }
 
     pub(crate) fn get_directory(&self, id: impl AsRef<str>) -> PathBuf {


### PR DESCRIPTION
The current experience for installing spin is to either use the install script or build from source. Users should be able to install Spin using their favorite package manager, such as Homebrew. https://github.com/fermyon/spin/issues/641

I am working on creating a `fermyon-spin` Homebrew formula. Homebrew is sandboxed such that you can only install into a subdirectory of `$HOMEBREW_PREFIX` ([`/opt/homebrew` on ARM macOs and `/usr/local` on Intel macOs](https://github.com/Homebrew/install/blob/fc8acb0828f89f8aa83162000db1b49de71fa5d8/install.sh#L132) ). The formula installs default plugins and templates to the `$HOMEBREW_PREFIX/etc/fermyon-spin` directory. 

The plugin and templates systems look at `$XDG_DATA_HOME` or more specifically `$HOME/Library/Application Support` for macOS. This updates them to look for the existence of a brew installation of Spin and if exists, use the `$HOMEBREW_PREFIX/etc/fermyon-spin` directory for plugins and templates.

If a user has a brew installation of spin and another installation or local execution, there could be duplication of plugins and templates, with each executable using their expected directory