### PR TITLE
Add e2e tests for config variables

### DIFF
--- a/tests/spinup_tests.rs
+++ b/tests/spinup_tests.rs
@@ -8,6 +8,11 @@ mod spinup_tests {
     const CONTROLLER: &dyn Controller = &SpinUp {};
 
     #[tokio::test]
+    async fn config_variables_default_works() {
+        testcases::config_variables_default_works(CONTROLLER).await
+    }
+
+    #[tokio::test]
     async fn key_value_works() {
         testcases::key_value_works(CONTROLLER).await
     }

--- a/tests/testcases/config-variables/Cargo.toml
+++ b/tests/testcases/config-variables/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "config-variables"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+http = "0.2"
+serde_qs = "0.12"
+spin-sdk = { path = "../../../sdk/rust"}
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[workspace]

--- a/tests/testcases/config-variables/spin.toml
+++ b/tests/testcases/config-variables/spin.toml
@@ -1,0 +1,21 @@
+spin_manifest_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A simple application that exercises the use of a configuration variable"
+name = "config-variables"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[variables]
+password = { default = "pw" }
+
+[[component]]
+id = "config-variables"
+source = "target/wasm32-wasi/release/config_variables.wasm"
+allowed_http_hosts = []
+[component.trigger]
+route = "/..."
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+watch = ["src/**/*.rs", "Cargo.toml"]
+[component.config]
+password = "{{ password }}"

--- a/tests/testcases/config-variables/src/lib.rs
+++ b/tests/testcases/config-variables/src/lib.rs
@@ -1,0 +1,26 @@
+use anyhow::{ensure, Result};
+use spin_sdk::{
+    config,
+    http::{Request, Response},
+    http_component,
+};
+
+#[http_component]
+fn handle_request(req: Request) -> Result<Response> {
+    let query = req
+        .uri()
+        .query()
+        .expect("Should have a password query string");
+    let query: std::collections::HashMap<String, String> = serde_qs::from_str(query)?;
+    let provided_password = query
+        .get("password")
+        .expect("Should have a password query string");
+    let expected_password = config::get("password")?;
+
+    ensure!(
+        provided_password == &expected_password,
+        "password must match expected"
+    );
+
+    Ok(http::Response::builder().status(200).body(None)?)
+}


### PR DESCRIPTION
Tests to configuration variables. One tests that the default variable value is used if none is set and the other (which cannot be run on `spin up` due to the way `deploy_args` works) asserts that the `--variables` deploy flag works as expected.