### PR TITLE
fix: added error handling `spin trigger [USAGE]`

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -28,7 +28,10 @@ pub const SPIN_WORKING_DIR: &str = "SPIN_WORKING_DIR";
 
 /// A command that runs a TriggerExecutor.
 #[derive(Parser, Debug)]
-#[clap(next_help_heading = "TRIGGER OPTIONS")]
+#[clap(
+    usage = "spin [COMMAND] [OPTIONS]",
+    next_help_heading = "TRIGGER OPTIONS"
+)]
 pub struct TriggerExecutorCommand<Executor: TriggerExecutor>
 where
     Executor::RunConfig: Args,


### PR DESCRIPTION
## Problem
all the subcommand for up and watch don't have validation for the `Upcommand.trigger_args` and so at the final step it gets invoked by  invalid args thus causing error

## Solution

Workaround
add usage macro to the `struct TriggerExecutorCommand`

### Issue linked

- [x] Closes: #1559 