### PR TITLE
feat: make bindle optional in spin-loader crate

### DIFF
--- a/crates/bindle/Cargo.toml
+++ b/crates/bindle/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spin-app = { path = "../app" }
 spin-common = { path = "../common" }
-spin-loader = { path = "../loader" }
+spin-loader = { path = "../loader", features = ["bindle"]}
 spin-manifest = { path = "../manifest" }
 tempfile = "3.3.0"
 thiserror = "1.0.37"

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.52"
-bindle = { workspace = true }
+bindle = { workspace = true, optional = true }
 bytes = "1.1.0"
 dirs = "4.0"
 dunce = "1.0"
@@ -32,3 +32,8 @@ tokio-util = "0.6"
 toml = "0.5"
 tracing = { workspace = true }
 walkdir = "2.3.2"
+
+[features]
+default = ["local"]
+bindle = ["dep:bindle"]
+local = []

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -34,6 +34,6 @@ tracing = { workspace = true }
 walkdir = "2.3.2"
 
 [features]
-default = ["local"]
+default = ["bindle", "local"]
 bindle = ["dep:bindle"]
 local = []

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -11,16 +11,20 @@
 #![deny(missing_docs)]
 
 mod assets;
+#[cfg(feature = "bindle")]
 pub mod bindle;
 pub mod cache;
 mod common;
+#[cfg(feature = "local")]
 pub mod local;
 mod validation;
 
 /// Load a Spin application configuration from a spin.toml manifest file.
+#[cfg(feature = "local")]
 pub use local::from_file;
 
 /// Load a Spin application configuration from Bindle.
+#[cfg(feature = "bindle")]
 pub use crate::bindle::from_bindle;
 
 /// Maximum number of assets to process in parallel


### PR DESCRIPTION
Add local and bindle features to spin-loader so that spin embedder can opt-out of bindle dep completely

Signed-off-by: Jiaxiao Zhou (Mossaka) <duibao55328@gmail.com>