### PR TITLE
Update to the upcoming WITs

### DIFF
--- a/wit/preview2/config.wit
+++ b/wit/preview2/config.wit
@@ -1,4 +1,4 @@
-default interface config {
+interface config {
   // Get a configuration value for the current component.
   // The config key must match one defined in in the component manifest.
   get-config: func(key: string) -> result<string, error>

--- a/wit/preview2/http-types.wit
+++ b/wit/preview2/http-types.wit
@@ -1,4 +1,4 @@
-default interface http-types {
+interface http-types {
    type http-status = u16
 
    type body = list<u8>

--- a/wit/preview2/http.wit
+++ b/wit/preview2/http.wit
@@ -1,5 +1,5 @@
-default interface http {
-    use pkg.http-types.{request, response, http-error}
+interface http {
+    use http-types.{request, response, http-error}
 
     send-request: func(req: request) -> result<response, http-error>
 }

--- a/wit/preview2/inbound-http.wit
+++ b/wit/preview2/inbound-http.wit
@@ -1,5 +1,5 @@
-default interface inbound-http {
-    use pkg.http-types.{request, response}
+interface inbound-http {
+    use http-types.{request, response}
 
     handle-request: func(req: request) -> response
 }

--- a/wit/preview2/inbound-redis.wit
+++ b/wit/preview2/inbound-redis.wit
@@ -1,5 +1,5 @@
-default interface inbound-redis {
-  use pkg.redis-types.{payload, error}
+interface inbound-redis {
+  use redis-types.{payload, error}
 
   // The entrypoint for a Redis handler.
   handle-message: func(message: payload) -> result<_, error>

--- a/wit/preview2/key-value.wit
+++ b/wit/preview2/key-value.wit
@@ -1,4 +1,4 @@
-default interface key-value {
+interface key-value {
   // A handle to an open key-value store
   type store = u32
 

--- a/wit/preview2/mysql.wit
+++ b/wit/preview2/mysql.wit
@@ -1,5 +1,5 @@
-default interface mysql {
-  use pkg.rdbms-types.{parameter-value, row-set}
+interface mysql {
+  use rdbms-types.{parameter-value, row-set}
 
   // General purpose error.
   variant mysql-error {

--- a/wit/preview2/postgres.wit
+++ b/wit/preview2/postgres.wit
@@ -1,5 +1,5 @@
-default interface postgres {
-  use pkg.rdbms-types.{parameter-value, row-set}
+interface postgres {
+  use rdbms-types.{parameter-value, row-set}
 
   // General purpose error.
   variant pg-error {

--- a/wit/preview2/rdbms-types.wit
+++ b/wit/preview2/rdbms-types.wit
@@ -1,4 +1,4 @@
-default interface rdbms-types {
+interface rdbms-types {
   enum db-data-type {
       boolean,
       int8,

--- a/wit/preview2/reactor.wit
+++ b/wit/preview2/reactor.wit
@@ -1,10 +1,12 @@
-default world reactor {
-  import config: pkg.config
-  import postgres: pkg.postgres
-  import mysql: pkg.mysql
-  import redis: pkg.redis
-  import key-value: pkg.key-value
-  import http: pkg.http
-  export inbound-http: pkg.inbound-http
-  export inbound-redis: pkg.inbound-redis
+package spin:reactor
+
+world reactor {
+  import config
+  import postgres
+  import mysql
+  import redis
+  import key-value
+  import http
+  export inbound-http
+  export inbound-redis
 }

--- a/wit/preview2/redis-types.wit
+++ b/wit/preview2/redis-types.wit
@@ -1,4 +1,4 @@
-default interface redis-types {
+interface redis-types {
   // General purpose error.
   enum error {
       success,

--- a/wit/preview2/redis.wit
+++ b/wit/preview2/redis.wit
@@ -1,5 +1,5 @@
-default interface redis {
-  use pkg.redis-types.{payload, redis-parameter, redis-result, error}
+interface redis {
+  use redis-types.{payload, redis-parameter, redis-result, error}
 
   // Publish a Redis message to the specificed channel and return an error, if any.
   publish: func(address: string, channel: string, payload: payload) -> result<_, error>


### PR DESCRIPTION
Update the WITs to follow the upcoming package format. This will not be able to land until https://github.com/bytecodealliance/wit-bindgen/pull/580 and https://github.com/bytecodealliance/wasmtime/pull/6390 land and possible a new version for wit-bindgen and wasmtime. 

I used the package name `spin:reactor` for the entire WIT package. Happy to change it