### PR TITLE
Move resolve_file_path to spin_common

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -10,5 +10,6 @@
 
 pub mod arg_parser;
 pub mod data_dir;
+pub mod paths;
 pub mod sha256;
 pub mod sloth;

--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -1,11 +1,14 @@
-use anyhow::anyhow;
+//! Resolves a file path to a manifest file
+
+use anyhow::{anyhow, Result};
 use std::path::{Path, PathBuf};
 
-use crate::opts::DEFAULT_MANIFEST_FILE;
+/// The name given to the default manifest file.
+pub const DEFAULT_MANIFEST_FILE: &str = "spin.toml";
 
 /// Resolves a manifest path provided by a user, which may be a file or
 /// directory, to a path to a manifest file.
-pub(crate) fn resolve_file_path(provided_path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
+pub fn resolve_manifest_file_path(provided_path: impl AsRef<Path>) -> Result<PathBuf> {
     let path = provided_path.as_ref();
 
     if path.is_file() {

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -37,7 +37,7 @@ pub struct BuildCommand {
 
 impl BuildCommand {
     pub async fn run(self) -> Result<()> {
-        let manifest_file = crate::manifest::resolve_file_path(&self.app_source)?;
+        let manifest_file = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
         spin_build::build(&manifest_file, &self.component_id).await?;
 
         if self.up {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -26,7 +26,7 @@ pub struct DoctorCommand {
 
 impl DoctorCommand {
     pub async fn run(self) -> Result<()> {
-        let manifest_file = crate::manifest::resolve_file_path(&self.app_source)?;
+        let manifest_file = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
 
         println!("{icon}The Spin Doctor is in.", icon = Emoji("📟 ", ""));
         println!(

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -56,7 +56,7 @@ pub struct Push {
 
 impl Push {
     pub async fn run(self) -> Result<()> {
-        let app_file = crate::manifest::resolve_file_path(&self.app_source)?;
+        let app_file = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
 
         let dir = tempfile::tempdir()?;
         let app = spin_loader::local::from_file(&app_file, Some(dir.path())).await?;

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -247,7 +247,7 @@ impl UpCommand {
     }
 
     fn infer_file_source(path: impl Into<PathBuf>) -> AppSource {
-        match crate::manifest::resolve_file_path(path.into()) {
+        match spin_common::paths::resolve_manifest_file_path(path.into()) {
             Ok(file) => AppSource::File(file),
             Err(e) => AppSource::Unresolvable(e.to_string()),
         }

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -96,7 +96,7 @@ impl WatchCommand {
             },
         ));
 
-        let app = crate::manifest::resolve_file_path(&self.app_source)?;
+        let app = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
 
         // Prepare RuntimeConfig for Watchexec
         let app_dir = parent_dir(&app)?;
@@ -211,7 +211,7 @@ impl WatchCommand {
     }
 
     async fn generate_filter_config(&self) -> Result<crate::watch_filter::Config> {
-        let app = crate::manifest::resolve_file_path(&self.app_source)?;
+        let app = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
         let app_dir = parent_dir(&app)?;
         let app_manifest = spin_loader::local::raw_manifest_from_file(&app)
             .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod build_info;
 pub mod commands;
-pub mod manifest;
 pub(crate) mod opts;
 mod watch_filter;
 mod watch_state;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,4 +1,4 @@
-pub const DEFAULT_MANIFEST_FILE: &str = "spin.toml";
+pub const DEFAULT_MANIFEST_FILE: &str = spin_common::paths::DEFAULT_MANIFEST_FILE;
 pub const APP_MANIFEST_FILE_OPT: &str = "APP_MANIFEST_FILE";
 pub const INSECURE_OPT: &str = "INSECURE";
 pub const BUILD_UP_OPT: &str = "UP";


### PR DESCRIPTION
Moves `manifest::resolve_file_path` out of the CLI and into `spin-common`.  Currently this code is duplicated between `Spin` and the cloud plugin.

Will update `cloud-plugin` if we decide this fits the "common" criteria.