### PR TITLE
Exit early when trigger process fails

### DIFF
--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -75,7 +75,6 @@ fn color_choice(stream: atty::Stream) -> termcolor::ColorChoice {
 #[macro_export]
 macro_rules! step {
     ($step:expr, $($arg:tt)*) => {{
-
         $crate::cprint!($crate::colors::bold_green(), $step);
         print!(" ");
         println!($($arg)*);

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -2,7 +2,6 @@ use anyhow::Error;
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
-use spin_cli::build_info::*;
 use spin_cli::commands::external::predefined_externals;
 use spin_cli::commands::{
     build::BuildCommand,
@@ -16,6 +15,7 @@ use spin_cli::commands::{
     up::UpCommand,
     watch::WatchCommand,
 };
+use spin_cli::{build_info::*, subprocess::ExitStatusError};
 use spin_redis_engine::RedisTrigger;
 use spin_trigger::cli::help::HelpArgsOnlyTrigger;
 use spin_trigger::cli::TriggerExecutorCommand;
@@ -24,6 +24,10 @@ use spin_trigger_http::HttpTrigger;
 #[tokio::main]
 async fn main() {
     if let Err(err) = _main().await {
+        if let Some(e) = err.downcast_ref::<ExitStatusError>() {
+            std::process::exit(e.code())
+        }
+
         terminal::error!("{err}");
         print_error_chain(err);
         std::process::exit(1)

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -206,7 +206,7 @@ impl UpCommand {
         if status.success() {
             Ok(())
         } else {
-            std::process::exit(status.code().unwrap_or(1))
+            Err(crate::subprocess::ExitStatusError::new(status).into())
         }
     }
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -206,7 +206,7 @@ impl UpCommand {
         if status.success() {
             Ok(())
         } else {
-            bail!(status);
+            std::process::exit(status.code().unwrap_or(1))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod build_info;
 pub mod commands;
 pub(crate) mod opts;
+pub mod subprocess;
 mod watch_filter;
 mod watch_state;
 
-pub use crate::opts::HELP_ARGS_ONLY_TRIGGER_TYPE;
+pub use opts::HELP_ARGS_ONLY_TRIGGER_TYPE;

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -1,0 +1,34 @@
+/// An error representing a subprocess that errored
+///
+/// This can be used to propogate a subprocesses exit status.
+/// When this error is encountered the cli will exit with the status code
+/// instead of printing an error,
+#[derive(Debug)]
+pub struct ExitStatusError {
+    status: Option<i32>,
+}
+
+impl ExitStatusError {
+    pub(crate) fn new(status: std::process::ExitStatus) -> Self {
+        Self {
+            status: status.code(),
+        }
+    }
+
+    pub fn code(&self) -> i32 {
+        self.status.unwrap_or(1)
+    }
+}
+
+impl std::error::Error for ExitStatusError {}
+
+impl std::fmt::Display for ExitStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let _ = write!(f, "subprocess exited with status: ");
+        if let Some(status) = self.status {
+            writeln!(f, "{}", status)
+        } else {
+            writeln!(f, "unknown")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #966 

This exits the main process if the trigger subprocess fails early. 