### PR TITLE
Prevent concurrent `spin plugin update` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,13 +1616,13 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.10"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
+checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
 dependencies = [
  "cfg-if",
- "rustix 0.36.9",
- "windows-sys 0.45.0",
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5343,6 +5343,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "dirs 4.0.0",
+ "fd-lock",
  "flate2",
  "reqwest",
  "semver 1.0.16",

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 anyhow = "1.0"
 bytes = "1.1"
 dirs = "4.0"
+fd-lock = "3.0.12"
 flate2 = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 semver = "1.0"


### PR DESCRIPTION
This is in support of the plugin badger; it provides protection in case a badger tries to kick off an update while an update triggered by a previous badger is still running.  (It is built into `spin plugins update` rather than the badger, because it is probably wise for users not to accidentally do it either.)

User experience:

```
$ spin plugins update
Error: Another plugin update operation is already in progress
```