### PR TITLE
Record where plugins were installed from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5327,6 +5327,7 @@ dependencies = [
  "fd-lock",
  "flate2",
  "is-terminal",
+ "path-absolutize",
  "reqwest",
  "semver 1.0.16",
  "serde",

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -12,6 +12,7 @@ dirs = "4.0"
 fd-lock = "3.0.12"
 flate2 = "1.0"
 is-terminal = "0.4"
+path-absolutize = "3.0.11"
 reqwest = { version = "0.11", features = ["json"] }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/plugins/src/manager.rs
+++ b/crates/plugins/src/manager.rs
@@ -242,7 +242,7 @@ impl PluginManager {
     }
 
     fn write_install_record(&self, plugin_name: &str, source: &ManifestLocation) {
-        let install_record_path = self.store.install_record_file(plugin_name);
+        let install_record_path = self.store.installation_record_file(plugin_name);
 
         // A failure here shouldn't fail the install
         let install_record = source.to_install_record();

--- a/crates/plugins/src/store.rs
+++ b/crates/plugins/src/store.rs
@@ -13,6 +13,7 @@ use crate::{error::*, manifest::PluginManifest};
 
 /// Directory where the manifests of installed plugins are stored.
 pub const PLUGIN_MANIFESTS_DIRECTORY_NAME: &str = "manifests";
+const INSTALLATION_RECORD_FILE_NAME: &str = ".install.json";
 
 /// Houses utilities for getting the path to Spin plugin directories.
 pub struct PluginStore {
@@ -60,6 +61,12 @@ impl PluginStore {
             binary.set_extension("exe");
         }
         binary
+    }
+
+    pub fn install_record_file(&self, plugin_name: &str) -> PathBuf {
+        self.root
+            .join(plugin_name)
+            .join(INSTALLATION_RECORD_FILE_NAME)
     }
 
     pub fn installed_manifests(&self) -> Result<Vec<PluginManifest>> {

--- a/crates/plugins/src/store.rs
+++ b/crates/plugins/src/store.rs
@@ -63,7 +63,7 @@ impl PluginStore {
         binary
     }
 
-    pub fn install_record_file(&self, plugin_name: &str) -> PathBuf {
+    pub fn installation_record_file(&self, plugin_name: &str) -> PathBuf {
         self.root
             .join(plugin_name)
             .join(INSTALLATION_RECORD_FILE_NAME)

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -382,7 +382,7 @@ async fn copy_template_into(
 
 fn write_install_record(dest_dir: &Path, source: &TemplateSource) {
     let layout = TemplateLayout::new(dest_dir);
-    let install_record_path = layout.install_record_file();
+    let install_record_path = layout.installation_record_file();
 
     // A failure here shouldn't fail the install
     let install_record = source.to_install_record();

--- a/crates/templates/src/store.rs
+++ b/crates/templates/src/store.rs
@@ -105,7 +105,7 @@ impl TemplateLayout {
         self.metadata_dir().join(SNIPPETS_DIR_NAME)
     }
 
-    pub fn install_record_file(&self) -> PathBuf {
+    pub fn installation_record_file(&self) -> PathBuf {
         self.template_dir.join(INSTALLATION_RECORD_FILE_NAME)
     }
 }

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -456,7 +456,7 @@ fn parse_string_constraints(raw: &RawParameter) -> anyhow::Result<StringConstrai
 fn read_install_record(layout: &TemplateLayout) -> InstalledFrom {
     use crate::reader::{parse_installed_from, RawInstalledFrom};
 
-    let installed_from_text = std::fs::read_to_string(layout.install_record_file()).ok();
+    let installed_from_text = std::fs::read_to_string(layout.installation_record_file()).ok();
     match installed_from_text.and_then(parse_installed_from) {
         Some(RawInstalledFrom::Git { git }) => InstalledFrom::Git(git),
         Some(RawInstalledFrom::File { dir }) => InstalledFrom::Directory(dir),

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -121,6 +121,7 @@ impl Install {
             self.yes_to_all,
             self.override_compatibility_check,
             downgrade,
+            &manifest_location,
         )
         .await?;
         Ok(())
@@ -263,6 +264,7 @@ impl Upgrade {
                 self.yes_to_all,
                 self.override_compatibility_check,
                 self.downgrade,
+                &manifest_location,
             )
             .await?;
         }
@@ -288,6 +290,7 @@ impl Upgrade {
             self.yes_to_all,
             self.override_compatibility_check,
             self.downgrade,
+            &manifest_location,
         )
         .await?;
         Ok(())
@@ -458,6 +461,7 @@ async fn try_install(
     yes_to_all: bool,
     override_compatibility_check: bool,
     downgrade: bool,
+    source: &ManifestLocation,
 ) -> Result<bool> {
     let install_action = manager.check_manifest(
         manifest,
@@ -473,7 +477,7 @@ async fn try_install(
 
     let package = manager::get_package(manifest)?;
     if continue_to_install(manifest, package, yes_to_all)? {
-        let installed = manager.install(manifest, package).await?;
+        let installed = manager.install(manifest, package, source).await?;
         println!("Plugin '{installed}' was installed successfully!");
 
         if let Some(description) = manifest.description() {


### PR DESCRIPTION
As a secondary request, #1580 suggests that we display where plugins were installed from.  We can't do that at the moment because we don't record that information.  This PR records manifest locations in a `.install.json` file in the plugin directory (next to `<plugin>.license`).

The code is based on the template origin recording code, although there are some changes to reflect existing differences, such as registry origins, and recording info in JSON instead of TOML.

NOTE: This PR does _not_ include displaying the plugin source, which is what #1580 asks for, because at the moment there would be nothing to show - it is merely laying the ground for the future feature.
