### PR TITLE
fix(registry/push): skip pushing empty blobs

### DIFF
--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -106,7 +106,10 @@ impl Client {
                 // locked application file with the file digest.
                 for entry in WalkDir::new(&source) {
                     let entry = entry?;
-                    if entry.file_type().is_file() && !entry.file_type().is_dir() {
+                    if entry.file_type().is_file()
+                        && !entry.file_type().is_dir()
+                        && entry.metadata()?.len() > 0
+                    {
                         tracing::trace!(
                             "Adding new layer for asset {:?}",
                             spin_loader::to_relative(entry.path(), &source)?


### PR DESCRIPTION
This commit checks the length of a blob before adding it as a layer to be uploaded to a container registry.