### PR TITLE
fix(go/sdk): Populate full url in request object

### DIFF
--- a/sdk/go/http/http.go
+++ b/sdk/go/http/http.go
@@ -27,6 +27,8 @@ const (
 	// manifest (that is, _excluding_ the base, but including the wildcard
 	// indicator if present).
 	HeaderRawComponentRoot = "spin-raw-component-route"
+	// The client address for the request.
+	HeaderClientAddr = "spin-client-addr"
 )
 
 // Override the default HTTP client to be compatible with the Spin SDK.


### PR DESCRIPTION
This changes the request object to parse the full url rather than the uri.  This correctly populates the Scheme, Host, and Query fields.

```
url.URL{
        Scheme:      "http",
        Opaque:      "",
        User:        (*url.Userinfo)(nil),
        Host:        "localhost:3000",
        Path:        "/hello/world",
        RawPath:     "",
        OmitHost:    false,
        ForceQuery:  false,
        RawQuery:    "foo=bar",
        Fragment:    "",
        RawFragment: "",
    },
```