### PR TITLE
fix `spin-timer` example regression

### DIFF
--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -88,12 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
 name = "async-channel"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,17 +207,6 @@ dependencies = [
  "base64 0.13.1",
  "blowfish",
  "getrandom 0.2.8",
-]
-
-[[package]]
-name = "bigdecimal"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -350,76 +333,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
-dependencies = [
- "borsh-derive",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
-dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate",
- "proc-macro2",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
 
 [[package]]
 name = "byteorder"
@@ -1233,7 +1150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "libz-sys",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1265,70 +1182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "frunk"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89c703bf50009f383a0873845357cc400a95fc535f836feddfe015d7df6e1e0"
-dependencies = [
- "frunk_core",
- "frunk_derives",
- "frunk_proc_macros",
-]
-
-[[package]]
-name = "frunk_core"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a446d01a558301dca28ef43222864a9fa2bd9a2e71370f769d5d5d5ec9f3537"
-
-[[package]]
-name = "frunk_derives"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83164912bb4c97cfe0772913c7af7387ee2e00cb6d4636fb65a35b3d0c8f173"
-dependencies = [
- "frunk_proc_macro_helpers",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "frunk_proc_macro_helpers"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015425591bbeb0f5b8a75593340f1789af428e9f887a4f1e36c0c471f067ef50"
-dependencies = [
- "frunk_core",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "frunk_proc_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea01524f285deab48affffb342b97f186e657b119c3f1821ac531780e0fbfae0"
-dependencies = [
- "frunk_core",
- "frunk_proc_macros_impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "frunk_proc_macros_impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a802d974cc18ee7fe1a7868fc9ce31086294fd96ba62f8da64ecb44e92a2653"
-dependencies = [
- "frunk_core",
- "frunk_proc_macro_helpers",
- "proc-macro-hack",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -1562,15 +1415,6 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1637,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "hrana-client-proto"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f15d50a607f7f2cb8cb97cad7ae746f861139e8ebc425a8545195a556d6102"
+checksum = "f16b4e41e289da3fd60e64f245246a97e78fab7b3788c6d8147b3ae7d9f5e533"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -2044,18 +1888,20 @@ dependencies = [
 
 [[package]]
 name = "libsql-client"
-version = "0.24.5"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8861153820a4228a1261ee92138345f7e08c71e64a75c95217247427172f2ce8"
+checksum = "e119ff2e259fe776a1340d2cb40baf4d44c32e5a9fd2755e756fc46802c79c70"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.21.0",
+ "fallible-iterator",
+ "futures",
  "hrana-client-proto",
  "num-traits",
  "reqwest",
  "serde",
  "serde_json",
+ "sqlite3-parser",
  "tracing",
  "url",
 ]
@@ -2072,14 +1918,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.8"
+name = "libz-ng-sys"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "2468756f34903b582fe7154dc1ffdebd89d0562c4a43b53c621bb0f1b1043ccb"
 dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
+ "cmake",
+ "libc",
 ]
 
 [[package]]
@@ -2279,7 +2124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9006c95034ccf7b903d955f210469119f6c3477fc9c9e7a7845ce38a3e665c2a"
 dependencies = [
  "base64 0.13.1",
- "bigdecimal",
  "bindgen",
  "bitflags 1.3.2",
  "bitvec",
@@ -2289,14 +2133,12 @@ dependencies = [
  "cmake",
  "crc32fast",
  "flate2",
- "frunk",
  "lazy_static",
  "lexical",
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
  "regex",
- "rust_decimal",
  "saturating",
  "serde",
  "serde_json",
@@ -2305,8 +2147,6 @@ dependencies = [
  "smallvec",
  "subprocess",
  "thiserror",
- "time",
- "uuid",
 ]
 
 [[package]]
@@ -2518,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -2532,9 +2372,10 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
+ "flate2",
  "mysql_async",
  "mysql_common",
  "spin-core",
@@ -2546,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -2560,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
@@ -2679,12 +2520,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
+ "uncased",
 ]
 
 [[package]]
@@ -2774,15 +2636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,12 +2660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,26 +2675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -3051,15 +2878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rend"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,31 +2938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
-dependencies = [
- "bytecheck",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,24 +2949,6 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe32e8c89834541077a5c5bbe5691aa69324361e27e6aeb3552a737db4a70c8"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytecheck",
- "byteorder",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3343,12 +3118,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -3617,7 +3386,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-app"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3630,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3652,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3669,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3686,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -3739,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3761,6 +3530,7 @@ dependencies = [
  "serde_json",
  "shellexpand 3.1.0",
  "spin-common",
+ "spin-config",
  "spin-manifest",
  "tempfile",
  "terminal",
@@ -3773,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "indexmap",
  "serde",
@@ -3783,9 +3553,10 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "spin-app",
  "spin-core",
  "spin-key-value",
@@ -3795,9 +3566,10 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "once_cell",
  "rand 0.8.5",
  "rusqlite",
@@ -3808,9 +3580,10 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "libsql-client",
  "spin-sqlite",
  "spin-world",
@@ -3820,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3861,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "wasmtime",
 ]
@@ -3871,6 +3644,25 @@ name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
+name = "sqlite3-parser"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3995a6daa13c113217b6ad22154865fb06f9cb939bef398fd04f4a7aaaf5bd7"
+dependencies = [
+ "bitflags 2.2.1",
+ "cc",
+ "fallible-iterator",
+ "indexmap",
+ "log",
+ "memchr",
+ "phf",
+ "phf_codegen",
+ "phf_shared",
+ "smallvec",
+ "uncased",
+]
 
 [[package]]
 name = "sqlparser"
@@ -4325,6 +4117,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uncased"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicase"

--- a/examples/spin-timer/app-example/src/lib.rs
+++ b/examples/spin-timer/app-example/src/lib.rs
@@ -1,9 +1,9 @@
 wit_bindgen::generate!({
     world: "spin-timer",
-    path: "../spin-timer.wit"
+    path: ".."
 });
 
-use fermyon::example::config;
+use fermyon::spin::config;
 
 struct MySpinTimer;
 

--- a/examples/spin-timer/deps/spin/config.wit
+++ b/examples/spin-timer/deps/spin/config.wit
@@ -1,0 +1,14 @@
+package fermyon:spin
+
+interface config {
+  // Get a configuration value for the current component.
+  // The config key must match one defined in in the component manifest.
+  get-config: func(key: string) -> result<string, error>
+
+  variant error {
+      provider(string),
+      invalid-key(string),
+      invalid-schema(string),
+      other(string),
+  }
+}

--- a/examples/spin-timer/spin-timer.wit
+++ b/examples/spin-timer/spin-timer.wit
@@ -1,19 +1,6 @@
 package fermyon:example
 
-interface config {
-  // Get a configuration value for the current component.
-  // The config key must match one defined in in the component manifest.
-  get-config: func(key: string) -> result<string, error>
-
-  variant error {
-      provider(string),
-      invalid-key(string),
-      invalid-schema(string),
-      other(string),
-  }
-}
-
 world spin-timer {
-  import config
+  import fermyon:spin/config
   export handle-timer-request: func()
 }

--- a/examples/spin-timer/src/main.rs
+++ b/examples/spin-timer/src/main.rs
@@ -10,7 +10,7 @@ use spin_trigger::{
 };
 
 wasmtime::component::bindgen!({
-    path: "spin-timer.wit",
+    path: ".",
     world: "spin-timer",
     async: true
 });


### PR DESCRIPTION
The recent `wit-bindgen` update broke this example due to changes in how WIT represents interface and world namespaces.  Specifically, the host defines the `config` interface under `fermyon:spin`, whereas the `spin-timer` world is defined under `fermyon:examples`, so we need to tell WIT they're in different packages.

Fixes #1662