### PR TITLE
ci: Build aarch64 releases on ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
               targetDir: "target/release",
             }
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               arch: "aarch64",
               extension: "",
               extraArgs: "--features openssl/vendored --target aarch64-unknown-linux-gnu",


### PR DESCRIPTION
This matches our amd64 build and improves binary compatibility with systems using older glibc.