### PR TITLE
Remove unhelpful error when preparing spin configuration

### DIFF
--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -148,13 +148,11 @@ async fn prepare(
     let components = future::join_all(
         raw.components
             .into_iter()
-            .map(|c| async { core(c, &src, base_dst.as_ref()).await })
-            .collect::<Vec<_>>(),
+            .map(|c| async { core(c, &src, base_dst.as_ref()).await }),
     )
     .await
     .into_iter()
-    .collect::<Result<Vec<_>>>()
-    .context("Failed to prepare configuration")?;
+    .collect::<Result<Vec<_>>>()?;
 
     let variables = raw
         .variables


### PR DESCRIPTION
The error "Failed to prepare configuration" does not tell the user anything as they generally have no idea what "preparing" configuration actually means. The errors returned from the `core` function already provide all the context the user needs to address their issue, and so the "Failed to prepare configuration" error is just noise.

(As a bonus to this PR, I removed some unnecessary allocation)