### PR TITLE
`spin doctor`: allow selecting which diagnostics to run

### DIFF
--- a/crates/doctor/src/manifest/trigger.rs
+++ b/crates/doctor/src/manifest/trigger.rs
@@ -15,6 +15,8 @@ pub struct TriggerDiagnostic;
 impl Diagnostic for TriggerDiagnostic {
     type Diagnosis = TriggerDiagnosis;
 
+    const ID: &'static str = "manifest:trigger";
+
     async fn diagnose(&self, patient: &PatientApp) -> Result<Vec<Self::Diagnosis>> {
         let manifest: toml::Value = toml_edit::de::from_document(patient.manifest_doc.clone())?;
 

--- a/crates/doctor/src/manifest/version.rs
+++ b/crates/doctor/src/manifest/version.rs
@@ -19,6 +19,8 @@ pub struct VersionDiagnostic;
 impl Diagnostic for VersionDiagnostic {
     type Diagnosis = VersionDiagnosis;
 
+    const ID: &'static str = "manifest:version";
+
     async fn diagnose(&self, patient: &PatientApp) -> Result<Vec<Self::Diagnosis>> {
         let doc = &patient.manifest_doc;
         let test: VersionProbe =

--- a/crates/doctor/src/test.rs
+++ b/crates/doctor/src/test.rs
@@ -68,7 +68,7 @@ pub struct TestPatient {
 
 impl TestPatient {
     fn new(manifest_temp: TempPath) -> Result<Self> {
-        let inner = Checkup::new(&manifest_temp).patient()?;
+        let inner = Checkup::new(&manifest_temp, &[]).patient()?;
         Ok(Self {
             inner,
             _manifest_temp: manifest_temp,

--- a/crates/doctor/src/wasm.rs
+++ b/crates/doctor/src/wasm.rs
@@ -47,6 +47,9 @@ pub trait WasmDiagnostic {
     /// A [`Diagnosis`] representing the problem(s) this can detect.
     type Diagnosis: Diagnosis;
 
+    /// The id of the diagnostic.
+    const ID: &'static str;
+
     /// Check the given [`PatientWasm`], returning any problem(s) found.
     async fn diagnose_wasm(
         &self,
@@ -58,6 +61,8 @@ pub trait WasmDiagnostic {
 #[async_trait]
 impl<T: WasmDiagnostic + Send + Sync> Diagnostic for T {
     type Diagnosis = <Self as WasmDiagnostic>::Diagnosis;
+
+    const ID: &'static str = T::ID;
 
     async fn diagnose(&self, patient: &PatientApp) -> Result<Vec<Self::Diagnosis>> {
         let path = &patient.manifest_path;

--- a/crates/doctor/src/wasm/missing.rs
+++ b/crates/doctor/src/wasm/missing.rs
@@ -15,6 +15,8 @@ pub struct WasmMissingDiagnostic;
 impl WasmDiagnostic for WasmMissingDiagnostic {
     type Diagnosis = WasmMissing;
 
+    const ID: &'static str = "wasm:missing";
+
     async fn diagnose_wasm(
         &self,
         _app: &PatientApp,

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -22,6 +22,12 @@ pub struct DoctorCommand {
         default_value = DEFAULT_MANIFEST_FILE
     )]
     pub app_source: PathBuf,
+
+    /// Run only the specified check.  You may specify this
+    /// several times to run multiple checks.  The default is
+    /// to run all checks.
+    #[clap(long = "check", multiple = true)]
+    checks: Vec<String>,
 }
 
 impl DoctorCommand {
@@ -35,7 +41,7 @@ impl DoctorCommand {
             icon = Emoji("🩺 ", "")
         );
 
-        let count = spin_doctor::Checkup::new(manifest_file)
+        let count = spin_doctor::Checkup::new(manifest_file, &self.checks)
             .for_each_diagnosis(move |diagnosis, patient| {
                 async move {
                     show_diagnosis(&*diagnosis);


### PR DESCRIPTION
This is WIP for discussion.

The idea is to give each diagnostic an identifier (like a lint ID), so that `spin doctor` can be told to check for only specific problems.  Why would you not want to know about ALL the problems?  The goal I have in mind is the "Why doesn't Spin install the wasm32-wasi target so it _just works_" scenario, and the solution I am exploring is roughly like this:

* User creates a new app from a Rust template
* The Rust template has some configuration saying "run the `rust` checks after instantiation"
* We want to run _only_ the `rust` checks because we know that out of the box there will be issues like "missing Wasm"
  * Arguably we could run all the checks, but we wouldn't want to present "missing Wasm" as a problem when the user has just created the app - it makes it seem like app creation hasn't done what it should have done
  * Arguably we could run `spin build` after instantiation and save them the effort (and us the diagnostic)?  Yeah, but then we need to run the Rust check _first_ to make sure we can build at all...

This is, for sure, a few steps down the line.  And there might be better ways to do it.  But basically the idea is to allow `spin doctor` to act as a setup assistant, not only something the user can reach for when they have identified a problem.

Happy to discuss, or to hear if people already have planned solutions the same problems and specific ways they'd like to see them tackled.

NOTE: the PR currently has an issue where if you limit it to, say, `wasm` checks, but the manifest doesn't parse, then the doctor says "no problems found" rather than "your application is so busted that you need to run the full checks to unbust it before I can help with the thing you asked about," so I need to look at this if we are okay with this option existing.