### PR TITLE
minor ux improvement when validation on config fails

### DIFF
--- a/crates/loader/src/common.rs
+++ b/crates/loader/src/common.rs
@@ -23,7 +23,7 @@ impl TryFrom<RawVariable> for Variable {
     fn try_from(var: RawVariable) -> Result<Self, Self::Error> {
         ensure!(
             var.required ^ var.default.is_some(),
-            "variable has both `required` and `default` set"
+            "variable should either have `required` set to true OR have a non-empty default value"
         );
         Ok(Variable {
             default: var.default,

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -167,7 +167,13 @@ async fn prepare(
     let variables = raw
         .variables
         .into_iter()
-        .map(|(key, var)| Ok((key, var.try_into()?)))
+        .map(|(key, var)| {
+            Ok((
+                key.clone(),
+                var.try_into()
+                    .map_err(|err| anyhow!("variable '{}': {}", key, err))?,
+            ))
+        })
         .collect::<Result<_>>()?;
 
     Ok(Application {


### PR DESCRIPTION
while playing around with config variables, I ran into some problems and it was not easy to identify which config was having problem.

e.g.

when i had config like below in `spin.toml`
```
allowed_channel = { required = true, secret = true, default = "x" }

OR

allowed_channel = { secret = true }
```

I get error 

```
$) spin up

Error: variable has both `required` and `default` set

```

with the fix, we get following error msg in both the scenarios:

```
$) spin up

Error: variable 'allowed_channel': variable should either have `required` set to true OR a non-empty default value
```
