### PR TITLE
When `spin watch` terminates `spin up`, allow it to delete its temp dir

### DIFF
--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -202,6 +202,17 @@ impl WatchCommand {
         let mut spin_args = match state {
             State::Building => vec![String::from("build")],
             State::Running => vec![String::from("up")],
+            State::WaitingForSpinUpToExit => {
+                // This should never happen and it's a logic error if it does.
+                // Currently this tries to gracefully continue but it might mean
+                // the watch state and running process are out of sync in which
+                // case it might be better to panic...?
+                debug_assert!(false, "spin watch: Should not have tried to start a process while in the WaitingForSpinUpToExit state");
+                tracing::error!(
+                    "Internal error: spin watch tried to restart while waiting for spin up to exit"
+                );
+                vec![String::from("build")]
+            }
         };
         spin_args.append(&mut vec![String::from("-f"), manifest_path]);
         if matches!(state, State::Running) {


### PR DESCRIPTION
Fixes #1698.

The heart of this fix simply changes Unix builds to send SIGINT (Ctrl+C) to stop `spin up` instead of just nuking it.  This allows `spin up` to exit gracefully, cleaning up its turds.  And all is grand, except, wee small problem, this by itself results in builds getting nuked before they can complete, so the user no longer sees their changes, and hey, if I want that, I can just use `spin up` amirite?

The reason for this is that the `Building` and `Running` states get out of sync with the actual process.  On a change, the state machine moves into `Building` (and starts the build), but `spin up` is still cleaning up.  When `up` exits, all watch see is "the child process completed", and it takes that to be the current child process i.e. `build`.  Great, so we can nuke `build` and start `up`.  Uh oh.

There are probably various ways of solving this, and I am a bit wary of the one this PR goes for, but that's why we have review cycles.  What it does is add a new state to watch's internal state machine, "waiting for `spin up` to exit".  When something changes while we are in Running, we go into waiting first, and when we get a ChildProcessCompleted in waiting, _then_ we go into building and do a start.

Waiting is not a great state because it doesn't map to a Spin command, and watch really wants states to map to commands.  And if means all the effect clauses now need to think about waiting as well as building and running, and I am not sure I have them doing the right thing...

...BUT...

...it _seems_ to work, and I _think_ the transitions make sense.

Longer term, this exposes possible pain points with `watchexec`.  It seems very much designed around "there is a command and we will restart that command."  We do some magic to intercept those restarts and go "not so fast, I think you will find that the command is actually `spin up` today", but things like the ChildProcessCompleted event are clearly designed for an environment where you are not juggling multiple commands and processes (like CPC doesn't provide _any_ info about the process, because you're meant to know what the process is because there's only one of them).

@calebschoepp this would really benefit from your deep knowledge of spin watch and watchexec, especially in terms of whether the transitions and the tests for those transitions make sense (the tests have a fair bit of "just change the test to match the error" I'm afraid).  I have not yet really tested with "skip build" or "clear" turned on so there might be some glitches there and I am not sure I will know how to fix them if there are.  And of course I'm very open to better ways of managing the graceful exit, this is just something that kinda made sense to me and seemed to work...!  Thanks!