### PR TITLE
Validate variable and config key names at app load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,6 +5260,7 @@ dependencies = [
  "serde_json",
  "shellexpand 3.1.0",
  "spin-common",
+ "spin-config",
  "spin-manifest",
  "tempfile",
  "terminal",

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shellexpand = "3.1"
 spin-common = { path = "../common" }
+spin-config = { path = "../config" }
 spin-manifest = { path = "../manifest" }
 tempfile = "3.3.0"
 terminal = { path = "../terminal" }

--- a/crates/loader/src/validation.rs
+++ b/crates/loader/src/validation.rs
@@ -1,4 +1,26 @@
+use std::collections::HashMap;
+
 use anyhow::{ensure, Context, Result};
+
+use crate::common::RawVariable;
+
+pub(crate) fn validate_variable_names(variables: &HashMap<String, RawVariable>) -> Result<()> {
+    for name in variables.keys() {
+        if let Err(spin_config::Error::InvalidKey(m)) = spin_config::Key::new(name) {
+            anyhow::bail!("Invalid variable name {name}: {m}. Variable names and config keys may contain only lower-case letters, numbers, and underscores.");
+        };
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_config_keys(config: &Option<HashMap<String, String>>) -> Result<()> {
+    for name in config.iter().flat_map(|c| c.keys()) {
+        if let Err(spin_config::Error::InvalidKey(m)) = spin_config::Key::new(name) {
+            anyhow::bail!("Invalid config key {name}: {m}. Variable names and config keys may contain only lower-case letters, numbers, and underscores.");
+        };
+    }
+    Ok(())
+}
 
 pub(crate) fn validate_key_value_stores(key_value_stores: &Option<Vec<String>>) -> Result<()> {
     for store in key_value_stores.iter().flatten() {


### PR DESCRIPTION
This fixes #1622 as far as we can go within Spin.  I think that the cloud plugin takes the manifest before validation (the local load pipeline doesn't come apart at the right place) so this would need to be ported to the cloud plugin separately.