### PR TITLE
fix(build): Remove git worktree requirements for build to succeed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,9 @@ const RUST_OUTBOUND_REDIS_INTEGRATION_TEST: &str = "tests/outbound-redis/http-ru
 const TIMER_TRIGGER_INTEGRATION_TEST: &str = "examples/spin-timer/app-example";
 
 fn main() {
+    // Extract environment information to be passed to plugins.
+    // Git information will be set to defaults if Spin is not
+    // built within a Git worktree.
     vergen::EmitBuilder::builder()
         .build_date()
         .build_timestamp()
@@ -23,7 +26,6 @@ fn main() {
         .git_commit_date()
         .git_commit_timestamp()
         .git_sha(true)
-        .fail_on_error()
         .emit()
         .expect("failed to extract build information");
 

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -8,17 +8,14 @@ fn main() {
         format!("-{pre}")
     };
 
-    let output = Command::new("git")
+    let commit = Command::new("git")
         .arg("rev-parse")
         .arg("HEAD")
         .output()
-        .expect("failed to execute `git`");
-
-    let commit = if output.status.success() {
-        String::from_utf8(output.stdout).unwrap()
-    } else {
-        panic!("`git` failed: {}", String::from_utf8_lossy(&output.stderr));
-    };
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+        .unwrap_or(String::from("unknown"));
 
     let commit = commit.trim();
 


### PR DESCRIPTION
fixes #1589

The git environment variables passed to plugins will be set to [`vergen`'s defaults](https://github.com/rustyhorde/vergen/blob/8e0f393f59696b68b533e2fc94eba22ff7c2e377/vergen/src/feature/git/gix.rs#L244) if Spin is being built from source code rather than a git environment.

Aside: The fact that the Rust SDK was preventing successful builds of Spin provides impetus for maybe moving the SDKs to their own repositories