### PR TITLE
`spin new`: match unrecognised template as tag

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use path_absolutize::Absolutize;
 use tokio;
@@ -119,10 +119,12 @@ impl TemplateNewCommandCore {
                 .with_context(|| format!("Error retrieving template {}", template_id))?
             {
                 Some(template) => template,
-                None => {
-                    println!("Template {template_id} not found");
-                    return Ok(());
-                }
+                None => match prompt_template(&template_manager, &variant, &[template_id.clone()])
+                    .await?
+                {
+                    Some(template) => template,
+                    None => return Ok(()),
+                },
             },
             None => match prompt_template(&template_manager, &variant, &self.tags).await? {
                 Some(template) => template,
@@ -218,6 +220,14 @@ async fn prompt_template(
         Some(t) => t,
         None => return Ok(None),
     };
+    if templates.is_empty() {
+        if tags.len() == 1 {
+            bail!("No templates matched '{}'", tags[0]);
+        } else {
+            bail!("No templates matched all tags");
+        }
+    }
+
     let opts = templates
         .iter()
         .map(|t| format!("{} ({})", t.id(), t.description_or_empty()))


### PR DESCRIPTION
This, prompted by #1525, makes `spin new/add` more forgiving of users unsure of the exact template name.  If the template is not recognised, it tries to recover by searching for it as a tag:

```
ivan@hecate:~/testing$ spin new rust tplmadness
Pick a template to start your application with:
> http-rust (HTTP request handler using Rust)
  redis-rust (Redis message handler using Rust)

ivan@hecate:~/testing$ spin new http tplmadness
Pick a template to start your application with:
> http-c (HTTP request handler using C and the Zig toolchain)
  http-empty (HTTP application with no components)
  http-go (HTTP request handler using (Tiny)Go)
  http-grain (HTTP request handler using Grain)
  http-php (HTTP request handler using PHP)
  http-py (HTTP request handler using Python)
  http-rust (HTTP request handler using Rust)
  http-swift (HTTP request handler using SwiftWasm)
  http-zig (HTTP request handler using Zig)
  static-fileserver (Serves static files from an asset directory)

ivan@hecate:~/testing$ spin new biscuits tplmadness
Error: No templates matched 'biscuits'
```

This could be made even more forgiving by using a name match too:

```
ivan@hecate:~/testing$ spin new r tplmadness
Error: No templates matched 'r'  # What if this listed all templates containing 'r', or with 'r' in a start-of-word position?
```

And if we wanted to meet the original request in #1525 we could recognise a special value such as `.` as matching anything, but then maybe we get into the "I can never remember the special value" problem...
