### PR TITLE
ci(build.yml): run e2e job on larger runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,8 @@ jobs:
         run: make test-sdk-go
 
   e2e-tests:
-    runs-on: ubuntu-22.04
+    # run on a larger runner for more SSD/resource access
+    runs-on: ubuntu-22.04-4core-spin
     needs: build-rust-ubuntu
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Run the e2e job on a larger runner.

This will incur a $0.016 per minute rate for using this Ubuntu/4-core larger runner, per https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates.  If a given e2e run lasts 45 minutes, this would incur a cost of $0.72.  (Note: minutes used for a run _should_ decrease noticeably on the larger runner, but we don't know how much yet.)  This may be more than we'd like to spend depending on level of usage, so we'll want to monitor costs.  Still, I am curious to see if it helps the e2e job run to completion; also keen to use this as an exercise on how/where we might utilize these larger runners.

Ref https://github.com/fermyon/spin/issues/1700