### PR TITLE
fix go sdk error when running tests

### DIFF
--- a/sdk/go/key_value/key-value.go
+++ b/sdk/go/key_value/key-value.go
@@ -87,7 +87,7 @@ func Close(store Store) {
 }
 
 func toCBytes(x []byte) C.key_value_list_u8_t {
-	return C.key_value_list_u8_t{ptr: &x[0], len: C.size_t(len(x))}
+	return C.key_value_list_u8_t{ptr: (*C.uint8_t)(unsafe.Pointer(&x[0])), len: C.size_t(len(x))}
 }
 
 func toCStr(x string) C.key_value_string_t {


### PR DESCRIPTION
when running unit tests on one of my project (https://github.com/rajatjindal/goodfirstissue branch: wasm6), I ran into following issue:

```
$) CGO_ENABLED=1 go test ./... -cover
.
<a lot of warnings>
.
# github.com/fermyon/spin/sdk/go/key_value
vendor/github.com/fermyon/spin/sdk/go/key_value/key-value.go:90:36: cannot use &x[0] (value of type *byte) as *_Ctype_uchar value in struct literal
```


which is fixed by this PR and I am able to run tests successfully. 

But I am not entirely sure of the side effect this change may have. so opening the PR to collect feedback