### PR TITLE
use commit and debug build of release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,12 +226,13 @@ jobs:
           delete_release: true
 
       - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.10.0
+        uses: rajatjindal/release-action@v0.0.1
         with:
           tag: canary
           allowUpdates: true
           prerelease: true
           artifacts: "checksums-canary.txt,spin-canary*"
+          commit: ${{ github.sha }}
           body: |
             This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
             It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.


### PR DESCRIPTION
sometimes we find the canary release links to be broken for no apparent reason and this triggers failures in e2e tests and potentially user downloads as well.

while I am able to reproduce the issue, it is inconsistent. based on debugging so far, it may be a race condition to when we publish the release and a new commit is pushed to main branch. 

to facilitate debugging, this PR makes two changes:

- use a debug build from a fork of release-action. it just adds some console.log statements 
- add commit sha when creating the release (instead of pointing it to `main` branch by default, which can drift while new commits are pushed). 

next steps:

monitor the links with above changes and:

- if we don't run into this issue again, it would mean adding commit sha has fixed the issue. at this point stop using fork.
- if we run into issue again, check debug logs and check if GitHub api is returning draft: false/true in the response. While it may not point us to the root cause directly, it will potentially help us identify next step for debugging.

