### PR TITLE
Fix Redis Rust component instantiation

### DIFF
--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -58,6 +58,7 @@ pub fn redis_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         mod __spin_redis {
             struct Spin;
+            ::spin_sdk::export_reactor!(Spin);
 
             impl ::spin_sdk::inbound_redis::InboundRedis for Spin {
                 fn handle_message(msg: ::spin_sdk::inbound_redis::Payload) -> Result<(), ::spin_sdk::redis::Error> {


### PR DESCRIPTION
Fixes #1650.

I am not sure if this is the right solution - I have a rough sense for what it's doing, but it is cargo-culted in from the HTTP component macro rather!  It did seem to fix it in my limited testing but you folks are the experts...