### PR TITLE
SQLite manifest validation and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ test-spin-up:
 test-kv:
 	RUST_LOG=$(LOG_LEVEL) cargo test --test spinup_tests --features e2e-tests --no-fail-fast -- spinup_tests::key_value --nocapture
 
+.PHONY: test-sqlite
+test-sqlite:
+	RUST_LOG=$(LOG_LEVEL) cargo test --test spinup_tests --features e2e-tests --no-fail-fast -- spinup_tests::sqlite --nocapture
+
 .PHONY: test-outbound-redis
 test-outbound-redis:
 	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --features outbound-redis-tests --no-fail-fast -- --nocapture

--- a/tests/spinup_tests.rs
+++ b/tests/spinup_tests.rs
@@ -18,6 +18,16 @@ mod spinup_tests {
     }
 
     #[tokio::test]
+    async fn sqlite_works() {
+        testcases::sqlite_works(CONTROLLER).await
+    }
+
+    #[tokio::test]
+    async fn sqlite_validation_works() {
+        testcases::sqlite_validation_works(CONTROLLER).await
+    }
+
+    #[tokio::test]
     async fn http_go_works() {
         testcases::http_go_works(CONTROLLER).await
     }

--- a/tests/testcases/sqlite-undefined-db/.cargo/config.toml
+++ b/tests/testcases/sqlite-undefined-db/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/tests/testcases/sqlite-undefined-db/Cargo.toml
+++ b/tests/testcases/sqlite-undefined-db/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name    = "sqlite-undefined-db"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# General-purpose crate with common HTTP types.
+http = "0.2"
+itertools = "0.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_qs = "0.12"
+spin-sdk = { path = "../../../sdk/rust", features = ["experimental"] }
+# The wit-bindgen-rust dependency generates bindings for interfaces.
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[workspace]

--- a/tests/testcases/sqlite-undefined-db/spin.toml
+++ b/tests/testcases/sqlite-undefined-db/spin.toml
@@ -1,0 +1,16 @@
+spin_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that requests access to an undefined SQLite database."
+name = "sqlite-undefined-db"
+trigger = {type = "http", base = "/test"}
+version = "1.0.0"
+
+[[component]]
+id = "hello"
+# intentionally use undefined ~words~ databases
+sqlite_databases = ["default", "anaspeptic", "pericombobulations"]
+source = "target/wasm32-wasi/release/sqlite_undefined_db.wasm"
+[component.trigger]
+route = "/..."
+[component.build]
+command = "cargo build --release --target wasm32-wasi"

--- a/tests/testcases/sqlite-undefined-db/src/lib.rs
+++ b/tests/testcases/sqlite-undefined-db/src/lib.rs
@@ -1,0 +1,14 @@
+use anyhow::{ensure, Result};
+use itertools::sorted;
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    key_value::{Error, Store},
+};
+
+#[http_component]
+fn handle_request(req: Request) -> Result<Response> {
+    // We don't need to do anything here: it should never get called because
+    // spin up should fail at SQLite validation.
+    Ok(http::Response::builder().status(200).body(None)?)
+}

--- a/tests/testcases/sqlite/.cargo/config.toml
+++ b/tests/testcases/sqlite/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/tests/testcases/sqlite/Cargo.toml
+++ b/tests/testcases/sqlite/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name    = "sqlite"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# General-purpose crate with common HTTP types.
+http = "0.2"
+itertools = "0.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_qs = "0.12"
+spin-sdk = { path = "../../../sdk/rust", features = ["experimental"] }
+# The wit-bindgen-rust dependency generates bindings for interfaces.
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[workspace]

--- a/tests/testcases/sqlite/spin.toml
+++ b/tests/testcases/sqlite/spin.toml
@@ -1,0 +1,15 @@
+spin_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that exercises SQLite storage."
+name = "sqlite"
+trigger = {type = "http", base = "/test"}
+version = "1.0.0"
+
+[[component]]
+id = "hello"
+sqlite_databases = ["default"]
+source = "target/wasm32-wasi/release/sqlite.wasm"
+[component.trigger]
+route = "/..."
+[component.build]
+command = "cargo build --release --target wasm32-wasi"

--- a/tests/testcases/sqlite/src/lib.rs
+++ b/tests/testcases/sqlite/src/lib.rs
@@ -1,0 +1,34 @@
+use anyhow::{ensure, Result};
+use spin_sdk::{
+    http::{Request, Response},
+    http_component,
+    sqlite::{Connection, Error, ValueParam},
+};
+
+#[http_component]
+fn handle_request(req: Request) -> Result<Response> {
+    ensure!(matches!(Connection::open("forbidden"), Err(Error::AccessDenied)));
+
+    let query = req.uri().query().expect("Should have a testkey query string");
+    let query: std::collections::HashMap::<String, String> = serde_qs::from_str(query)?;
+    let init_key = query.get("testkey").expect("Should have a testkey query string");
+    let init_val = query.get("testval").expect("Should have a testval query string");
+
+    let conn = Connection::open_default()?;
+
+    let results = conn.execute("SELECT * FROM testdata WHERE key = ?", &[ValueParam::Text(init_key)])?;
+
+    assert_eq!(1, results.rows.len());
+    assert_eq!(2, results.columns.len());
+
+    let key_index = results.columns.iter().position(|c| c == "key").unwrap();
+    let value_index = results.columns.iter().position(|c| c == "value").unwrap();
+
+    let fetched_key: &str = results.rows[0].get(key_index).unwrap();
+    let fetched_value: &str = results.rows[0].get(value_index).unwrap();
+
+    assert_eq!(init_key, fetched_key);
+    assert_eq!(init_val, fetched_value);
+
+    Ok(http::Response::builder().status(200).body(None)?)
+}


### PR DESCRIPTION
```
$ spin up
Error: One or more components use SQLite databases which are not defined.
Check the spelling, or pass a runtime configuration file that defines these stores.
See https://developer.fermyon.com/spin/dynamic-configuration#sqlite-storage-runtime-configuration
Details:
- Component sqlmadness uses database 'honkytonk'
```

The docs page doesn't exist yet so I could take that line out and put it back in when we do the formal release of SQLite, but I'm not immensely motivated!