### PR TITLE
Small SQLite clean up

### DIFF
--- a/crates/sqlite-inproc/src/lib.rs
+++ b/crates/sqlite-inproc/src/lib.rs
@@ -86,17 +86,10 @@ impl Connection for InProcConnection {
         Ok(spin_world::sqlite::QueryResult { columns, rows })
     }
 
-    fn execute_batch(
-        &self,
-        statements: &str,
-    ) -> Result<spin_world::sqlite::QueryResult, spin_world::sqlite::Error> {
+    fn execute_batch(&self, statements: &str) -> anyhow::Result<()> {
         let conn = self.0.lock().unwrap();
-        conn.execute_batch(statements)
-            .map_err(|e| spin_world::sqlite::Error::Io(e.to_string()))?;
-        Ok(spin_world::sqlite::QueryResult {
-            rows: vec![],
-            columns: vec![],
-        })
+        conn.execute_batch(statements)?;
+        Ok(())
     }
 }
 

--- a/crates/sqlite-libsql/src/lib.rs
+++ b/crates/sqlite-libsql/src/lib.rs
@@ -26,8 +26,8 @@ impl spin_sqlite::Connection for LibsqlClient {
     fn query(
         &self,
         query: &str,
-        parameters: Vec<spin_world::sqlite::Value>,
-    ) -> Result<spin_world::sqlite::QueryResult, spin_world::sqlite::Error> {
+        parameters: Vec<sqlite::Value>,
+    ) -> Result<sqlite::QueryResult, sqlite::Error> {
         let stmt =
             libsql_client::statement::Statement::with_args(query, &convert_parameters(&parameters));
         let client = self.client.clone();
@@ -42,74 +42,50 @@ impl spin_sqlite::Connection for LibsqlClient {
         })
         .join()
         .unwrap_or_else(|_| Err(anyhow::anyhow!("internal thread error")))
-        .map_err(|e| spin_world::sqlite::Error::Io(e.to_string()))?;
+        .map_err(|e| sqlite::Error::Io(e.to_string()))?;
 
-        let rows = result
-            .rows
-            .into_iter()
-            .map(|r| {
-                let values = r.values.into_iter().map(convert_result).collect();
-                RowResult { values }
-            })
-            .collect();
-        Ok(spin_world::sqlite::QueryResult {
+        Ok(sqlite::QueryResult {
             columns: result.columns,
-            rows,
+            rows: convert_rows(result.rows),
         })
     }
 
-    fn execute_batch(
-        &self,
-        statements: &str,
-    ) -> Result<spin_world::sqlite::QueryResult, spin_world::sqlite::Error> {
+    fn execute_batch(&self, statements: &str) -> anyhow::Result<()> {
         let client = self.client.clone();
 
-        // SURELY THIS IS NOT SOMETHING WE HAVE TO DO SURELY
-        let stmts: Vec<_> =
-            sqlparser::parser::Parser::parse_sql(&sqlparser::dialect::SQLiteDialect {}, statements)
-                .map_err(|e| spin_world::sqlite::Error::Io(e.to_string()))? // TODO: Io is a non-ideal error here
-                .iter()
-                .map(|st| st.to_string())
-                .map(libsql_client::Statement::from)
-                .collect();
+        // Unfortunately, the libsql library requires that the statements are already split
+        // into individual statement strings which requires us to parse the supplied SQL string.
+        let stmts: Vec<_> = sqlparser::parser::Parser::parse_sql(
+            &sqlparser::dialect::SQLiteDialect {},
+            statements,
+        )?
+        .iter()
+        .map(|st| st.to_string())
+        .map(libsql_client::Statement::from)
+        .collect();
 
         // As in `query`, the shenanigans just wrap a call to libsql's `Client::batch()`.
-        let results = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(client.batch(stmts))
         })
         .join()
-        .unwrap_or_else(|_| Err(anyhow::anyhow!("internal thread error")))
-        .map_err(|e| spin_world::sqlite::Error::Io(e.to_string()))?;
+        .unwrap_or_else(|_| Err(anyhow::anyhow!("internal thread error")))?;
 
-        // .into_iter() is needed so that last() is owned
-        let result = match results.into_iter().last() {
-            Some(rs) => rs,
-            None => {
-                return Ok(spin_world::sqlite::QueryResult {
-                    columns: vec![],
-                    rows: vec![],
-                })
-            }
-        };
-
-        // TODO: Well this all looks eerily familiar
-        let rows = result
-            .rows
-            .into_iter()
-            .map(|r| {
-                let values = r.values.into_iter().map(convert_result).collect();
-                RowResult { values }
-            })
-            .collect();
-        Ok(spin_world::sqlite::QueryResult {
-            columns: result.columns,
-            rows,
-        })
+        Ok(())
     }
 }
 
-fn convert_result(v: libsql_client::Value) -> sqlite::Value {
+fn convert_rows(rows: Vec<libsql_client::Row>) -> Vec<RowResult> {
+    rows.into_iter()
+        .map(|r| {
+            let values = r.values.into_iter().map(convert_value).collect();
+            RowResult { values }
+        })
+        .collect()
+}
+
+fn convert_value(v: libsql_client::Value) -> sqlite::Value {
     use libsql_client::Value;
 
     match v {
@@ -121,15 +97,17 @@ fn convert_result(v: libsql_client::Value) -> sqlite::Value {
     }
 }
 
-fn convert_parameters(parameters: &[spin_world::sqlite::Value]) -> Vec<libsql_client::Value> {
+fn convert_parameters(parameters: &[sqlite::Value]) -> Vec<libsql_client::Value> {
+    use libsql_client::Value;
+
     parameters
         .iter()
         .map(|v| match v {
-            sqlite::Value::Integer(value) => libsql_client::Value::Integer { value: *value },
-            sqlite::Value::Real(value) => libsql_client::Value::Float { value: *value },
-            sqlite::Value::Text(t) => libsql_client::Value::Text { value: t.clone() },
-            sqlite::Value::Blob(b) => libsql_client::Value::Blob { value: b.clone() },
-            sqlite::Value::Null => libsql_client::Value::Null,
+            sqlite::Value::Integer(value) => Value::Integer { value: *value },
+            sqlite::Value::Real(value) => Value::Float { value: *value },
+            sqlite::Value::Text(t) => Value::Text { value: t.clone() },
+            sqlite::Value::Blob(b) => Value::Blob { value: b.clone() },
+            sqlite::Value::Null => Value::Null,
         })
         .collect()
 }

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -23,10 +23,7 @@ pub trait Connection: Send + Sync {
         parameters: Vec<spin_world::sqlite::Value>,
     ) -> Result<spin_world::sqlite::QueryResult, spin_world::sqlite::Error>;
 
-    fn execute_batch(
-        &self,
-        _statements: &str,
-    ) -> Result<spin_world::sqlite::QueryResult, spin_world::sqlite::Error>;
+    fn execute_batch(&self, statements: &str) -> anyhow::Result<()>;
 }
 
 /// An implementation of the SQLite host


### PR DESCRIPTION
A few small clean up items for the SQLite feature:

* Make `execute_batch` return `anyhow::Result<()>`
* Some small renames and code reformatting 