### PR TITLE
Change sqlite query-result to a pseudo resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "host"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=b6d42fe41e5690844a661deb631d996a2b49debc#b6d42fe41e5690844a661deb631d996a2b49debc"
+source = "git+https://github.com/fermyon/spin-componentize?rev=a7135e9b9b5c0130c021c0bd460516c546eb546a#a7135e9b9b5c0130c021c0bd460516c546eb546a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5155,7 +5155,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=b6d42fe41e5690844a661deb631d996a2b49debc#b6d42fe41e5690844a661deb631d996a2b49debc"
+source = "git+https://github.com/fermyon/spin-componentize?rev=a7135e9b9b5c0130c021c0bd460516c546eb546a#a7135e9b9b5c0130c021c0bd460516c546eb546a"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.26.0",
@@ -6371,7 +6371,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=b6d42fe41e5690844a661deb631d996a2b49debc#b6d42fe41e5690844a661deb631d996a2b49debc"
+source = "git+https://github.com/fermyon/spin-componentize?rev=a7135e9b9b5c0130c021c0bd460516c546eb546a#a7135e9b9b5c0130c021c0bd460516c546eb546a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6419,7 +6419,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "0.0.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=b6d42fe41e5690844a661deb631d996a2b49debc#b6d42fe41e5690844a661deb631d996a2b49debc"
+source = "git+https://github.com/fermyon/spin-componentize?rev=a7135e9b9b5c0130c021c0bd460516c546eb546a#a7135e9b9b5c0130c021c0bd460516c546eb546a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,10 +115,10 @@ tracing = { version = "0.1", features = ["log"] }
 wasmtime-wasi = { version = "8.0.1", features = ["tokio"] }
 wasi-common-preview1 = { package = "wasi-common", version = "8.0.1" }
 wasmtime = { version = "8.0.1", features = ["component-model"] }
-spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "b6d42fe41e5690844a661deb631d996a2b49debc" }
-wasi-host = { package = "host", git = "https://github.com/fermyon/spin-componentize", rev = "b6d42fe41e5690844a661deb631d996a2b49debc" }
-wasi-common = { git = "https://github.com/fermyon/spin-componentize", rev = "b6d42fe41e5690844a661deb631d996a2b49debc" }
-wasi-cap-std-sync = { git = "https://github.com/fermyon/spin-componentize", rev = "b6d42fe41e5690844a661deb631d996a2b49debc" }
+spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "a7135e9b9b5c0130c021c0bd460516c546eb546a" }
+wasi-host = { package = "host", git = "https://github.com/fermyon/spin-componentize", rev = "a7135e9b9b5c0130c021c0bd460516c546eb546a" }
+wasi-common = { git = "https://github.com/fermyon/spin-componentize", rev = "a7135e9b9b5c0130c021c0bd460516c546eb546a" }
+wasi-cap-std-sync = { git = "https://github.com/fermyon/spin-componentize", rev = "a7135e9b9b5c0130c021c0bd460516c546eb546a" }
 
 [workspace.dependencies.bindle]
 git = "https://github.com/fermyon/bindle"

--- a/wit/ephemeral/sqlite.wit
+++ b/wit/ephemeral/sqlite.wit
@@ -37,7 +37,7 @@ type query-result = u32
 get-columns: func(query-result: query-result) -> expected<list<string>, error>
 
 // Get a `row-result` at a given index for a given `query-result`
-get-row-result: func(query-result: query-result, index: u32) -> expected<option<row-result>, error>
+next-row-result: func(query-result: query-result) -> expected<option<row-result>, error>
 
 // Free the query result resource
 free-query-result: func(query-result: query-result)

