### PR TITLE
Print available routes as links

### DIFF
--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -170,6 +170,14 @@ impl RoutePattern {
         format!("{}{}", Self::sanitize(base.into()), Self::sanitize(path))
     }
 
+    /// Build a URL from a base prefix and the pattern
+    pub fn urlify(&self, base_url: &str) -> (String, impl fmt::Display) {
+        match self {
+            Self::Exact(path) => (format!("{base_url}{path}"), Wildness::Exact),
+            Self::Wildcard(pattern) => (format!("{base_url}{pattern}"), Wildness::Wild),
+        }
+    }
+
     fn absolutize<S: Into<String>>(s: S) -> String {
         let s = s.into();
         if s.starts_with('/') {
@@ -197,6 +205,20 @@ impl fmt::Display for RoutePattern {
         match &self {
             RoutePattern::Exact(path) => write!(f, "{}", path),
             RoutePattern::Wildcard(pattern) => write!(f, "{} (wildcard)", pattern),
+        }
+    }
+}
+
+enum Wildness {
+    Exact,
+    Wild,
+}
+
+impl fmt::Display for Wildness {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::Exact => write!(f, ""),
+            Self::Wild => write!(f, " (wildcard)"),
         }
     }
 }

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -129,6 +129,24 @@ macro_rules! ceprint {
     };
 }
 
+pub fn print_link(url: &str) {
+    if atty::is(atty::Stream::Stdout) {
+        print!("{}", link(url));
+    } else {
+        print!("{url}");
+    }
+}
+
+#[cfg(unix)]
+fn link(url: &str) -> String {
+    format!("\x1B]8;;{url}\x1B\\{url}\x1B]8;;\x1B\\")
+}
+
+#[cfg(not(unix))]
+fn link(url: &str) -> String {
+    url.to_owned()
+}
+
 pub mod colors {
     use termcolor::{Color, ColorSpec};
 

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -150,7 +150,10 @@ impl TriggerExecutor for HttpTrigger {
 
         println!("Available Routes:");
         for (route, component_id) in self.router.routes() {
-            println!("  {}: {}{}", component_id, base_url, route);
+            let (url, wild) = route.urlify(&base_url);
+            print!("  {component_id}: ");
+            terminal::print_link(&url);
+            println!("{wild}");
             if let Some(component) = self.engine.app().get_component(component_id) {
                 if let Some(description) = component.get_metadata(DESCRIPTION_KEY)? {
                     println!("    {}", description);


### PR DESCRIPTION
Fixes #1672.

(Though actually this only addresses `spin up` - a `cloud-plugin` port would be needed to address @ingride's original issue.)

The implementation I ended up with is not very tidy at the call site, because it needs multiple print statements for each output line.  I looked at using alternate formatting to linkify routes (allowing e.g. `println!("  {id}: {url:#}{wild}");`) but I couldn't see a way to skip the formatting if the output stream wasn't a terminal.  I also wondered about a `terminal::print_link!` macro that would accept the whole line but only linkify the URL bit, but I couldn't see how to handle that level of generality.  So, Rust whizzes, if you have any ideas, I am eager to learn!

Anyway here is what the result looks like - this is WSL in Windows Terminal, other terminals may vary!

![image](https://github.com/fermyon/spin/assets/865538/827a1047-c88c-4dfd-a409-fd8e93ec6fcd)

(I didn't linkify the base URL, because I was too lazy to scan the components to see if the base URL was actually mapped - I always click on a component rather than the base.  But if other folks use the base then I can do it too.)