### PR TITLE
Warn when directly using a WebAssembly component

### DIFF
--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -49,18 +49,23 @@ impl Loader for TriggerLoader {
             .as_ref()
             .context("LockedComponentSource missing source field")?;
         let path = parse_file_url(source)?;
-        spin_core::Component::new(
-            engine,
-            spin_componentize::componentize_if_necessary(&fs::read(&path).await.with_context(
-                || {
-                    format!(
-                        "failed to read component source from disk at path '{}'",
-                        path.display()
-                    )
-                },
-            )?)?,
-        )
-        .with_context(|| format!("loading module {path:?}"))
+        let bytes = fs::read(&path).await.with_context(|| {
+            format!(
+                "failed to read component source from disk at path '{}'",
+                path.display()
+            )
+        })?;
+        let component = spin_componentize::componentize_if_necessary(&bytes)?;
+        let was_already_component = matches!(component, std::borrow::Cow::Borrowed(_));
+        if was_already_component {
+            println!(
+                "Warning: spin component at path {} is already a WebAssembly component. \
+                Directly using WebAssembly components is an experimental feature.",
+                path.display()
+            )
+        }
+        spin_core::Component::new(engine, component)
+            .with_context(|| format!("loading module {path:?}"))
     }
 
     async fn load_module(

--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -59,8 +59,8 @@ impl Loader for TriggerLoader {
         let was_already_component = matches!(component, std::borrow::Cow::Borrowed(_));
         if was_already_component {
             println!(
-                "Warning: spin component at path {} is already a WebAssembly component. \
-                Directly using WebAssembly components is an experimental feature.",
+                "Warning: Spin component at path {} is a WebAssembly component instead of a \
+                WebAssembly module. Use of the WebAssembly component model is an experimental feature.",
                 path.display()
             )
         }


### PR DESCRIPTION
Fixes #1571

This emits a warning when loading a WebAssembly component directly instead of a core module.

> Warning: spin component at path /Users/rylev/Code/fermyon/min-spin/target/wasm32-unknown-unknown/release/min.wasm is already a WebAssembly component. Directly using WebAssembly components is an experimental feature.

This warning is a bit hard to see. We may want to highlight the warning in bold yellow much like we do in red for errors and other important things in green. 