### PR TITLE
ci(.github): discontinue use of unmaintained actions

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -93,12 +93,11 @@ runs:
   using: "composite"
   steps:
     - name: Install latest Rust stable toolchain
-      uses: actions-rs/toolchain@v1
+      shell: bash
       if: ${{ inputs.rust == 'true' }}
-      with:
-        toolchain: ${{ inputs.rust-version }}
-        default: true
-        components: clippy, rustfmt
+      run: |
+        rustup toolchain install ${{ inputs.rust-version }} --component clippy --component rustfmt
+        rustup default ${{ inputs.rust-version }}
 
     - name: "Install Wasm Rust target"
       run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,8 @@ jobs:
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
 
       - name: build release
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: "--all-features --release ${{ matrix.config.extraArgs }}"
+        shell: bash
+        run: cargo build --all-features --release ${{ matrix.config.extraArgs }}
 
       - name: Sign the binary with GitHub OIDC token
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - "v*"
 
+env:
+  RUST_VERSION: 1.68
+
 jobs:
   build-and-sign:
     name: build and sign release assets
@@ -85,14 +88,18 @@ jobs:
           cosign-release: v2.0.0
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.68
-          default: true
-          target: ${{ matrix.config.target }}
+        shell: bash
+        run: |
+          rustup toolchain install ${{ env.RUST_VERSION }}
+          rustup default ${{ env.RUST_VERSION }}
+
+      - name: Install target
+        if: matrix.config.target != ''
+        shell: bash
+        run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi --toolchain 1.68 && rustup target add wasm32-unknown-unknown --toolchain 1.68
+        run: rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
This update was motivated by the slew of deprecation warnings spotted in recent CI runs (for example, this [build workflow run](https://github.com/fermyon/spin/actions/runs/5868420592) and this [release workflow run](https://github.com/fermyon/spin/actions/runs/5868420584)).  It turns out they all stem from the [actions-rs/toolchain](https://github.com/actions-rs/toolchain) and [actions-rs/cargo](https://github.com/actions-rs/cargo) actions, which unfortunately no longer appear to be maintained (ref https://github.com/actions-rs/toolchain/issues/216 and https://github.com/actions-rs/cargo/issues/216).

While there may be alternative actions (such as https://github.com/dtolnay/rust-toolchain), I propose we just invoke the `rustup` and `cargo` commands directly, seeing as how our use case is fairly straightforward.

Example runs from this changeset: [build](https://github.com/vdice/spin/actions/runs/5872410262) and [release](https://github.com/vdice/spin/actions/runs/5872410261).