### PR TITLE
Clearer error message on installing older version of installed plugin

### DIFF
--- a/crates/plugins/src/manager.rs
+++ b/crates/plugins/src/manager.rs
@@ -122,7 +122,7 @@ impl PluginManager {
                 });
             } else if installed.version > plugin_manifest.version && !allow_downgrades {
                 bail!(
-                    "Newer version {} of plugin '{}' is already installed. To downgrade to version {} set the `--downgrade` flag.",
+                    "Newer version {} of plugin '{}' is already installed. To downgrade to version {}, run `spin plugins upgrade` with the `--downgrade` flag.",
                     installed.version,
                     plugin_manifest.name(),
                     plugin_manifest.version,


### PR DESCRIPTION
Fixes #1578 (sorry @kate-goldenring I know you had assigned it to yourself but there didn't seem to be a PR attached and I guessed it probably wasn't WIP, but if it is then please biff this PR)

Error now reads:

```
$ spin plugins install js2wasm -v 0.3.0
Error: Newer version 0.4.0 of plugin 'js2wasm' is already installed. To downgrade to version 0.3.0, run `spin plugins upgrade` with the `--downgrade` flag.
```