### PR TITLE
Fix `spin doctor` spurious "missing Wasm file" if app is in another directory

### DIFF
--- a/crates/doctor/src/wasm/missing.rs
+++ b/crates/doctor/src/wasm/missing.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use crate::{Diagnosis, PatientApp, Treatment};
 
-use super::{PatientWasm, WasmDiagnostic, WasmSource};
+use super::{PatientWasm, WasmDiagnostic};
 
 /// WasmMissingDiagnostic detects missing Wasm sources.
 #[derive(Default)]
@@ -20,8 +20,8 @@ impl WasmDiagnostic for WasmMissingDiagnostic {
         _app: &PatientApp,
         wasm: PatientWasm,
     ) -> anyhow::Result<Vec<Self::Diagnosis>> {
-        if let WasmSource::Local(path) = wasm.source() {
-            if !path.exists() {
+        if let Some(abs_path) = wasm.abs_source_path() {
+            if !abs_path.exists() {
                 return Ok(vec![WasmMissing(wasm)]);
             }
         }
@@ -49,10 +49,10 @@ impl WasmMissing {
 impl Diagnosis for WasmMissing {
     fn description(&self) -> String {
         let id = self.0.component_id();
-        let WasmSource::Local(path) = self.0.source() else {
+        let Some(rel_path) = self.0.source_path() else {
             unreachable!("unsupported source");
         };
-        format!("Component {id:?} source {path:?} is missing")
+        format!("Component {id:?} source {rel_path:?} is missing")
     }
 
     fn treatment(&self) -> Option<&dyn Treatment> {

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -223,7 +223,7 @@ async fn core(
 }
 
 /// Ensures that the path is canonicalized and absolutized base on the `src` path
-fn canonicalize_and_absolutize(mut path: PathBuf, src: &Path) -> anyhow::Result<PathBuf> {
+pub fn canonicalize_and_absolutize(mut path: PathBuf, src: &Path) -> anyhow::Result<PathBuf> {
     path = path.canonicalize().unwrap_or(path);
     // If path is UTF-8 and we can successfully perform tilde and environment expansion, do so.
     if let Some(p) = path.as_os_str().to_str() {


### PR DESCRIPTION
I ran into this because I was playing with `spin doctor` using `spin doctor -f ~/testing/kvmadness` and it reported that my Wasm file was missing.  It looks like it currently probes for the file relative to the current directory rather than the app directory.

This fixes that, but it feels a bit verbose, like I am passing more stuff around more places than should be necessary.  @lann I'd be grateful for any insight on how you envisaged things like this being structured.  I saw that the `WasmDiagnostic` trait passes the `PatientApp` that includes the manifest file path, and originally used that to construct the absolute Wasm path in `diagnose_wasm`. 
 But it felt like that would end up getting repeated in multiple diagnostics so I moved it into the `PatientWasm` type.  Anyway I don't want to end up spoiling the design on my first outing _grin_