### PR TITLE
Small simplifications for spin-app

### DIFF
--- a/crates/app/src/host_component.rs
+++ b/crates/app/src/host_component.rs
@@ -14,9 +14,7 @@ use crate::{App, AppComponent};
 /// runtime configuration.
 ///
 /// Dynamic host components differ from regular host components in that they can be
-/// reference and thus (re-)configured dynamically (on a per trigger instance basis)
-/// where as regular host components are static and do not change over the
-/// runtime of a Spin instance.
+/// configured on a per-component basis.
 pub trait DynamicHostComponent: HostComponent {
     /// Called on [`AppComponent`] instance initialization.
     ///


### PR DESCRIPTION
Small tweaks to `spin-app` after some spelunking. The following changes were made:
* Add some docs. Even though these are internal types, it still helps to have some docs about *why* they're there.
* Unrolled some type aliases. I find type aliases that are not reused generally make things harder to understand. 
* Made `DynSafeDynamicHostComponent::update_data_any` take just a `&mut Data` instead of a `&mut Box<dyn Any + Send>`. There doesn't seem to be any need for that more complicated type
* Made `DynamicHostComponents` `pub(crate)`