--- a/wit/ephemeral/sqlite.wit
+++ b/wit/ephemeral/sqlite.wit
@@ -9,6 +9,8 @@ variant error {
   access-denied,
   // The provided connection is not valid
   invalid-connection,
+  // The provided query result is not valid
+  invalid-query-result,
   // The database has reached its capacity
   database-full,
   // Some implementation-specific error has occurred (e.g. I/O)
@@ -28,13 +30,17 @@ execute: func(conn: connection, statement: string, parameters: list<value>) -> e
 // Close the specified `connection`.
 close: func(conn: connection)
 
-// A result of a query
-record query-result {
-  // The names of the columns retrieved in the query
-  columns: list<string>,
-  // the row results each containing the values for all the columns for a given row
-  rows: list<row-result>,
-}
+// A result of making a query
+type query-result = u32
+
+// Get columns for a given `query-result`
+get-columns: func(query-result: query-result) -> expected<list<string>, error>
+
+// Get a `row-result` at a given index for a given `query-result`
+get-row-result: func(query-result: query-result, index: u32) -> expected<option<row-result>, error>
+
+// Free the query result resource
+free-query-result: func(query-result: query-result)
 
 // A set of values for each of the columns in a query-result
 record row-result {

--- a/wit/preview2/sqlite.wit
+++ b/wit/preview2/sqlite.wit
@@ -10,6 +10,8 @@ default interface sqlite {
     access-denied,
     // The provided connection is not valid
     invalid-connection,
+    // The provided query result is not valid
+    invalid-query-result,
     // The database has reached its capacity
     database-full,
     // Some implementation-specific error has occurred (e.g. I/O)
@@ -29,13 +31,17 @@ default interface sqlite {
   // Close the specified `connection`.
   close: func(conn: connection)
 
-  // A result of a query
-  record query-result {
-    // The names of the columns retrieved in the query
-    columns: list<string>,
-    // the row results each containing the values for all the columns for a given row
-    rows: list<row-result>,
-  }
+  // A result of making a query
+  type query-result = u32
+
+  // Get columns for a given `query-result`
+  get-columns: func(query-result: query-result) -> result<list<string>, error>
+
+  // Get a `row-result` at a given index for a given `query-result`
+  get-row-result: func(query-result: query-result, index: u32) -> result<option<row-result>, error>
+
+  // Free the query result resource
+  free-query-result: func(query-result: query-result)
 
   // A set of values for each of the columns in a query-result
   record row-result {

--- a/wit/preview2/sqlite.wit
+++ b/wit/preview2/sqlite.wit
@@ -38,7 +38,7 @@ default interface sqlite {
   get-columns: func(query-result: query-result) -> result<list<string>, error>
 
   // Get a `row-result` at a given index for a given `query-result`
-  get-row-result: func(query-result: query-result, index: u32) -> result<option<row-result>, error>
+  next-row-result: func(query-result: query-result) -> result<option<row-result>, error>
 
   // Free the query result resource
   free-query-result: func(query-result: query-result)


### PR DESCRIPTION
Hot on the heels of #1408 landing, this PR proposes a change to the API that makes `query-result` (i.e., the return type from executing a sqlite statement) into a pseudo resource. This changes the API so that instead of receiving all of the results at once, the user must instead either collect the results through some iteration or query from a specific index of the `query-result`.

## What this looks like in code

On the Rust side of things, this is largely hidden behind an iterator:

```rust
   let todos = conn
         .execute(&format!("SELECT * FROM todos;"), &[])?
         .rows()
         // the only change from previous version is the need for the `?`
         // since each iteration is technically failable (more on this below)
         .map(|r| -> anyhow::Result<Todo> { r?.try_into() }) 
         .collect::<anyhow::Result<Vec<Todo>>>()?;
```

## Downsides

There are a few known downsides to this approach:

* This is ever so slightly more complicated as the user is no longer given a simple data structure
  * As a consequence of this, the SDKs need to do more work to hide some of this complexity.
  * This will be reduced in the future when resources, streams, etc are introduced
* Each call to get the next value in `query-result` can fail since we technically never know on the host side if they handle we're being given is still valid. 
  * I believe this issue would go away with resources.

## Upsides

* The guest has much less risk of running into memory issues if the `query-result` set is very large. 
* This is more future proof compatible with resources and streams 

