### PR TITLE
List plugins in help

### DIFF
--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -1,11 +1,12 @@
 use anyhow::Error;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
 use spin_cli::build_info::*;
+use spin_cli::commands::external::predefined_externals;
 use spin_cli::commands::{
     build::BuildCommand,
-    cloud::{CloudCommand, DeployCommand, LoginCommand},
+    cloud::{DeployCommand, LoginCommand},
     doctor::DoctorCommand,
     external::execute_external_subcommand,
     new::{AddCommand, NewCommand},
@@ -38,7 +39,37 @@ async fn _main() -> anyhow::Result<()> {
         )
         .with_ansi(std::io::stderr().is_terminal())
         .init();
-    SpinApp::parse().run().await
+
+    let plugin_help_entries = plugin_help_entries();
+
+    let mut cmd = SpinApp::command();
+    for plugin in &plugin_help_entries {
+        let subcmd = clap::Command::new(plugin.display_text())
+            .about(plugin.about.as_str())
+            .allow_hyphen_values(true)
+            .disable_help_flag(true)
+            .arg(
+                clap::Arg::new("command")
+                    .allow_hyphen_values(true)
+                    .multiple_values(true),
+            );
+        cmd = cmd.subcommand(subcmd);
+    }
+
+    if !plugin_help_entries.is_empty() {
+        cmd = cmd.after_help("* implemented via plugin");
+    }
+
+    let matches = cmd.clone().get_matches();
+
+    if let Some((subcmd, _)) = matches.subcommand() {
+        if plugin_help_entries.iter().any(|e| e.name == subcmd) {
+            let command = std::env::args().skip(1).collect();
+            return execute_external_subcommand(command, cmd).await;
+        }
+    }
+
+    SpinApp::from_arg_matches(&matches)?.run(cmd).await
 }
 
 fn print_error_chain(err: anyhow::Error) {
@@ -76,7 +107,6 @@ enum SpinApp {
     New(NewCommand),
     Add(AddCommand),
     Up(UpCommand),
-    Cloud(CloudCommand),
     // acts as a cross-level subcommand shortcut -> `spin cloud deploy`
     Deploy(DeployCommand),
     // acts as a cross-level subcommand shortcut -> `spin cloud login`
@@ -104,13 +134,12 @@ enum TriggerCommands {
 
 impl SpinApp {
     /// The main entry point to Spin.
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self, app: clap::Command<'_>) -> Result<(), Error> {
         match self {
             Self::Templates(cmd) => cmd.run().await,
             Self::Up(cmd) => cmd.run().await,
             Self::New(cmd) => cmd.run().await,
             Self::Add(cmd) => cmd.run().await,
-            Self::Cloud(cmd) => cmd.run(SpinApp::command()).await,
             Self::Deploy(cmd) => cmd.run(SpinApp::command()).await,
             Self::Login(cmd) => cmd.run(SpinApp::command()).await,
             Self::Registry(cmd) => cmd.run().await,
@@ -119,7 +148,7 @@ impl SpinApp {
             Self::Trigger(TriggerCommands::Redis(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::HelpArgsOnly(cmd)) => cmd.run().await,
             Self::Plugins(cmd) => cmd.run().await,
-            Self::External(cmd) => execute_external_subcommand(cmd, SpinApp::command()).await,
+            Self::External(cmd) => execute_external_subcommand(cmd, app).await,
             Self::Watch(cmd) => cmd.run().await,
             Self::Doctor(cmd) => cmd.run().await,
         }
@@ -129,4 +158,54 @@ impl SpinApp {
 /// Returns build information, similar to: 0.1.0 (2be4034 2022-03-31).
 fn build_info() -> String {
     format!("{SPIN_VERSION} ({SPIN_COMMIT_SHA} {SPIN_COMMIT_DATE})")
+}
+
+struct PluginHelpEntry {
+    name: String,
+    about: String,
+}
+
+impl PluginHelpEntry {
+    fn from_plugin(plugin: &spin_plugins::manifest::PluginManifest) -> Option<Self> {
+        if hide_plugin_in_help(plugin) {
+            None
+        } else {
+            Some(Self {
+                name: plugin.name(),
+                about: plugin.description().unwrap_or_default().to_owned(),
+            })
+        }
+    }
+
+    fn display_text(&self) -> String {
+        format!("{}*", self.name)
+    }
+}
+
+fn plugin_help_entries() -> Vec<PluginHelpEntry> {
+    let mut entries = installed_plugin_help_entries();
+    for (name, about) in predefined_externals() {
+        if !entries.iter().any(|e| e.name == name) {
+            entries.push(PluginHelpEntry { name, about });
+        }
+    }
+    entries
+}
+
+fn installed_plugin_help_entries() -> Vec<PluginHelpEntry> {
+    let Ok(manager) = spin_plugins::manager::PluginManager::try_default() else {
+        return vec![];
+    };
+    let Ok(manifests) = manager.store().installed_manifests() else {
+        return vec![];
+    };
+
+    manifests
+        .iter()
+        .filter_map(PluginHelpEntry::from_plugin)
+        .collect()
+}
+
+fn hide_plugin_in_help(plugin: &spin_plugins::manifest::PluginManifest) -> bool {
+    plugin.name().starts_with("trigger-")
 }

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -26,26 +26,6 @@ pub struct LoginCommand {
     args: Vec<String>,
 }
 
-#[derive(Debug, Args, PartialEq)]
-#[clap(
-    about = "Commands for publishing applications to the Fermyon Cloud.",
-    allow_hyphen_values = true,
-    disable_help_flag = true
-)]
-pub struct CloudCommand {
-    /// All args to be passed through to the plugin
-    #[clap(hide = true)]
-    args: Vec<String>,
-}
-
-impl CloudCommand {
-    pub async fn run(self, app: clap::App<'_>) -> Result<()> {
-        let mut cmd = vec!["cloud".to_string()];
-        cmd.append(&mut self.args.clone());
-        execute_external_subcommand(cmd, app).await
-    }
-}
-
 impl DeployCommand {
     pub async fn run(self, app: clap::App<'_>) -> Result<()> {
         let mut cmd = vec!["cloud".to_string(), "deploy".to_string()];


### PR DESCRIPTION
This is an experiment to see if people like this experience or not.  Here's what it looks like on the proverbial my machine:

```
$ spin
spin 1.3.0-pre0 (b6a752f 2023-06-08)
The Spin CLI

USAGE:
    spin <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    add          Scaffold a new component into an existing application
    build        Build the Spin application
    cloud        Commands for publishing applications to the Fermyon Cloud.
    deploy       Package and upload an application to the Fermyon Platform
    help         Print this message or the help of the given subcommand(s)
    js2wasm      A plugin to convert js files to Spin compatible modules
    login        Log into to the Fermyon Cloud.
    new          Scaffold a new application based on a template
    pluginify    
    plugins      Install/uninstall Spin plugins
    py2wasm      A plugin to convert Python applications to Spin compatible modules
    registry     Commands for working with OCI registries to distribute applications
    templates    Commands for working with WebAssembly component templates
    timer        IT IS I THE GREAT OZ
    up           Start the Spin application
    watch        Build and run the Spin application, rebuilding and restarting it when files
                     change
```

At the moment, I expect there to be a bug when the `cloud` plugin is installed, since that's a legit command as well.  I have a feeling I can solve this by _steeples fingers_ abolishing the `cloud` command and just always injecting the help entry - because Kate has put all the magic into the `external` side rather than the command side, I think it will behave correctly even if no actual `CloudCommand` exists.  But I will investigate that if we decide to go forward with this; one way or another it will be fixable.
