### PR TITLE
Add constructor for HostComponentInitData

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -139,10 +139,8 @@ where
         let working_dir = std::env::var(SPIN_WORKING_DIR).context(SPIN_WORKING_DIR)?;
         let locked_url = std::env::var(SPIN_LOCKED_URL).context(SPIN_LOCKED_URL)?;
 
-        let init_data = crate::HostComponentInitData {
-            kv: self.key_values.clone(),
-            sqlite: self.sqlite_statements.clone(),
-        };
+        let init_data =
+            crate::HostComponentInitData::new(&*self.key_values, &*self.sqlite_statements);
 
         let loader = TriggerLoader::new(working_dir, self.allow_transient_write);
         let executor = self.build_executor(loader, locked_url, init_data).await?;

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -161,6 +161,21 @@ pub struct HostComponentInitData {
     sqlite: Vec<String>,
 }
 
+impl HostComponentInitData {
+    /// Create an instance of `HostComponentInitData`.  `key_value_init_values`
+    /// will be added to the default key-value store; `sqlite_init_statements`
+    /// will be run against the default SQLite database.
+    pub fn new(
+        key_value_init_values: impl Into<Vec<(String, String)>>,
+        sqlite_init_statements: impl Into<Vec<String>>,
+    ) -> Self {
+        Self {
+            kv: key_value_init_values.into(),
+            sqlite: sqlite_init_statements.into(),
+        }
+    }
+}
+
 /// Execution context for a TriggerExecutor executing a particular App.
 pub struct TriggerAppEngine<Executor: TriggerExecutor> {
     /// Engine to be used with this executor.


### PR DESCRIPTION
This is a purely technical change to better support embedding scenarios.  At the moment, an embedder wanting to leverage `TriggerExecutorBuilder::build()` can only provide empty initialisation data; this provides for embedders to support `spin up --key-value`-style storage setup features.
