### PR TITLE
Allow getting http trigger metadata from (locked)app from spin-http

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -174,7 +174,7 @@ impl<'a, L: MaybeLoader> App<'a, L> {
         &'this self,
         key: MetadataKey<T>,
     ) -> Result<Option<T>> {
-        self.locked.metadata.get_typed(key)
+        self.locked.get_metadata(key)
     }
 
     /// Deserializes typed metadata for this app.
@@ -185,7 +185,7 @@ impl<'a, L: MaybeLoader> App<'a, L> {
         &'this self,
         key: MetadataKey<T>,
     ) -> Result<T> {
-        self.locked.metadata.require_typed(key)
+        self.locked.require_metadata(key)
     }
 
     /// Returns an iterator of custom config [`Variable`]s defined for this app.

--- a/crates/app/src/locked.rs
+++ b/crates/app/src/locked.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::values::ValuesMap;
+use crate::{metadata::MetadataExt, values::ValuesMap};
 
 /// A String-keyed map with deterministic serialization order.
 pub type LockedMap<T> = std::collections::BTreeMap<String, T>;
@@ -36,6 +36,29 @@ impl LockedApp {
     /// Serializes the [`LockedApp`] into JSON data.
     pub fn to_json(&self) -> serde_json::Result<Vec<u8>> {
         serde_json::to_vec_pretty(&self)
+    }
+
+    /// Deserializes typed metadata for this app.
+    ///
+    /// Returns `Ok(None)` if there is no metadata for the given `key` and an
+    /// `Err` only if there _is_ a value for the `key` but the typed
+    /// deserialization failed.
+    pub fn get_metadata<'this, T: Deserialize<'this>>(
+        &'this self,
+        key: crate::MetadataKey<T>,
+    ) -> crate::Result<Option<T>> {
+        self.metadata.get_typed(key)
+    }
+
+    /// Deserializes typed metadata for this app.
+    ///
+    /// Like [`LockedApp::get_metadata`], but returns an error if there is
+    /// no metadata for the given `key`.
+    pub fn require_metadata<'this, T: Deserialize<'this>>(
+        &'this self,
+        key: crate::MetadataKey<T>,
+    ) -> crate::Result<T> {
+        self.metadata.require_typed(key)
     }
 }
 

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app_info;
 pub mod config;
 pub mod routes;
+pub mod trigger;
 pub mod wagi;
 
 pub const WELL_KNOWN_PREFIX: &str = "/.well-known/spin/";

--- a/crates/http/src/trigger.rs
+++ b/crates/http/src/trigger.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+use spin_app::MetadataKey;
+
+/// Http trigger metadata key
+pub const METADATA_KEY: MetadataKey<Metadata> = MetadataKey::new("trigger");
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Metadata {
+    // The type of trigger which should always been "http" in this case
+    pub r#type: String,
+    // The based url
+    pub base: String,
+}

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -23,8 +23,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server,
 };
-use serde::{Deserialize, Serialize};
-use spin_app::{AppComponent, MetadataKey};
+use spin_app::AppComponent;
 use spin_core::Engine;
 use spin_http::{
     app_info::AppInfo,
@@ -43,8 +42,6 @@ pub use tls::TlsConfig;
 
 pub(crate) type RuntimeData = ();
 pub(crate) type Store = spin_core::Store<RuntimeData>;
-
-const TRIGGER_METADATA_KEY: MetadataKey<TriggerMetadata> = MetadataKey::new("trigger");
 
 /// The Spin HTTP trigger.
 pub struct HttpTrigger {
@@ -84,13 +81,6 @@ impl CliArgs {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-struct TriggerMetadata {
-    r#type: String,
-    base: String,
-}
-
 #[async_trait]
 impl TriggerExecutor for HttpTrigger {
     const TRIGGER_TYPE: &'static str = "http";
@@ -99,7 +89,10 @@ impl TriggerExecutor for HttpTrigger {
     type RunConfig = CliArgs;
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
-        let base = engine.app().require_metadata(TRIGGER_METADATA_KEY)?.base;
+        let base = engine
+            .app()
+            .require_metadata(spin_http::trigger::METADATA_KEY)?
+            .base;
 
         let component_routes = engine
             .trigger_configs()
@@ -459,6 +452,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use anyhow::Result;
+    use serde::Deserialize;
     use spin_testing::test_socket_addr;
 
     use super::*;


### PR DESCRIPTION
Allows getting http trigger metadata from an app and locked app without needing to pull in the entire `http-trigger` crate (by instead using the more lightweight `spin_http` crate). 

This also extends `LockedApp` to be able to easily deserialize metadata based on a given metadata key. 