### PR TITLE
Fix merge woe with new K/V trait function

### DIFF
--- a/crates/key-value-azure/src/lib.rs
+++ b/crates/key-value-azure/src/lib.rs
@@ -33,6 +33,10 @@ impl StoreManager for KeyValueAzureCosmos {
             client: self.client.clone(),
         }))
     }
+
+    fn is_defined(&self, _store_name: &str) -> bool {
+        true
+    }
 }
 
 struct AzureCosmosStore {


### PR DESCRIPTION
K/V validation added a new `StoreManager` trait function.  Unfortunately, in the meantime, we had added a new `StoreManager` implementation (Azure CosmosDB).  And I didn't think about this when I merged (because there was no conflict).  And now `main` is broken.

So, uh, this unbreaks `main`.