### PR TITLE
More info in message when Redis e2e fails

### DIFF
--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -899,7 +899,8 @@ pub async fn redis_go_works(controller: &dyn Controller) {
 
         assert!(expected_logs
             .iter()
-            .all(|item| stderr.contains(&item.to_string())));
+            .all(|item| stderr.contains(&item.to_string())),
+        "Expected log lines to contain all of {expected_logs:?} but actual lines were '{stderr:?}'");
 
         Ok(())
     }
@@ -955,7 +956,8 @@ pub async fn redis_rust_works(controller: &dyn Controller) {
 
         assert!(expected_logs
             .iter()
-            .all(|item| stderr.contains(&item.to_string())));
+            .all(|item| stderr.contains(&item.to_string())),
+        "Expected log lines to contain all of {expected_logs:?} but actual lines were '{stderr:?}'");
 
         Ok(())
     }


### PR DESCRIPTION
Currently, if a Redis trigger e2e fails, the message is `assertion failed: expected_logs.iter().all(|item| stderr.contains(&item.to_string()))`.

This amends the message to include the actual contents of stderr.
