### PR TITLE
Remove instructions to install Fermyon Platform dependencies for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,6 @@
 # Integration test
 
-## Dependencies
-
-Please add following dependencies to your PATH before running `make test-integration`.
-
-* [bindle-server](https://github.com/deislabs/bindle)
-* [nomad](https://github.com/hashicorp/nomad)
-* [Hippo.Web](https://github.com/deislabs/hippo)
+Run integration tests with `make test-integration`.
 
 # E2E tests for spin
 


### PR DESCRIPTION
Fermyon Platform tests have been removed. We can also remove the directive in the integration tests readme to install associated dependencies