### PR TITLE
fix(plugins): Display required Spin version of incompatible plugins

### DIFF
--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -40,6 +40,10 @@ impl PluginManifest {
         self.license.as_ref()
     }
 
+    pub fn spin_compatibility(&self) -> String {
+        self.spin_compatibility.clone()
+    }
+
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref()
     }

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -353,10 +353,10 @@ impl List {
         } else {
             for p in plugins {
                 let installed = if p.installed { " [installed]" } else { "" };
-                let compat = match p.compatibility {
-                    PluginCompatibility::Compatible => "",
-                    PluginCompatibility::IncompatibleSpin => " [requires other Spin version]",
-                    PluginCompatibility::Incompatible => " [incompatible]",
+                let compat = match &p.compatibility {
+                    PluginCompatibility::Compatible => String::new(),
+                    PluginCompatibility::IncompatibleSpin(v) => format!(" [requires Spin {v}]"),
+                    PluginCompatibility::Incompatible => String::from(" [incompatible]"),
                 };
                 println!("{} {}{}{}", p.name, p.version, installed, compat);
             }
@@ -367,7 +367,7 @@ impl List {
 #[derive(Debug)]
 pub(crate) enum PluginCompatibility {
     Compatible,
-    IncompatibleSpin,
+    IncompatibleSpin(String),
     Incompatible,
 }
 
@@ -378,7 +378,7 @@ impl PluginCompatibility {
             if manifest.is_compatible_spin_version(spin_version) {
                 Self::Compatible
             } else {
-                Self::IncompatibleSpin
+                Self::IncompatibleSpin(manifest.spin_compatibility())
             }
         } else {
             Self::Incompatible


### PR DESCRIPTION
fixes https://github.com/fermyon/spin/issues/1562

Currently listing plugins doesn't say what version of spin is requred:

```bash
$ spin plugins list
cloud 0.1.0 [requires other Spin version]
js2wasm 0.1.0
js2wasm 0.2.0
js2wasm 0.3.0 [requires other Spin version]
js2wasm 0.4.0
py2wasm 0.1.0
py2wasm 0.1.1
py2wasm 0.2.0 [installed]
```

This makes the list more informative:
```bash
$ spin plugins list
cloud 0.1.0 [requires Spin >=1.3]
js2wasm 0.1.0
js2wasm 0.2.0
js2wasm 0.3.0 [requires Spin <=0.7]
js2wasm 0.4.0
py2wasm 0.1.0
py2wasm 0.1.1
py2wasm 0.2.0 [installed]
```

> Note: i messed with js2wasm manifest to make it incompat for demo purposes

Considerations
- the plugin manifests allow for fairly complicated semver. We could run into this getting messy but it is unlikely