### PR TITLE
ci(build.yml): add concurrency config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,12 @@ on:
       - "README.md"
       - "tests/README.md"
 
+# Serialize workflow runs per ref
+# Cancel any outdated, in-flight runs for refs other than 'main'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
Update the build.yml GH workflow with [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) configuration.

- Serializes runs for a given ref

- In-flight run(s) for a given ref (besides the `main` branch) are cancelled if out-of-date (i.e. when newer commits are pushed to the ref, eg PR branch, etc).  This becomes especially important when some parts of CI may utilize larger runners at an increased per-minute cost.

Ref https://github.com/fermyon/spin/pull/1702#issuecomment-1688730028 for further context