### PR TITLE
also delete release when deleting tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: canary
+          delete_release: true
 
       - name: Recreate canary tag and release
         uses: ncipollo/release-action@v1.10.0


### PR DESCRIPTION
this attempts to fix issue where sometimes our canary release is marked as 'draft' and re-runs won't help as it will just update the existing release (which is already draft).

I still don't have a good answer as to why the release is getting marked as draft (except someone reporting same issue here https://github.com/ncipollo/release-action/issues/336#issue-1728946267). may be if we push to main while previous release is being tagged?