### PR TITLE
Run e2e tests against local build by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ ARCH = $(shell uname -p)
 
 ## dependencies for e2e-tests
 E2E_VOLUME_MOUNT     ?=
-E2E_BUILD_SPIN       ?= false
+E2E_USE_CANARY       ?= false ## Whether to use the canary build instead of the local build
+E2E_BUILD_SPIN 	     =  $(if $E2E_USE_CANARY == "false",true,false)
 E2E_TESTS_DOCKERFILE ?= e2e-tests.Dockerfile
 MYSQL_IMAGE          ?= mysql:8.0.22
 REDIS_IMAGE          ?= redis:7.0.8-alpine3.17

--- a/e2e-tests-aarch64.Dockerfile
+++ b/e2e-tests-aarch64.Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04
 
-ARG BUILD_SPIN=false
+# Whether to build spin from the local source
+# When set to false, the `SPIN_VERSION` build is used instead.
+ARG BUILD_SPIN=true
 ARG SPIN_VERSION=canary
 
 WORKDIR /root
@@ -67,9 +69,10 @@ RUN wget https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-
 WORKDIR /e2e-tests
 COPY . .
 
-RUN if [ "${BUILD_SPIN}" == "true" ]; then                                                                                      \
-    cargo build --release &&                                                                                                    \
-    cp target/release/spin /usr/local/bin/spin;                                                                                 \
+RUN if [ "${BUILD_SPIN}" = "true" ]; then                                                                                      \
+    git config --global http.proxy "" &&                                                                                       \
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --release &&                                                        \
+    cp target/release/spin /usr/local/bin/spin;                                                                                \
     fi
 
 RUN spin --version

--- a/e2e-tests.Dockerfile
+++ b/e2e-tests.Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04
 
-ARG BUILD_SPIN=false
+# Whether to build spin from the local source
+# When set to false, the `SPIN_VERSION` build is used instead.
+ARG BUILD_SPIN=true
 ARG SPIN_VERSION=canary
 
 WORKDIR /root
@@ -59,17 +61,18 @@ RUN tinygo version;   \
     node --version;   \
     swift --version;
 
-RUN wget https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz &&         \
-    tar -xvf spin-${SPIN_VERSION}-linux-amd64.tar.gz &&                                                                       \
-    ls -ltr &&                                                                                                                  \
+RUN wget https://github.com/fermyon/spin/releases/download/${SPIN_VERSION}/spin-${SPIN_VERSION}-linux-amd64.tar.gz &&          \
+    tar -xvf spin-${SPIN_VERSION}-linux-amd64.tar.gz &&                                                                        \
+    ls -ltr &&                                                                                                                 \
     mv spin /usr/local/bin/spin;
 
 WORKDIR /e2e-tests
 COPY . .
 
-RUN if [ "${BUILD_SPIN}" == "true" ]; then                                                                                      \
-    cargo build --release &&                                                                                                    \
-    cp target/release/spin /usr/local/bin/spin;                                                                                 \
+RUN if [ "${BUILD_SPIN}" = "true" ]; then                                                                                      \
+    git config --global http.proxy "" &&                                                                                       \
+    cargo build --release &&                                                                                                   \
+    cp target/release/spin /usr/local/bin/spin;                                                                                \
     fi
 
 RUN spin --version


### PR DESCRIPTION
This switches local e2e testing to test against local changes. If users want the old default of running against canary they can do so with the `E2E_USE_CANARY` env variable set to `true`. 

I believe the default of testing against local changes is the more intuitive default rather than testing against an already release artifact (which already has e2e tests run against it in CI).