### PR TITLE
Improve config key error name validation errors

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -135,23 +135,23 @@ impl<'a> Key<'a> {
     fn validate(key: &str) -> Result<()> {
         {
             if key.is_empty() {
-                Err("may not be empty".to_string())
-            } else if !key.bytes().next().unwrap().is_ascii_lowercase() {
-                Err("must start with an ASCII letter".to_string())
-            } else if !key.bytes().last().unwrap().is_ascii_alphanumeric() {
-                Err("must end with an ASCII alphanumeric char".to_string())
-            } else if key.contains("__") {
-                Err("may not contain multiple consecutive underscores".to_string())
+                Err("must not be empty".to_string())
             } else if let Some(invalid) = key
                 .chars()
                 .find(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == &'_'))
             {
-                Err(format!("invalid character {:?}", invalid))
+                Err(format!("invalid character {:?}. Variable names and config keys may contain only lower-case letters, numbers, and underscores.", invalid))
+            } else if !key.bytes().next().unwrap().is_ascii_lowercase() {
+                Err("must start with a lowercase ASCII letter".to_string())
+            } else if !key.bytes().last().unwrap().is_ascii_alphanumeric() {
+                Err("must end with a lowercase ASCII letter or digit".to_string())
+            } else if key.contains("__") {
+                Err("must not contain multiple consecutive underscores".to_string())
             } else {
                 Ok(())
             }
         }
-        .map_err(|reason| Error::InvalidKey(format!("{key:?} {reason}")))
+        .map_err(|reason| Error::InvalidKey(format!("{key:?}: {reason}")))
     }
 }
 

--- a/crates/loader/src/validation.rs
+++ b/crates/loader/src/validation.rs
@@ -16,7 +16,7 @@ pub(crate) fn validate_variable_names(variables: &HashMap<String, RawVariable>) 
 pub(crate) fn validate_config_keys(config: &Option<HashMap<String, String>>) -> Result<()> {
     for name in config.iter().flat_map(|c| c.keys()) {
         if let Err(spin_config::Error::InvalidKey(m)) = spin_config::Key::new(name) {
-            anyhow::bail!("Invalid config key {name}: {m}. Variable names and config keys may contain only lower-case letters, numbers, and underscores.");
+            anyhow::bail!("Invalid config key {m}"); // No need to give name as it's already in the message
         };
     }
     Ok(())


### PR DESCRIPTION
This is prompted by #1628 and follows on from #1623.  It:

1. Rephrases some messages to talk about _lowercase_ ASCII letters rather than just ASCII letters.

2. Reorders config key name validation so that "invalid character" checks come before special additional restrictions such as "first position must be a letter."  This means that a name such as `NAUGHTY_KEY` gets the "invalid character, here are the valid ones" message rather than one that talks specifically about "the first character".

3. Tweaks some wording e.g. from `"" may not be empty` to `"" must not be empty` to be clear that this is a requirement rather than an inscrutable observation that Spin is not sure if "" is empty or not.

Example new messages:

```
$ spin up -f ~/testing/badconfig/
Error: Invalid config key "NAUGHTY-KEY": invalid character 'N'. Variable names and config keys may contain only lower-case letters, numbers, and underscores.

$ spin up -f ~/testing/badconfig/
Error: Invalid config key "naughty-key": invalid character '-'. Variable names and config keys may contain only lower-case letters, numbers, and underscores.

$ spin up -f ~/testing/badconfig/
Error: Invalid config key "naughty__key": must not contain multiple consecutive underscores
```
