### PR TITLE
`spin doctor`: detect Rust not installed/Wasm target not installed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5160,10 +5160,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "reqwest",
  "serde",
  "similar",
  "spin-loader",
  "tempfile",
+ "terminal",
  "tokio",
  "toml 0.7.3",
  "toml_edit 0.19.8",

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+reqwest = { version = "0.11", features = ["stream"] }
 serde = { version = "1", features = ["derive"] }
 similar = "2"
 spin-loader = { path = "../loader" }
+tempfile = "3.3.0"
+terminal = { path = "../terminal" }
 tokio = "1"
 toml = "0.7"
 toml_edit = "0.19"

--- a/crates/doctor/src/rustlang.rs
+++ b/crates/doctor/src/rustlang.rs
@@ -1,0 +1,2 @@
+/// Diagnose Wasm target problems.
+pub mod target;

--- a/crates/doctor/src/rustlang/target.rs
+++ b/crates/doctor/src/rustlang/target.rs
@@ -1,0 +1,232 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::{Diagnosis, Diagnostic, PatientApp, StopDiagnosing, Treatment};
+
+/// VersionDiagnostic detects problems with the app manifest version field.
+#[derive(Default)]
+pub struct TargetDiagnostic;
+
+#[async_trait]
+impl Diagnostic for TargetDiagnostic {
+    type Diagnosis = TargetDiagnosis;
+
+    async fn diagnose(&self, patient: &PatientApp) -> Result<Vec<Self::Diagnosis>> {
+        // TODO: this, down to the "does the app use Rust" check, probably ought to move up to the Rust level
+        // but we can defer this until we have more Rust diagnoses
+        let path = &patient.manifest_path;
+        let manifest = spin_loader::local::raw_manifest_from_file(&path)
+            .await?
+            .into_v1();
+        let uses_rust = manifest.components.iter().any(|c| {
+            c.build
+                .as_ref()
+                .map(|b| b.command.starts_with("cargo"))
+                .unwrap_or_default()
+        });
+
+        if uses_rust {
+            diagnose_rust_wasi_target().await
+        } else {
+            Ok(vec![])
+        }
+    }
+}
+
+async fn diagnose_rust_wasi_target() -> Result<Vec<TargetDiagnosis>> {
+    // does any component contain a build command with `cargo` as the program?
+    // if so, run rustup target list --installed and:
+    // - if rustup is not present, check if cargo is present
+    //   - if not, return RustNotInstalled
+    //   - if so, warn but return empty list (Rust is installed but not via rustup, so we can't perform a diagnosis - bit of an edge case this one, and the user probably knows what they're doing...?)
+    // - if rustup is present but the list does not contain wasm32-wasi, return WasmTargetNotInstalled
+    // - if the list does contain wasm32-wasi, return an empty list
+    // NOTE: this does not currently check against the Rust SDK MSRV - that could
+    // be a future enhancement or separate diagnosis, but at least the Rust compiler
+    // should give a clear error for that!
+
+    let diagnosis = match get_rustup_target_status().await? {
+        RustupStatus::AllInstalled => vec![],
+        RustupStatus::WasiNotInstalled => vec![TargetDiagnosis::WasmTargetNotInstalled],
+        RustupStatus::RustupNotInstalled => match get_cargo_status().await? {
+            CargoStatus::Installed => {
+                terminal::warn!(
+                    "Spin Doctor can't determine if the Rust wasm32-wasi target is installed."
+                );
+                vec![]
+            }
+            CargoStatus::NotInstalled => vec![TargetDiagnosis::RustNotInstalled],
+        },
+    };
+    Ok(diagnosis)
+}
+
+#[allow(clippy::enum_variant_names)]
+enum RustupStatus {
+    RustupNotInstalled,
+    WasiNotInstalled,
+    AllInstalled,
+}
+
+async fn get_rustup_target_status() -> Result<RustupStatus> {
+    let target_list_output = tokio::process::Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+        .await;
+    let status = match target_list_output {
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                RustupStatus::RustupNotInstalled
+            } else {
+                anyhow::bail!("Failed to run `rustup target list --installed`: {e:#}")
+            }
+        }
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.lines().any(|line| line == "wasm32-wasi") {
+                RustupStatus::AllInstalled
+            } else {
+                RustupStatus::WasiNotInstalled
+            }
+        }
+    };
+    Ok(status)
+}
+
+enum CargoStatus {
+    Installed,
+    NotInstalled,
+}
+
+async fn get_cargo_status() -> Result<CargoStatus> {
+    let cmd_output = tokio::process::Command::new("cargo")
+        .arg("--version")
+        .output()
+        .await;
+    let status = match cmd_output {
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                CargoStatus::NotInstalled
+            } else {
+                anyhow::bail!("Failed to run `cargo --version`: {e:#}")
+            }
+        }
+        Ok(_) => CargoStatus::Installed,
+    };
+    Ok(status)
+}
+
+/// TargetDiagnosis represents a problem with the Rust target.
+#[derive(Debug)]
+pub enum TargetDiagnosis {
+    /// Rust is not installed: neither cargo nor rustup is present
+    RustNotInstalled,
+    /// The Rust wasm32-wasi target is not installed: rustup is present but the target isn't
+    WasmTargetNotInstalled,
+}
+
+impl Diagnosis for TargetDiagnosis {
+    fn description(&self) -> String {
+        match self {
+            Self::RustNotInstalled => "The Rust compiler isn't installed".into(),
+            Self::WasmTargetNotInstalled => {
+                "The required Rust target 'wasm32-wasi' isn't installed".into()
+            }
+        }
+    }
+
+    fn treatment(&self) -> Option<&dyn Treatment> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl Treatment for TargetDiagnosis {
+    fn summary(&self) -> String {
+        match self {
+            Self::RustNotInstalled => "Install the Rust compiler and the wasm32-wasi target",
+            Self::WasmTargetNotInstalled => "Install the Rust wasm32-wasi target",
+        }
+        .into()
+    }
+
+    async fn dry_run(&self, _patient: &PatientApp) -> Result<String> {
+        let message = match self {
+            Self::RustNotInstalled => "Download and run the Rust installer from https://rustup.rs, with the `--target wasm32-wasi` option",
+            Self::WasmTargetNotInstalled => "Run the following command:\n    `rustup target add wasm32-wasi`",
+        };
+        Ok(message.into())
+    }
+
+    async fn treat(&self, _patient: &mut PatientApp) -> Result<()> {
+        match self {
+            Self::RustNotInstalled => {
+                install_rust_with_wasi_target().await?;
+            }
+            Self::WasmTargetNotInstalled => {
+                install_wasi_target()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn install_rust_with_wasi_target() -> Result<()> {
+    let status = run_rust_installer().await?;
+    anyhow::ensure!(status.success(), "Rust installation failed: {status:?}");
+    let stop = StopDiagnosing::new("Because Rust was just installed, you may need to run a script or restart your command shell to add Rust to your PATH. Please follow the instructions at the end of the installer output above before re-running `spin doctor`.");
+    Err(anyhow::anyhow!(stop))
+}
+
+#[cfg(not(windows))]
+async fn run_rust_installer() -> Result<std::process::ExitStatus> {
+    use std::io::Write;
+
+    let resp = reqwest::get("https://sh.rustup.rs").await?;
+    let script = resp.bytes().await?;
+
+    let mut cmd = std::process::Command::new("sh");
+    cmd.args(["-s", "--", "--target", "wasm32-wasi"]);
+    cmd.stdin(std::process::Stdio::piped());
+    let mut shell = cmd.spawn()?;
+    let mut stdin = shell.stdin.take().unwrap();
+    std::thread::spawn(move || {
+        stdin.write_all(&script).unwrap();
+    });
+
+    let output = shell.wait_with_output()?;
+    Ok(output.status)
+}
+
+#[cfg(windows)]
+async fn run_rust_installer() -> Result<std::process::ExitStatus> {
+    // We currently distribute Windows builds only for x64, so hopefully
+    // this won't be an issue.
+    if std::env::consts::ARCH != "x86_64" {
+        anyhow::bail!("Spin Doctor can only install Rust for Windows on x64 processors");
+    }
+
+    let temp_dir = tempfile::TempDir::new()?;
+    let installer_path = temp_dir.path().join("rustup-init.exe");
+
+    let resp = reqwest::get("https://win.rustup.rs/x86_64").await?;
+    let installer_bin = resp.bytes().await?;
+
+    std::fs::write(&installer_path, &installer_bin)?;
+
+    let mut cmd = std::process::Command::new(installer_path);
+    cmd.args(["--target", "wasm32-wasi"]);
+    let status = cmd.status()?;
+    Ok(status)
+}
+
+fn install_wasi_target() -> Result<()> {
+    let mut cmd = std::process::Command::new("rustup");
+    cmd.args(["target", "add", "wasm32-wasi"]);
+    let status = cmd.status()?;
+    anyhow::ensure!(
+        status.success(),
+        "Installation command {cmd:?} failed: {status:?}"
+    );
+    Ok(())
+}

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -63,7 +63,17 @@ impl DoctorCommand {
                                     println!("{icon}Treatment applied!", icon = Emoji("❤  ", ""));
                                 }
                                 Err(err) => {
-                                    show_error("Treatment failed: ", err);
+                                    match err.downcast_ref::<spin_doctor::StopDiagnosing>() {
+                                        Some(stop) => {
+                                            terminal::einfo!(
+                                                "Action required!",
+                                                "{}",
+                                                stop.message()
+                                            );
+                                            return Ok(());
+                                        }
+                                        None => show_error("Treatment failed: ", err),
+                                    };
                                 }
                             }
                         }


### PR DESCRIPTION
This works (as best I can tell without going through a full build-uninstall Rust-doctor-install Rust cycle every time), but was at least partly a learning exercise, and raised a few questions/considerations:

* This was implemented in Spin itself mostly to ease the proof of concept development.  I generally feel that Spin shouldn't know about this stuff and it should go out to a plugin, but wanted to get my head around this before working on a spin doctor plugin system.

* I initially tried to follow the Wasm model of having an `impl<T: RustDiagnostic> Diagnostic for T`, but this hits ye olde "conflicting implementations of Diagnostic" problem (because what if T implemented WasmDiagnostic and RustDiagnostic what then Ivan).  It seems like, bar shenanigans, only one family of diagnostics can have this blanket implementation (there's a similar issue with treatments).  I ducked the issue for this PR, but we might need to tackle this a different way in future.

* It wasn't quite clear to me how to manage multiple overlapping diagnoses and treatments.  The specific case here was "Rust is out of date".  I could have made this a third arm of the `TargetDiagnosis` enum (it's misnamed, I know) but then we need to get into "Rust is out of date and _does_ have the Wasm target" (so only needs updating) vs "Rust is out of date and _doesn't_ have the Wasm target" (so needs update and `target add`).  I didn't want to use a vector of diagnostics because that would result in multiple doctor prompts.  (To be clear, four cases of the enum would be fine!  I just felt like I should check in with other folks before embarking on a combinatoric explosion.)