### PR TITLE
Allow re-initializing the connection store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5516,6 +5516,7 @@ dependencies = [
  "spin-sqlite",
  "spin-sqlite-inproc",
  "spin-sqlite-libsql",
+ "spin-world",
  "tempfile",
  "tokio",
  "toml 0.5.11",

--- a/crates/sqlite-libsql/src/lib.rs
+++ b/crates/sqlite-libsql/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use libsql_client::DatabaseClient;
 use spin_world::sqlite::{self, RowResult};
 
@@ -13,12 +11,6 @@ impl LibsqlClient {
         Self {
             client: libsql_client::reqwest::Client::new(url, token),
         }
-    }
-}
-
-impl spin_sqlite::ConnectionManager for LibsqlClient {
-    fn get_connection(&self) -> Result<Arc<dyn spin_sqlite::Connection>, sqlite::Error> {
-        Ok(Arc::new(self.clone()))
     }
 }
 

--- a/crates/sqlite/src/host_component.rs
+++ b/crates/sqlite/src/host_component.rs
@@ -40,10 +40,10 @@ impl HostComponent for SqliteComponent {
         // The Noop implementation will never get called.
         struct Noop;
         impl ConnectionsStore for Noop {
-            fn get_connection_manager(
+            fn get_connection(
                 &self,
                 _database: &str,
-            ) -> Option<&(dyn crate::ConnectionManager + 'static)> {
+            ) -> Option<Arc<dyn crate::Connection + 'static>> {
                 debug_assert!(false, "`Noop` `ConnectionsStore` was called");
                 None
             }
@@ -67,7 +67,7 @@ impl DynamicHostComponent for SqliteComponent {
         for component in app.components() {
             let connections_store = (self.init_connections_store)(&component);
             for allowed in component.get_metadata(DATABASES_KEY)?.unwrap_or_default() {
-                if connections_store.get_connection_manager(&allowed).is_none() {
+                if connections_store.get_connection(&allowed).is_none() {
                     let err = format!("- Component {} uses database '{allowed}'", component.id());
                     errors.push(err);
                 }

--- a/crates/sqlite/src/host_component.rs
+++ b/crates/sqlite/src/host_component.rs
@@ -43,9 +43,15 @@ impl HostComponent for SqliteComponent {
             fn get_connection(
                 &self,
                 _database: &str,
-            ) -> Option<Arc<dyn crate::Connection + 'static>> {
+            ) -> Result<Option<Arc<(dyn crate::Connection + 'static)>>, spin_world::sqlite::Error>
+            {
                 debug_assert!(false, "`Noop` `ConnectionsStore` was called");
-                None
+                Ok(None)
+            }
+
+            fn has_connection_for(&self, _database: &str) -> bool {
+                debug_assert!(false, "`Noop` `ConnectionsStore` was called");
+                false
             }
         }
         SqliteDispatch::new(Arc::new(Noop))
@@ -67,7 +73,7 @@ impl DynamicHostComponent for SqliteComponent {
         for component in app.components() {
             let connections_store = (self.init_connections_store)(&component);
             for allowed in component.get_metadata(DATABASES_KEY)?.unwrap_or_default() {
-                if connections_store.get_connection(&allowed).is_none() {
+                if !connections_store.has_connection_for(&allowed) {
                     let err = format!("- Component {} uses database '{allowed}'", component.id());
                     errors.push(err);
                 }

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -24,6 +24,7 @@ spin-key-value-sqlite = { path = "../key-value-sqlite" }
 spin-sqlite = { path = "../sqlite" }
 spin-sqlite-inproc = { path = "../sqlite-inproc" }
 spin-sqlite-libsql = { path = "../sqlite-libsql" }
+spin-world = { path = "../world" }
 sanitize-filename = "0.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/trigger/src/runtime_config.rs
+++ b/crates/trigger/src/runtime_config.rs
@@ -10,6 +10,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
+use spin_sqlite::ConnectionManager;
 
 use self::{
     config_provider::{ConfigProvider, ConfigProviderOpts},
@@ -107,7 +108,7 @@ impl RuntimeConfig {
     /// Return an iterator of named configured [`SqliteDatabase`]s.
     pub fn sqlite_databases(
         &self,
-    ) -> Result<impl IntoIterator<Item = (String, sqlite::SqliteDatabase)>> {
+    ) -> Result<impl IntoIterator<Item = (String, Box<dyn ConnectionManager>)>> {
         let mut databases = HashMap::new();
         // Insert explicitly-configured databases
         for opts in self.opts_layers() {

--- a/crates/trigger/src/runtime_config.rs
+++ b/crates/trigger/src/runtime_config.rs
@@ -6,11 +6,12 @@ use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
-use spin_sqlite::ConnectionManager;
+use spin_sqlite::Connection;
 
 use self::{
     config_provider::{ConfigProvider, ConfigProviderOpts},
@@ -108,7 +109,7 @@ impl RuntimeConfig {
     /// Return an iterator of named configured [`SqliteDatabase`]s.
     pub fn sqlite_databases(
         &self,
-    ) -> Result<impl IntoIterator<Item = (String, Box<dyn ConnectionManager>)>> {
+    ) -> Result<impl IntoIterator<Item = (String, Arc<dyn Connection>)>> {
         let mut databases = HashMap::new();
         // Insert explicitly-configured databases
         for opts in self.opts_layers() {

--- a/crates/trigger/src/runtime_config/sqlite.rs
+++ b/crates/trigger/src/runtime_config/sqlite.rs
@@ -27,8 +27,15 @@ pub(crate) fn build_component(
 struct SimpleConnectionsStore(HashMap<String, Arc<dyn Connection>>);
 
 impl ConnectionsStore for SimpleConnectionsStore {
-    fn get_connection(&self, database: &str) -> Option<Arc<(dyn Connection + 'static)>> {
-        self.0.get(database).cloned()
+    fn get_connection(
+        &self,
+        database: &str,
+    ) -> Result<Option<Arc<(dyn Connection + 'static)>>, spin_world::sqlite::Error> {
+        Ok(self.0.get(database).cloned())
+    }
+
+    fn has_connection_for(&self, database: &str) -> bool {
+        self.0.contains_key(database)
     }
 }
 


### PR DESCRIPTION
This PR changes the SQLite implementation to mirror the Key-Value implementation more closely by allowing re-initialization of a store of connections inside of `DynamicHostComponent::update_data`. This is strictly needed for Spin itself, but other implementations may wish to take advantage of this capability.