### PR TITLE
fix(tests): Distinguish between deploy and up args in integration tests

### DIFF
--- a/crates/e2e-testing/src/controller.rs
+++ b/crates/e2e-testing/src/controller.rs
@@ -21,7 +21,8 @@ pub trait Controller {
         &self,
         app_name: &str,
         trigger_type: &str,
-        mut args: Vec<&str>,
+        mut deploy_args: Vec<&str>,
+        mut up_args: Vec<&str>,
         state_dir: &str,
     ) -> Result<Result<AppInstance, ExitedInstance>>;
     async fn stop_app(

--- a/crates/e2e-testing/src/spin_controller.rs
+++ b/crates/e2e-testing/src/spin_controller.rs
@@ -41,17 +41,18 @@ impl Controller for SpinUp {
         &self,
         app_name: &str,
         trigger_type: &str,
-        mut xargs: Vec<&str>,
+        mut _deploy_args: Vec<&str>,
+        mut up_args: Vec<&str>,
         state_dir: &str,
     ) -> Result<Result<AppInstance, ExitedInstance>> {
         let appdir = spin::appdir(app_name);
 
         let mut cmd = vec!["spin", "up"];
-        if !xargs.is_empty() {
-            cmd.append(&mut xargs);
+        if !up_args.is_empty() {
+            cmd.append(&mut up_args);
         }
 
-        if !xargs.contains(&"--state_dir") {
+        if !up_args.contains(&"--state_dir") {
             cmd.push("--state-dir");
             cmd.push(state_dir);
         }

--- a/crates/e2e-testing/src/testcase.rs
+++ b/crates/e2e-testing/src/testcase.rs
@@ -56,9 +56,14 @@ pub struct TestCase {
     pub plugins: Option<Vec<String>>,
 
     /// optional
-    /// if provided, appended to `spin up/deploy` command
+    /// if provided, appended to `spin deploy` command
     #[builder(default = "vec![]")]
     pub deploy_args: Vec<String>,
+
+    /// optional
+    /// if provided, appended to `spin up` command
+    #[builder(default = "vec![]")]
+    pub up_args: Vec<String>,
 
     /// optional
     /// if provided, executed as command line before running `spin build`
@@ -175,8 +180,15 @@ impl TestCase {
         // run `spin up` (or `spin deploy` for cloud).
         // `AppInstance` has some basic info about the running app like base url, routes (only for cloud) etc.
         let deploy_args = self.deploy_args.iter().map(|s| s as &str).collect();
+        let up_args = self.up_args.iter().map(|s| s as &str).collect();
         let run_result = controller
-            .run_app(&appname, &self.trigger_type, deploy_args, &state_dir)
+            .run_app(
+                &appname,
+                &self.trigger_type,
+                deploy_args,
+                up_args,
+                &state_dir,
+            )
             .await
             .context("running app")?;
         match run_result {

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -46,6 +46,10 @@ pub async fn key_value_works(controller: &dyn Controller) {
         .name("key-value".to_string())
         .appname(Some("key-value".to_string()))
         .template(None)
+        .up_args(vec![
+            "--key-value".to_string(),
+            format!("{init_key}={init_value}"),
+        ])
         .deploy_args(vec![
             "--key-value".to_string(),
             format!("{init_key}={init_value}"),
@@ -133,7 +137,7 @@ pub async fn sqlite_works(controller: &dyn Controller) {
         .name("sqlite".to_string())
         .appname(Some("sqlite".to_string()))
         .template(None)
-        .deploy_args(vec![
+        .up_args(vec![
             "--sqlite".to_string(),
             "\"CREATE TABLE testdata(key TEXT, value TEXT)\"".to_string(),
             "--sqlite".to_string(),
@@ -768,7 +772,7 @@ pub async fn header_dynamic_env_works(controller: &dyn Controller) {
     let tc = TestCaseBuilder::default()
         .name("headers-dynamic-env-test".to_string())
         .appname(Some("headers-dynamic-env-test".to_string()))
-        .deploy_args(vec!["--env".to_string(), "foo=bar".to_string()])
+        .up_args(vec!["--env".to_string(), "foo=bar".to_string()])
         .assertions(
             |metadata: AppMetadata,
              stdout_stream: Option<Pin<Box<dyn AsyncBufRead>>>,
@@ -814,7 +818,7 @@ pub async fn http_rust_outbound_mysql_works(controller: &dyn Controller) {
     let tc = TestCaseBuilder::default()
         .name("http-rust-outbound-mysql".to_string())
         .appname(Some("http-rust-outbound-mysql".to_string()))
-        .deploy_args(vec!["--env".to_string(), "foo=bar".to_string()])
+        .up_args(vec!["--env".to_string(), "foo=bar".to_string()])
         .assertions(
             |metadata: AppMetadata,
              stdout_stream: Option<Pin<Box<dyn AsyncBufRead>>>,
@@ -1033,6 +1037,11 @@ pub async fn registry_works(controller: &dyn Controller) {
         .appname(Some("http-go-registry-generated".to_string()))
         .push_to_registry(Some(registry_app_url.clone()))
         .deploy_args(vec![
+            "--from-registry".to_string(),
+            registry_app_url.clone(),
+            "--insecure".to_string(),
+        ])
+        .up_args(vec![
             "--from-registry".to_string(),
             registry_app_url.clone(),
             "--insecure".to_string(),


### PR DESCRIPTION
`spin deploy` does not support the same set of args as `spin up`. This helps distinguish that in the tests, right now most apparently for `--sqlite`