### PR TITLE
windows: Statically compile MSVC runtime

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,6 @@
 [net]
     git-fetch-with-cli = true
+
+# Statically compile MSVC runtime
+[target.'cfg(target_env = "msvc")']
+    rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
This should allow `spin` to be run on Windows without installing a MSVC runtime.