### PR TITLE
Canonicalize source path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4859,6 +4859,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs 4.0.0",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5300,6 +5309,7 @@ dependencies = [
  "semver 1.0.16",
  "serde",
  "serde_json",
+ "shellexpand 3.1.0",
  "spin-common",
  "spin-manifest",
  "tempfile",
@@ -6992,7 +7002,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "shellexpand",
+ "shellexpand 2.1.2",
  "syn 1.0.109",
  "witx",
 ]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = "0.11.9"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+shellexpand = "3.1"
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
 tempfile = "3.3.0"

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -235,11 +235,7 @@ fn canonicalize_and_absolutize(mut path: PathBuf, src: &Path) -> anyhow::Result<
             }
         }
     }
-    Ok(if path.is_absolute() {
-        path
-    } else {
-        src.join(path)
-    })
+    Ok(src.join(path))
 }
 
 /// A parsed URL source for a component module.


### PR DESCRIPTION
This allows users to have "~/some/path/../to/binary" as their source in their `spin.toml`.