### PR TITLE
Use native types for go sdk

### DIFF
--- a/sdk/go/key_value/key-value.go
+++ b/sdk/go/key_value/key-value.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-type Store C.key_value_store_t
+type Store uint32
 
 const (
 	errorKindStoreTableFull = iota

--- a/sdk/go/redis/internals.go
+++ b/sdk/go/redis/internals.go
@@ -100,7 +100,7 @@ func srem(addr string, key string, values []string) (int64, error) {
 	return int64(cpayload), toErr(err)
 }
 
-type RedisParameterKind C.uint8_t
+type RedisParameterKind uint8
 
 const (
 	RedisParameterKindInt64 = iota
@@ -112,7 +112,7 @@ type RedisParameter struct {
 	Val interface{}
 }
 
-type RedisResultKind C.uint8_t
+type RedisResultKind uint8
 
 const (
 	RedisResultKindNil = iota


### PR DESCRIPTION
This change doesn't change behavior but removes exported C types.

Also makes the go docs less scary.
Example: https://pkg.go.dev/github.com/fermyon/spin/sdk/go@v1.4.1/redis#RedisParameter