### PR TITLE
core: Add Engine::find_host_component_handle

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -262,6 +262,13 @@ impl<T: Send + Sync> Engine<T> {
         let inner = Arc::new(self.module_linker.instantiate_pre(module)?);
         Ok(ModuleInstancePre { inner })
     }
+
+    /// Find the [`HostComponentDataHandle`] for a [`HostComponent`] if configured for this engine.
+    pub fn find_host_component_handle<HC: HostComponent>(
+        &self,
+    ) -> Option<HostComponentDataHandle<HC>> {
+        self.host_components.find_handle()
+    }
 }
 
 impl<T> AsRef<wasmtime::Engine> for Engine<T> {

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -132,12 +132,10 @@ async fn test_host_component() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_host_component_data_update() {
-    // Need to build Engine separately to get the HostComponentDataHandle
-    let mut engine_builder = Engine::builder(&test_config()).unwrap();
-    let factor_data_handle = engine_builder
-        .add_host_component(MultiplierHostComponent)
+    let engine = test_engine();
+    let multiplier_handle = engine
+        .find_host_component_handle::<MultiplierHostComponent>()
         .unwrap();
-    let engine: Engine<()> = engine_builder.build();
 
     let stdout = run_core_wasi_test_engine(
         &engine,
@@ -145,7 +143,7 @@ async fn test_host_component_data_update() {
         |store_builder| {
             store_builder
                 .host_components_data()
-                .set(factor_data_handle, Multiplier(100));
+                .set(multiplier_handle, Multiplier(100));
         },
         |_| {},
     )


### PR DESCRIPTION
This method allows a HostComponentDataHandle to be looked up after an Engine has been built.