### PR TITLE
Avoid showing SQLite features in releases until ready

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -108,7 +108,7 @@ where
     key_values: Vec<(String, String)>,
 
     /// Run a sqlite migration against the default database
-    #[clap(long = "sqlite")]
+    #[clap(long = "sqlite", hide = true)]
     sqlite_statements: Vec<String>,
 
     #[clap(long = "help-args-only", hide = true)]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -24,3 +24,4 @@ serde = {version = "1.0.163", optional = true}
 default = ["export-sdk-language"]
 export-sdk-language = []
 json = ["dep:serde", "dep:serde_json"]
+experimental = []

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -9,6 +9,7 @@ pub mod outbound_http;
 pub mod key_value;
 
 /// Sqlite
+#[cfg(feature = "experimental")]
 pub mod sqlite;
 
 /// Exports the procedural macros for writing handlers for Spin components.


### PR DESCRIPTION
We do not expect SQLite to be entirely ready at the next Spin release, but do not want to wrestle with cherry picking commits and disentangling conflicts.  Therefore the plan is:

* Suppress the `spin up --sqlite` flag from being shown in the help text.
* Gate the Rust SDK `sqlite` module behind a feature flag.

The second needs a bit of coordination with #1549 so I'll have a chat with the author of that one and see what order we want to do things in.