### PR TITLE
spin doctor component config diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,6 +5165,8 @@ dependencies = [
  "reqwest",
  "serde",
  "similar",
+ "spin-app",
+ "spin-config",
  "spin-loader",
  "tempfile",
  "terminal",

--- a/crates/config/src/host_component.rs
+++ b/crates/config/src/host_component.rs
@@ -92,7 +92,7 @@ impl config::Host for ComponentConfig {
 impl From<Error> for config::Error {
     fn from(err: Error) -> Self {
         match err {
-            Error::InvalidKey(msg) => Self::InvalidKey(msg),
+            Error::InvalidKey(key, reason) => Self::InvalidKey(format!("{key:?}: {reason}")),
             Error::InvalidSchema(msg) => Self::InvalidSchema(msg),
             Error::Provider(msg) => Self::Provider(msg.to_string()),
             other => Self::Other(format!("{}", other)),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -89,7 +89,7 @@ impl Resolver {
             .variables
             .get(key)
             // This should have been caught by validate_template
-            .ok_or_else(|| Error::InvalidKey(key.to_string()))?;
+            .ok_or_else(|| Error::InvalidKey(key.to_string(), "not found".to_string()))?;
 
         for provider in &self.providers {
             if let Some(value) = provider.get(&Key(key)).await.map_err(Error::Provider)? {
@@ -151,7 +151,7 @@ impl<'a> Key<'a> {
                 Ok(())
             }
         }
-        .map_err(|reason| Error::InvalidKey(format!("{key:?}: {reason}")))
+        .map_err(|reason| Error::InvalidKey(key.to_owned(), reason))
     }
 }
 
@@ -167,8 +167,8 @@ type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Invalid config key.
-    #[error("invalid config key: {0}")]
-    InvalidKey(String),
+    #[error("invalid config key: {0:?}: {1}")]
+    InvalidKey(String, String),
 
     /// Invalid config path.
     #[error("invalid config path: {0}")]

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -9,6 +9,8 @@ async-trait = "0.1"
 reqwest = { version = "0.11", features = ["stream"] }
 serde = { version = "1", features = ["derive"] }
 similar = "2"
+spin-app = { path = "../app" }
+spin-config = { path = "../config" }
 spin-loader = { path = "../loader" }
 tempfile = "3.3.0"
 terminal = { path = "../terminal" }

--- a/crates/doctor/src/lib.rs
+++ b/crates/doctor/src/lib.rs
@@ -32,6 +32,7 @@ impl Checkup {
         };
         checkup.add_diagnostic::<manifest::version::VersionDiagnostic>();
         checkup.add_diagnostic::<manifest::trigger::TriggerDiagnostic>();
+        checkup.add_diagnostic::<manifest::component_config::ComponentConfigDiagnostic>();
         checkup.add_diagnostic::<rustlang::target::TargetDiagnostic>(); // Do toolchain checks _before_ build checks
         checkup.add_diagnostic::<wasm::missing::WasmMissingDiagnostic>();
         checkup

--- a/crates/doctor/src/manifest.rs
+++ b/crates/doctor/src/manifest.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 use std::fs;
 
 use anyhow::{Context, Result};
@@ -6,6 +7,8 @@ use toml_edit::Document;
 
 use crate::Treatment;
 
+/// Diagnose component dynamic config problems.
+pub mod component_config;
 /// Diagnose app manifest trigger config problems.
 pub mod trigger;
 /// Diagnose app manifest version problems.

--- a/crates/doctor/src/manifest/component_config.rs
+++ b/crates/doctor/src/manifest/component_config.rs
@@ -1,0 +1,213 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::{Diagnosis, Diagnostic, PatientApp};
+
+/// ComponentConfigDiagnostic detects problems with component `config` entries.
+#[derive(Default)]
+pub struct ComponentConfigDiagnostic;
+
+#[async_trait]
+impl Diagnostic for ComponentConfigDiagnostic {
+    type Diagnosis = ComponentConfigDiagnosis;
+
+    async fn diagnose(&self, patient: &PatientApp) -> Result<Vec<Self::Diagnosis>> {
+        let variables = match patient
+            .manifest_doc
+            .get("variables")
+            .and_then(|item| item.as_table())
+        {
+            None => vec![],
+            Some(table) => app_variables(table),
+        };
+
+        let component_configs = match patient
+            .manifest_doc
+            .get("component")
+            .and_then(|item| item.as_array_of_tables())
+        {
+            None => vec![],
+            Some(arr) => arr.iter().filter_map(component_config).collect(),
+        };
+
+        if spin_config::Resolver::new(variables.clone()).is_err() {
+            // TODO: It eould be nice to be able to continue even if a variable failed
+            // to validate, but that requires more of the internals of spin_config than
+            // it currently exposes.
+            return Ok(vec![]);
+        }
+
+        let diagnoses = component_configs
+            .into_iter()
+            .flat_map(|(id, cfg)| diagnose_component(variables.clone(), id, cfg))
+            .collect();
+
+        Ok(diagnoses)
+    }
+}
+
+fn app_variables(table: &toml_edit::Table) -> Vec<(String, spin_app::Variable)> {
+    table
+        .iter()
+        .map(|(k, _)| {
+            (
+                k.to_owned(),
+                spin_app::Variable {
+                    default: None,
+                    secret: false,
+                },
+            )
+        })
+        .collect()
+}
+
+fn component_config(table: &toml_edit::Table) -> Option<(String, HashMap<String, String>)> {
+    let Some(id) = table.get("id").and_then(|item| item.as_str()) else {
+        return None;
+    };
+
+    let Some(cfg_table) = table.get("config").and_then(|item| item.as_table()) else {
+        return None;
+    };
+
+    let configs = cfg_table
+        .iter()
+        .flat_map(|(k, v)| {
+            v.as_str()
+                .map(|template| (k.to_owned(), template.to_owned()))
+        })
+        .collect();
+
+    Some((id.to_owned(), configs))
+}
+
+fn diagnose_component(
+    variables: Vec<(String, spin_app::Variable)>,
+    component_id: String,
+    cfg: HashMap<String, String>,
+) -> impl Iterator<Item = ComponentConfigDiagnosis> {
+    cfg.into_iter().filter_map(move |(key, t)| {
+        let mut resolver = spin_config::Resolver::new(variables.clone()).unwrap(); // Safe to unwrap because the caller checks the variables will go into a Resolver
+        resolver
+            .add_component_config(&component_id, vec![(key.clone(), t)])
+            .err()
+            .and_then(|e| ComponentConfigDiagnosis::try_create(&component_id, &key, e))
+    })
+}
+
+/// A problem with a component configuration entry.
+#[derive(Debug)]
+pub struct ComponentConfigDiagnosis {
+    inner: ComponentConfigDiagnosisInner,
+}
+
+impl ComponentConfigDiagnosis {
+    fn try_create(component_id: &str, key: &str, e: spin_config::Error) -> Option<Self> {
+        ComponentConfigDiagnosisInner::try_create(component_id, key, e).map(|inner| Self { inner })
+    }
+}
+
+// TODO: It would be nice to pick out invalid variable references, so we could
+// report all of them, but that would require exposing the expression parser.
+// The resolver turns both syntax errors and bad references into "InvalidTemplate".
+// But the message distinguishes the cause clearly.
+#[derive(Debug)]
+enum ComponentConfigDiagnosisInner {
+    InvalidKey {
+        component_id: String,
+        key: String,
+        reason: String,
+    },
+    InvalidTemplate {
+        component_id: String,
+        key: String,
+        reason: String,
+    },
+}
+
+impl ComponentConfigDiagnosisInner {
+    fn try_create(component_id: &str, key: &str, e: spin_config::Error) -> Option<Self> {
+        let component_id = component_id.to_owned();
+        let key = key.to_owned();
+        match e {
+            spin_config::Error::InvalidKey(_, reason) => Some(Self::InvalidKey {
+                component_id,
+                key,
+                reason,
+            }),
+            spin_config::Error::InvalidTemplate(reason) => Some(Self::InvalidTemplate {
+                component_id,
+                key,
+                reason,
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl Diagnosis for ComponentConfigDiagnosis {
+    // TODO: These are not readily treatable. We could suggest 'nearby' variables for bad
+    // references, but again that requires a lot of access to template internals, and would
+    // be a bit ad hoc anyway!
+    fn description(&self) -> String {
+        match &self.inner {
+            ComponentConfigDiagnosisInner::InvalidKey {
+                component_id,
+                key,
+                reason,
+            } => format!("config key '{key}' in component '{component_id}' is invalid: {reason}"),
+            ComponentConfigDiagnosisInner::InvalidTemplate {
+                component_id,
+                key,
+                reason,
+            } => format!(
+                "config entry '{key}' in component '{component_id}' has invalid template: {reason}"
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{run_correct_test, run_untreatable_test};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_correct() {
+        run_correct_test::<ComponentConfigDiagnostic>("component_config").await;
+    }
+
+    #[tokio::test]
+    async fn test_bad_key() {
+        let diag =
+            run_untreatable_test::<ComponentConfigDiagnostic>("component_config", "bad_key").await;
+        assert!(matches!(
+            diag.inner,
+            ComponentConfigDiagnosisInner::InvalidKey { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_bad_variable_ref() {
+        let diag =
+            run_untreatable_test::<ComponentConfigDiagnostic>("component_config", "bad_ref").await;
+        assert!(matches!(
+            diag.inner,
+            ComponentConfigDiagnosisInner::InvalidTemplate { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_bad_template_syntax() {
+        let diag =
+            run_untreatable_test::<ComponentConfigDiagnostic>("component_config", "bad_syntax")
+                .await;
+        assert!(matches!(
+            diag.inner,
+            ComponentConfigDiagnosisInner::InvalidTemplate { .. }
+        ));
+    }
+}

--- a/crates/doctor/src/test.rs
+++ b/crates/doctor/src/test.rs
@@ -46,6 +46,21 @@ pub async fn run_broken_test<D: Diagnostic + Default>(prefix: &str, suffix: &str
     diag
 }
 
+pub async fn run_untreatable_test<D: Diagnostic + Default>(
+    prefix: &str,
+    suffix: &str,
+) -> D::Diagnosis {
+    let patient = TestPatient::from_file(test_file_path(prefix, suffix));
+
+    let diag = assert_single_diagnosis::<D>(&patient).await;
+    assert!(
+        diag.treatment().is_none(),
+        "expected untreatable but was treatable"
+    );
+
+    diag
+}
+
 pub async fn assert_single_diagnosis<D: Diagnostic + Default>(
     patient: &PatientApp,
 ) -> D::Diagnosis {

--- a/crates/doctor/tests/data/component_config_bad_key.toml
+++ b/crates/doctor/tests/data/component_config_bad_key.toml
@@ -1,0 +1,8 @@
+[variables]
+var = { required = true }
+
+[[component]]
+id = "test"
+
+[component.config]
+my__key = "hello {{ var }}"

--- a/crates/doctor/tests/data/component_config_bad_ref.toml
+++ b/crates/doctor/tests/data/component_config_bad_ref.toml
@@ -1,0 +1,8 @@
+[variables]
+var = { required = true }
+
+[[component]]
+id = "test"
+
+[component.config]
+my_key = "hello {{ vaar }}"

--- a/crates/doctor/tests/data/component_config_bad_syntax.toml
+++ b/crates/doctor/tests/data/component_config_bad_syntax.toml
@@ -1,0 +1,8 @@
+[variables]
+var = { required = true }
+
+[[component]]
+id = "test"
+
+[component.config]
+my_key = "hello {{ var"

--- a/crates/doctor/tests/data/component_config_correct.toml
+++ b/crates/doctor/tests/data/component_config_correct.toml
@@ -1,0 +1,8 @@
+[variables]
+var = { required = true }
+
+[[component]]
+id = "test"
+
+[component.config]
+my_key = "hello {{ var }}"

--- a/crates/loader/src/validation.rs
+++ b/crates/loader/src/validation.rs
@@ -6,7 +6,7 @@ use crate::common::RawVariable;
 
 pub(crate) fn validate_variable_names(variables: &HashMap<String, RawVariable>) -> Result<()> {
     for name in variables.keys() {
-        if let Err(spin_config::Error::InvalidKey(m)) = spin_config::Key::new(name) {
+        if let Err(spin_config::Error::InvalidKey(_, m)) = spin_config::Key::new(name) {
             anyhow::bail!("Invalid variable name {name}: {m}. Variable names and config keys may contain only lower-case letters, numbers, and underscores.");
         };
     }
@@ -15,8 +15,8 @@ pub(crate) fn validate_variable_names(variables: &HashMap<String, RawVariable>) 
 
 pub(crate) fn validate_config_keys(config: &Option<HashMap<String, String>>) -> Result<()> {
     for name in config.iter().flat_map(|c| c.keys()) {
-        if let Err(spin_config::Error::InvalidKey(m)) = spin_config::Key::new(name) {
-            anyhow::bail!("Invalid config key {m}"); // No need to give name as it's already in the message
+        if let Err(spin_config::Error::InvalidKey(_, m)) = spin_config::Key::new(name) {
+            anyhow::bail!("Invalid config key {name}: {m}");
         };
     }
     Ok(())


### PR DESCRIPTION
```
$ spin doctor
📟 The Spin Doctor is in.
🩺 Checking spin.toml...

❗ Diagnosis: config entry 'ouch' in component 'vartest2' has invalid template: unmatched '{{' in template

❗ Diagnosis: config entry 'spork' in component 'vartest2' has invalid template: unknown variable "honk2"

❗ Diagnosis: config key 'plo____nk' in component 'vartest2' is invalid: must not contain multiple consecutive underscores
```

(This does not currently diagnose application variable validity, and it probably should.)

(Also not sure whether this is useful enough to be worth including, given that you get reasonable errors for these at `spin up` time... thoughts?)