### PR TITLE
Feature/mqtt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,6 +3414,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "outbound-mqtt"
+version = "1.5.0-pre0"
+dependencies = [
+ "anyhow",
+ "paho-mqtt",
+ "spin-core",
+ "spin-world",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "outbound-mysql"
 version = "1.5.0-pre0"
 dependencies = [
@@ -3453,6 +3471,32 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "paho-mqtt"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a19171f5b405f350373e32b6c2c4b47c225afccc837c11d2e7e22ba1749c62"
+dependencies = [
+ "async-channel",
+ "crossbeam-channel",
+ "futures",
+ "futures-timer",
+ "libc",
+ "log",
+ "paho-mqtt-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "paho-mqtt-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1782b5e75d712f951a2a4c7d3175a2ef37d93ddb3ad8656b37092f3f05464bc9"
+dependencies = [
+ "cmake",
+ "openssl-sys",
+]
 
 [[package]]
 name = "parking"
@@ -4827,6 +4871,7 @@ dependencies = [
  "spin-key-value-sqlite",
  "spin-loader",
  "spin-manifest",
+ "spin-mqtt-engine",
  "spin-oci",
  "spin-plugins",
  "spin-redis-engine",
@@ -5053,6 +5098,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-mqtt-engine"
+version = "1.5.0-pre0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "paho-mqtt",
+ "serde",
+ "spin-app",
+ "spin-core",
+ "spin-testing",
+ "spin-trigger",
+ "spin-world",
+ "tracing",
+]
+
+[[package]]
 name = "spin-oci"
 version = "1.5.0-pre0"
 dependencies = [
@@ -5242,6 +5304,7 @@ dependencies = [
  "futures",
  "indexmap",
  "outbound-http",
+ "outbound-mqtt",
  "outbound-mysql",
  "outbound-pg",
  "outbound-redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ spin-manifest = { path = "crates/manifest" }
 spin-oci = { path = "crates/oci" }
 spin-plugins = { path = "crates/plugins" }
 spin-redis-engine = { path = "crates/redis" }
+spin-mqtt-engine = { path = "crates/mqtt" }
 spin-templates = { path = "crates/templates" }
 spin-trigger = { path = "crates/trigger" }
 tempfile = "3.3.0"

--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,7 @@ error: the `wasm32-wasi` target is not installed
         "crates/trigger-http/tests/rust-http-test",
     );
     build_wasm_test_program("redis-rust.wasm", "crates/redis/tests/rust");
+    build_wasm_test_program("mqtt-rust.wasm", "crates/mqtt/tests/rust");
     build_wasm_test_program("wagi-test.wasm", "crates/trigger-http/tests/wagi-test");
 
     build_wasm_test_program(

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -39,7 +39,7 @@ impl<C> RawAppManifestAnyVersionImpl<C> {
     pub fn from_manifest(manifest: RawAppManifestImpl<C>) -> Self {
         Self {
             manifest,
-            spin_manifest_version: FixedStringVersion::default(),
+            spin_manifest_version: FixedStringVersion,
         }
     }
     /// Converts `RawAppManifestAnyVersionImpl` into underlying V1 manifest

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -23,7 +23,7 @@ use path_absolutize::Absolutize;
 use reqwest::Url;
 use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, ApplicationTrigger, CoreComponent,
-    HttpConfig, ModuleSource, RedisConfig, SpinVersion, TriggerConfig, WasmConfig,
+    HttpConfig, ModuleSource, MqttConfig, RedisConfig, SpinVersion, TriggerConfig, WasmConfig,
 };
 use tokio::{fs::File, io::AsyncReadExt};
 
@@ -440,6 +440,7 @@ fn resolve_trigger(
     let tc = match app_trigger {
         ApplicationTrigger::Http(_) => TriggerConfig::Http(HttpConfig::deserialize(partial)?),
         ApplicationTrigger::Redis(_) => TriggerConfig::Redis(RedisConfig::deserialize(partial)?),
+        ApplicationTrigger::Mqtt(_) => TriggerConfig::Mqtt(MqttConfig::deserialize(partial)?),
         ApplicationTrigger::External(_) => TriggerConfig::External(HashMap::deserialize(partial)?),
     };
     Ok(tc)
@@ -533,6 +534,20 @@ route = "/"
         let ct = &m1.components[0].trigger;
         assert!(matches!(t, ApplicationTrigger::Redis(_)));
         assert!(matches!(ct, TriggerConfig::Redis(_)));
+    }
+
+    #[test]
+    fn can_parse_mqtt_trigger() {
+        let m = load_test_manifest(
+            r#"{ type = "mqtt", address = "dummy" }"#,
+            r#"topic = "topi""#,
+        );
+
+        let m1 = m.into_v1();
+        let t = m1.info.trigger;
+        let ct = &m1.components[0].trigger;
+        assert!(matches!(t, ApplicationTrigger::Mqtt(_)));
+        assert!(matches!(ct, TriggerConfig::Mqtt(_)));
     }
 
     #[test]

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -545,7 +545,7 @@ route = "/"
     #[test]
     fn can_parse_mqtt_trigger() {
         let m = load_test_manifest(
-            r#"{ type = "mqtt", address = "dummy" }"#,
+            r#"{ type = "mqtt", address = "dummy", qos = 0 }"#,
             r#"topic = "topi""#,
         );
 

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -261,6 +261,8 @@ impl TryFrom<ApplicationTrigger> for RedisTriggerConfiguration {
 pub struct MqttTriggerConfiguration {
     /// Address of Mqtt server.
     pub address: String,
+    /// QoS level for Mqtt server.
+    pub qos: u8,
 }
 
 impl TryFrom<ApplicationTrigger> for MqttTriggerConfiguration {

--- a/crates/mqtt/Cargo.toml
+++ b/crates/mqtt/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "spin-mqtt-engine"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+[lib]
+doctest = false
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+futures = "0.3"
+serde = "1"
+spin-app = { path = "../app" }
+spin-core = { path = "../core" }
+spin-trigger = { path = "../trigger" }
+spin-world = { path = "../world" }
+paho-mqtt = { version = "0.12" }
+tracing = { workspace = true }
+
+[dev-dependencies]
+spin-testing = { path = "../testing" }

--- a/crates/mqtt/readme.md
+++ b/crates/mqtt/readme.md
@@ -1,0 +1,1 @@
+# MQTT trigger for the Spin runtime

--- a/crates/mqtt/src/lib.rs
+++ b/crates/mqtt/src/lib.rs
@@ -1,0 +1,133 @@
+mod spin;
+
+use crate::spin::SpinMqttExecutor;
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{de::IgnoredAny, Deserialize, Serialize};
+use spin_app::MetadataKey;
+use spin_trigger::{cli::NoArgs, TriggerAppEngine, TriggerExecutor};
+use std::{collections::HashMap, time::Duration};
+
+const TRIGGER_METADATA_KEY: MetadataKey<TriggerMetadata> = MetadataKey::new("trigger");
+pub(crate) type RuntimeData = ();
+pub(crate) type Store = spin_core::Store<RuntimeData>;
+
+// Spin Mqtt Trigger
+pub struct MqttTrigger {
+    engine: TriggerAppEngine<Self>,
+    // Mqtt address to connect to
+    address: String,
+    // Mapping of subscription topics to component IDs
+    topic_components: HashMap<String, String>,
+}
+
+/// Mqtt trigger configuration.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MqttTriggerConfig {
+    // Component ID to invoke
+    pub component: String,
+    // Topic to subscribe to
+    pub topic: String,
+    // Trigger executor (currently unused)
+    #[serde(default, skip_serializing)]
+    pub executor: IgnoredAny,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TriggerMetadata {
+    r#type: String,
+    address: String,
+}
+
+#[async_trait]
+impl TriggerExecutor for MqttTrigger {
+    const TRIGGER_TYPE: &'static str = "mqtt";
+    type RuntimeData = RuntimeData;
+    type TriggerConfig = MqttTriggerConfig;
+    type RunConfig = NoArgs;
+
+    async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
+        let address = engine.app().require_metadata(TRIGGER_METADATA_KEY)?.address;
+
+        let topic_components: HashMap<String, String> = engine
+            .trigger_configs()
+            .map(|(_, config)| (config.topic.clone(), config.component.clone()))
+            .collect();
+
+        Ok(Self {
+            engine,
+            address,
+            topic_components,
+        })
+    }
+
+    /// Run the Mqtt trigger indefinitely.
+    async fn run(self, _config: Self::RunConfig) -> Result<()> {
+        let address = &self.address;
+        tracing::info!("Connecting to Mqtt server at {}", address);
+        let client = paho_mqtt::Client::new(address.to_string())?;
+
+        let conn_opts = paho_mqtt::ConnectOptionsBuilder::new()
+            .keep_alive_interval(Duration::from_secs(60))
+            .clean_session(true)
+            .finalize();
+
+        client.connect(conn_opts)?;
+
+        for (topic, component) in self.topic_components.iter() {
+            tracing::info!("Subscribing component {component:?} to topic {topic:?}");
+            client.subscribe(topic, 1)?;
+        }
+
+        loop {
+            // Wait for message to appear in the message channel.
+            // Optimise this for parallel reads with single thread.
+
+            match client.start_consuming().recv().unwrap() {
+                Some(msg) => drop(self.handle(msg).await),
+                None => {
+                    println!("No message");
+                    if !client.is_connected() {
+                        println!("No Mqtt connection available");
+                        break Ok(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl MqttTrigger {
+    async fn handle(&self, msg: paho_mqtt::Message) -> Result<()> {
+        let topic = msg.topic();
+        tracing::info!("Received message on topic {:?}", topic);
+
+        if let Some(component_id) = self.topic_components.get(topic) {
+            tracing::trace!("Executing Mqtt component {component_id:?}");
+            let executor = SpinMqttExecutor;
+            executor
+                .execute(&self.engine, component_id, topic, msg.payload())
+                .await?
+        }
+
+        Ok(())
+    }
+}
+
+/// The Mqtt executor trait.
+/// All Mqtt executors must implement this trait.
+#[async_trait]
+pub trait MqttExecutor: Clone + Send + Sync + 'static {
+    async fn execute(
+        &self,
+        engine: &TriggerAppEngine<MqttTrigger>,
+        component_id: &str,
+        topic: &str,
+        payload: &[u8],
+    ) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/mqtt/src/spin.rs
+++ b/crates/mqtt/src/spin.rs
@@ -1,0 +1,58 @@
+use crate::{MqttExecutor, MqttTrigger, Store};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use spin_core::Instance;
+use spin_trigger::{EitherInstance, TriggerAppEngine};
+use spin_world::mqtt_types::{Error, Payload};
+
+#[derive(Clone)]
+pub struct SpinMqttExecutor;
+
+#[async_trait]
+impl MqttExecutor for SpinMqttExecutor {
+    async fn execute(
+        &self,
+        engine: &TriggerAppEngine<MqttTrigger>,
+        component_id: &str,
+        topic: &str,
+        payload: &[u8],
+    ) -> Result<()> {
+        tracing::trace!("Executing request using the Spin executor for component {component_id}");
+
+        let (instance, store) = engine.prepare_instance(component_id).await?;
+        let EitherInstance::Component(instance) = instance else {
+            unreachable!()
+        };
+
+        match Self::execute_impl(store, instance, topic, payload.to_vec()).await {
+            Ok(()) => {
+                tracing::trace!("Request finished OK");
+                Ok(())
+            }
+            Err(e) => {
+                tracing::trace!("Request finished with error {e}");
+                Err(e)
+            }
+        }
+    }
+}
+
+impl SpinMqttExecutor {
+    pub async fn execute_impl(
+        mut store: Store,
+        instance: Instance,
+        _topic: &str,
+        payload: Vec<u8>,
+    ) -> Result<()> {
+        let func = instance
+            .exports(&mut store)
+            .instance("fermyon:spin/inbound-mqtt")
+            .ok_or_else(|| anyhow!("no fermyon:spin/inbound-mqtt instance found"))?
+            .typed_func::<(Payload,), (Result<(), Error>,)>("handle-message")?;
+
+        match func.call_async(store, (payload,)).await? {
+            (Ok(()) | Err(Error::Success),) => Ok(()),
+            _ => Err(anyhow!("`handle-message` returned an error")),
+        }
+    }
+}

--- a/crates/mqtt/src/tests.rs
+++ b/crates/mqtt/src/tests.rs
@@ -1,0 +1,20 @@
+use super::*;
+use anyhow::Result;
+use paho_mqtt::Message;
+use spin_testing::{tokio, MqttTestConfig};
+
+fn create_trigger_event(topic: &str, payload: &str) -> paho_mqtt::Message {
+    Message::new(topic, payload, 0)
+}
+
+#[tokio::test]
+async fn test_pubsub() -> Result<()> {
+    let trigger: MqttTrigger = MqttTestConfig::default()
+        .test_program("mqtt-rust.wasm")
+        .build_trigger("messages")
+        .await;
+    let msg = create_trigger_event("messages", "hello");
+    trigger.handle(msg).await?;
+
+    Ok(())
+}

--- a/crates/mqtt/tests/rust/.cargo/.config
+++ b/crates/mqtt/tests/rust/.cargo/.config
@@ -1,0 +1,2 @@
+[build]
+    target = "wasm32-wasi"

--- a/crates/mqtt/tests/rust/Cargo.toml
+++ b/crates/mqtt/tests/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name    = "rust"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Suneet Nangia <suneetnangia@gmail.com>" ]
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+wit-bindgen = "0.8"
+
+[workspace]

--- a/crates/mqtt/tests/rust/src/lib.rs
+++ b/crates/mqtt/tests/rust/src/lib.rs
@@ -1,0 +1,20 @@
+use std::str::{from_utf8, Utf8Error};
+
+wit_bindgen::generate!("mqtt-trigger" in "../../../../wit/preview2");
+use exports::fermyon::spin::inbound_mqtt::{self, Error, Payload};
+
+struct SpinMqtt;
+export_mqtt_trigger!(SpinMqtt);
+
+impl inbound_mqtt::InboundMqtt for SpinMqtt {
+    fn handle_message(message: Payload) -> Result<(), Error> {
+        println!("Message: {:?}", from_utf8(&message));
+        Ok(())
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(_: Utf8Error) -> Self {
+        Self::Error
+    }
+}

--- a/crates/outbound-mqtt/Cargo.toml
+++ b/crates/outbound-mqtt/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "outbound-mqtt"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+[lib]
+doctest = false
+
+[dependencies]
+anyhow = "1.0"
+paho-mqtt = { version = "0.12" }
+spin-core = { path = "../core" }
+spin-world = { path = "../world" }
+tokio = { version = "1", features = ["sync"] }
+tracing = { workspace = true }

--- a/crates/outbound-mqtt/src/host_component.rs
+++ b/crates/outbound-mqtt/src/host_component.rs
@@ -1,0 +1,20 @@
+use spin_core::HostComponent;
+
+use crate::OutboundMqtt;
+
+pub struct OutboundMqttComponent;
+
+impl HostComponent for OutboundMqttComponent {
+    type Data = OutboundMqtt;
+
+    fn add_to_linker<T: Send>(
+        linker: &mut spin_core::Linker<T>,
+        get: impl Fn(&mut spin_core::Data<T>) -> &mut Self::Data + Send + Sync + Copy + 'static,
+    ) -> anyhow::Result<()> {
+        super::outbound_mqtt::add_to_linker(linker, get)
+    }
+
+    fn build_data(&self) -> Self::Data {
+        Default::default()
+    }
+}

--- a/crates/outbound-mqtt/src/lib.rs
+++ b/crates/outbound-mqtt/src/lib.rs
@@ -22,12 +22,13 @@ impl outbound_mqtt::Host for OutboundMqtt {
     async fn publish(
         &mut self,
         address: String,
+        qos: outbound_mqtt::Qos,
         topic: String,
         payload: Vec<u8>,
     ) -> Result<Result<(), Error>> {
         Ok(async {
             let client = self.get_conn(&address).await.map_err(log_error)?;
-            let message = paho_mqtt::Message::new(&topic, payload, 0);
+            let message = paho_mqtt::Message::new(&topic, payload, qos as i32);
             client.publish(message).map_err(log_error)?;
             Ok(())
         }

--- a/crates/outbound-mqtt/src/lib.rs
+++ b/crates/outbound-mqtt/src/lib.rs
@@ -1,0 +1,61 @@
+mod host_component;
+
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    time::Duration,
+};
+
+use anyhow::Result;
+use paho_mqtt::Client;
+use spin_core::async_trait;
+use spin_world::{mqtt as outbound_mqtt, mqtt_types::Error};
+
+pub use host_component::OutboundMqttComponent;
+
+#[derive(Default)]
+pub struct OutboundMqtt {
+    connections: HashMap<String, Client>,
+}
+
+#[async_trait]
+impl outbound_mqtt::Host for OutboundMqtt {
+    async fn publish(
+        &mut self,
+        address: String,
+        topic: String,
+        payload: Vec<u8>,
+    ) -> Result<Result<(), Error>> {
+        Ok(async {
+            let client = self.get_conn(&address).await.map_err(log_error)?;
+            let message = paho_mqtt::Message::new(&topic, payload, 0);
+            client.publish(message).map_err(log_error)?;
+            Ok(())
+        }
+        .await)
+    }
+}
+
+impl OutboundMqtt {
+    async fn get_conn(&mut self, address: &str) -> Result<&mut Client> {
+        let client = match self.connections.entry(address.to_string()) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => {
+                let client = Client::new(address.to_string())?;
+
+                let conn_opts = paho_mqtt::ConnectOptionsBuilder::new()
+                    .keep_alive_interval(Duration::from_secs(60))
+                    .clean_session(true)
+                    .finalize();
+                client.connect(conn_opts)?;
+
+                v.insert(client)
+            }
+        };
+        Ok(client)
+    }
+}
+
+fn log_error(err: impl std::fmt::Debug) -> Error {
+    tracing::warn!("Outbound Mqtt error: {err:?}");
+    Error::Error
+}

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -466,7 +466,7 @@ mod tests {
         PathBuf::from(crate_dir).join("tests")
     }
 
-    const TPLS_IN_THIS: usize = 12;
+    const TPLS_IN_THIS: usize = 13;
 
     #[tokio::test]
     async fn can_install_into_new_directory() {

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -176,7 +176,7 @@ impl MqttTestConfig {
         TestLoader {
             module_path: self.module_path.clone().expect("module path to be set"),
             trigger_type: "mqtt".into(),
-            app_trigger_metadata: json!({"address": "test-mqtt-host"}),
+            app_trigger_metadata: json!({"address": "test-mqtt-host", "qos": 0}),
             trigger_config: json!({
                 "component": "test-component",
                 "topic": self.mqtt_topic,

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3"
 indexmap = "1"
 outbound-http = { path = "../outbound-http" }
 outbound-redis = { path = "../outbound-redis" }
+outbound-mqtt = { path = "../outbound-mqtt" }
 outbound-pg = { path = "../outbound-pg" }
 outbound-mysql = { path = "../outbound-mysql" }
 spin-common = { path = "../common" }

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -113,6 +113,7 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
 
             if !self.disable_default_host_components {
                 builder.add_host_component(outbound_redis::OutboundRedisComponent)?;
+                builder.add_host_component(outbound_mqtt::OutboundMqttComponent)?;
                 builder.add_host_component(outbound_pg::OutboundPg::default())?;
                 builder.add_host_component(outbound_mysql::OutboundMysql::default())?;
                 self.loader.add_dynamic_host_component(

--- a/crates/trigger/src/locked.rs
+++ b/crates/trigger/src/locked.rs
@@ -15,7 +15,7 @@ use spin_app::{
 use spin_key_value::KEY_VALUE_STORES_KEY;
 use spin_manifest::{
     Application, ApplicationInformation, ApplicationOrigin, ApplicationTrigger, CoreComponent,
-    HttpConfig, HttpTriggerConfiguration, RedisConfig, TriggerConfig,
+    HttpConfig, HttpTriggerConfiguration, MqttConfig, RedisConfig, TriggerConfig,
 };
 use spin_sqlite::DATABASES_KEY;
 
@@ -111,6 +111,10 @@ impl LockedAppBuilder {
                     (ApplicationTrigger::Redis(_), TriggerConfig::Redis(RedisConfig{ channel, executor: _ })) => {
                         trigger_type = "redis";
                         builder.string("channel", channel);
+                    },
+                    (ApplicationTrigger::Mqtt(_), TriggerConfig::Mqtt(MqttConfig{ topic, executor: _ })) => {
+                        trigger_type = "mqtt";
+                        builder.string("topic", topic);
                     },
                     (ApplicationTrigger::External(c), TriggerConfig::External(t)) => {
                         trigger_type = c.trigger_type();

--- a/examples/mqtt-rust/.cargo/config.toml
+++ b/examples/mqtt-rust/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/examples/mqtt-rust/Cargo.toml
+++ b/examples/mqtt-rust/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name    = "spinmqtt"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# The Spin SDK.
+spin-sdk = { path = "../../sdk/rust" }
+[workspace]

--- a/examples/mqtt-rust/spin.toml
+++ b/examples/mqtt-rust/spin.toml
@@ -2,7 +2,7 @@ spin_manifest_version = "1"
 authors = ["Suneet Nangia <suneetnangia@gmail.com>"]
 description = "An MQTT application."
 name = "spin-mqtt"
-trigger = {type = "mqtt", address = "localhost"}
+trigger = {type = "mqtt", address = "localhost", qos = 0}
 version = "0.1.0"
 
 [[component]]

--- a/examples/mqtt-rust/spin.toml
+++ b/examples/mqtt-rust/spin.toml
@@ -1,0 +1,14 @@
+spin_manifest_version = "1"
+authors = ["Suneet Nangia <suneetnangia@gmail.com>"]
+description = "An MQTT application."
+name = "spin-mqtt"
+trigger = {type = "mqtt", address = "localhost"}
+version = "0.1.0"
+
+[[component]]
+id = "echo-message"
+source = "target/wasm32-wasi/release/spinmqtt.wasm"
+[component.trigger]
+topic="messages"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"

--- a/examples/mqtt-rust/src/lib.rs
+++ b/examples/mqtt-rust/src/lib.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use bytes::Bytes;
+use spin_sdk::mqtt_component;
+use std::str::from_utf8;
+
+/// A simple Spin Mqtt component.
+#[mqtt_component]
+fn on_message(message: Bytes) -> Result<()> {
+    println!("{}", from_utf8(&message)?);
+    Ok(())
+}

--- a/examples/redis-rust/Cargo.lock
+++ b/examples/redis-rust/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.4.0-pre0"
+version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/examples/rust-outbound-mqtt/.cargo/config.toml
+++ b/examples/rust-outbound-mqtt/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/examples/rust-outbound-mqtt/Cargo.toml
+++ b/examples/rust-outbound-mqtt/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rust-outbound-mqtt"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# General-purpose crate with common HTTP types.
+http = "0.2"
+# The Spin SDK.
+spin-sdk = { path = "../../sdk/rust" }
+
+[workspace]

--- a/examples/rust-outbound-mqtt/spin.toml
+++ b/examples/rust-outbound-mqtt/spin.toml
@@ -1,0 +1,15 @@
+spin_manifest_version = "1"
+authors = ["Suneet Nangia <suneetnangia@gmail.com>"]
+name = "rust-outbound-mqtt-example"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+environment = { MQTT_ADDRESS = "localhost", MQTT_TOPIC = "messages" }
+id = "outbound-mqtt"
+source = "target/wasm32-wasi/release/rust_outbound_mqtt.wasm"
+[component.trigger]
+route = "/publish"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"
+

--- a/examples/rust-outbound-mqtt/src/lib.rs
+++ b/examples/rust-outbound-mqtt/src/lib.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use spin_sdk::{
+    http::{internal_server_error, Request, Response},
+    http_component, mqtt,
+};
+
+// The environment variable set in `spin.toml` that points to the
+// address of the Mqtt server that the component will publish
+// a message to.
+const MQTT_ADDRESS_ENV: &str = "MQTT_ADDRESS";
+
+// The environment variable set in `spin.toml` that specifies
+// the Mqtt topic that the component will publish to.
+const MQTT_TOPIC_ENV: &str = "MQTT_TOPIC";
+
+/// This HTTP component demonstrates fetching a value from Mqtt
+/// by key, setting a key with a value, and publishing a message
+/// to a Mqtt topic. The component is triggered by an HTTP
+/// request served on the route configured in the `spin.toml`.
+#[http_component]
+fn publish(_req: Request) -> Result<Response> {
+    let address = std::env::var(MQTT_ADDRESS_ENV)?;
+    let topic = std::env::var(MQTT_TOPIC_ENV)?;
+    let message = "Hello from Spin!".as_bytes();
+
+    // Publish to Mqtt
+    match mqtt::publish(&address, &topic, message) {
+        Ok(()) =>  Ok(http::Response::builder().status(200).body(None)?),
+        Err(e) => { println!("{e}"); internal_server_error() } ,
+    }
+}

--- a/examples/rust-outbound-mqtt/src/lib.rs
+++ b/examples/rust-outbound-mqtt/src/lib.rs
@@ -24,7 +24,7 @@ fn publish(_req: Request) -> Result<Response> {
     let message = "Hello from Spin!".as_bytes();
 
     // Publish to Mqtt
-    match mqtt::publish(&address, &topic, message) {
+    match mqtt::publish(&address, mqtt::Qos::ExactlyOnce, &topic, message) {
         Ok(()) =>  Ok(http::Response::builder().status(200).body(None)?),
         Err(e) => { println!("{e}"); internal_server_error() } ,
     }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -1298,6 +1298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2377,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "outbound-mqtt"
+version = "1.5.0-pre0"
+dependencies = [
+ "anyhow",
+ "paho-mqtt",
+ "spin-core",
+ "spin-world",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "outbound-mysql"
 version = "1.5.0-pre0"
 dependencies = [
@@ -2409,6 +2427,32 @@ dependencies = [
  "spin-world",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "paho-mqtt"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a19171f5b405f350373e32b6c2c4b47c225afccc837c11d2e7e22ba1749c62"
+dependencies = [
+ "async-channel",
+ "crossbeam-channel",
+ "futures",
+ "futures-timer",
+ "libc",
+ "log",
+ "paho-mqtt-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "paho-mqtt-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1782b5e75d712f951a2a4c7d3175a2ef37d93ddb3ad8656b37092f3f05464bc9"
+dependencies = [
+ "cmake",
+ "openssl-sys",
 ]
 
 [[package]]
@@ -3603,6 +3647,7 @@ dependencies = [
  "futures",
  "indexmap",
  "outbound-http",
+ "outbound-mqtt",
  "outbound-mysql",
  "outbound-pg",
  "outbound-redis",

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -118,6 +118,13 @@ pub mod redis {
     }
 }
 
+// Implementation of the spin mqtt interface.
+#[allow(missing_docs)]
+pub mod mqtt {
+    pub use super::wit::fermyon::spin::mqtt::publish;
+    pub use super::wit::fermyon::spin::mqtt_types::*;
+}
+
 /// Implementation of the spin postgres db interface.
 pub mod pg;
 
@@ -258,4 +265,11 @@ pub mod inbound_http {
 #[doc(hidden)]
 pub mod inbound_redis {
     pub use super::wit::exports::fermyon::spin::inbound_redis::*;
+}
+
+/// Inbound mqtt trigger functionality
+// Hide the docs since this is only needed for the macro
+#[doc(hidden)]
+pub mod inbound_mqtt {
+    pub use super::wit::exports::fermyon::spin::inbound_mqtt::*;
 }

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -16,6 +16,7 @@ use spin_cli::commands::{
     watch::WatchCommand,
 };
 use spin_cli::{build_info::*, subprocess::ExitStatusError};
+use spin_mqtt_engine::MqttTrigger;
 use spin_redis_engine::RedisTrigger;
 use spin_trigger::cli::help::HelpArgsOnlyTrigger;
 use spin_trigger::cli::TriggerExecutorCommand;
@@ -139,6 +140,7 @@ enum SpinApp {
 enum TriggerCommands {
     Http(TriggerExecutorCommand<HttpTrigger>),
     Redis(TriggerExecutorCommand<RedisTrigger>),
+    Mqtt(TriggerExecutorCommand<MqttTrigger>),
     #[clap(name = spin_cli::HELP_ARGS_ONLY_TRIGGER_TYPE, hide = true)]
     HelpArgsOnly(TriggerExecutorCommand<HelpArgsOnlyTrigger>),
 }
@@ -157,6 +159,7 @@ impl SpinApp {
             Self::Build(cmd) => cmd.run().await,
             Self::Trigger(TriggerCommands::Http(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::Redis(cmd)) => cmd.run().await,
+            Self::Trigger(TriggerCommands::Mqtt(cmd)) => cmd.run().await,
             Self::Trigger(TriggerCommands::HelpArgsOnly(cmd)) => cmd.run().await,
             Self::Plugins(cmd) => cmd.run().await,
             Self::External(cmd) => execute_external_subcommand(cmd, app).await,

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -393,6 +393,7 @@ fn trigger_command_from_locked_app(locked_app: &LockedApp) -> Result<Vec<String>
     match trigger_info {
         ApplicationTrigger::Http(_) => Ok(trigger_command("http")),
         ApplicationTrigger::Redis(_) => Ok(trigger_command("redis")),
+        ApplicationTrigger::Mqtt(_) => Ok(trigger_command("mqtt")),
         ApplicationTrigger::External(cfg) => {
             resolve_trigger_plugin(cfg.trigger_type()).map(|p| vec![p])
         }

--- a/templates/mqtt-rust/content/.gitignore
+++ b/templates/mqtt-rust/content/.gitignore
@@ -1,0 +1,2 @@
+target/
+.spin/

--- a/templates/mqtt-rust/content/Cargo.toml
+++ b/templates/mqtt-rust/content/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "{{project-name | kebab_case}}"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# The Spin SDK.
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.4.1" }
+
+[workspace]

--- a/templates/mqtt-rust/content/spin.toml
+++ b/templates/mqtt-rust/content/spin.toml
@@ -1,0 +1,15 @@
+spin_manifest_version = "1"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+name = "{{project-name}}"
+trigger = { type = "mqtt", address = "{{mqtt-address}}" }
+version = "0.1.0"
+
+[[component]]
+id = "{{project-name | kebab_case}}"
+source = "target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
+allowed_http_hosts = []
+[component.trigger]
+topic = "{{mqtt-topic}}"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"

--- a/templates/mqtt-rust/content/src/lib.rs
+++ b/templates/mqtt-rust/content/src/lib.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use bytes::Bytes;
+use spin_sdk::mqtt_component;
+use std::str::from_utf8;
+
+/// A simple Spin Mqtt component.
+#[mqtt_component]
+fn on_message(message: Bytes) -> Result<()> {
+    println!("{}", from_utf8(&message)?);
+    // Implement me ...
+    Ok(())
+}

--- a/templates/mqtt-rust/metadata/spin-template.toml
+++ b/templates/mqtt-rust/metadata/spin-template.toml
@@ -1,0 +1,9 @@
+manifest_version = "1"
+id = "mqtt-rust"
+description = "Mqtt message handler using Rust"
+tags = ["mqtt", "rust"]
+
+[parameters]
+project-description = { type = "string",  prompt = "Description", default = "" }
+mqtt-address = { type = "string", prompt = "Mqtt address", default = "localhost" }
+mqtt-topic = { type = "string", prompt = "Mqtt topic" }

--- a/tests/testcases/head-rust-sdk-mqtt/.cargo/config.toml
+++ b/tests/testcases/head-rust-sdk-mqtt/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/tests/testcases/head-rust-sdk-mqtt/Cargo.toml
+++ b/tests/testcases/head-rust-sdk-mqtt/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name    = "head-rust-sdk-mqtt"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+http = "0.2"
+spin-sdk = { path = "../../../sdk/rust"}
+
+[workspace]

--- a/tests/testcases/head-rust-sdk-mqtt/spin.toml
+++ b/tests/testcases/head-rust-sdk-mqtt/spin.toml
@@ -1,0 +1,14 @@
+spin_version = "1"
+authors = ["Suneet Nangia <suneetnangia@gmail.com>"]
+description = "A simple mqtt application that exercises the Rust SDK in the current branch"
+name = "head-rust-sdk-mqtt"
+trigger = {type = "mqtt", address = "localhost"}
+version = "1.0.0"
+
+[[component]]
+id = "hello"
+source = "target/wasm32-wasi/release/head_rust_sdk_mqtt.wasm"
+[component.trigger]
+topic = "my-topic"
+[component.build]
+command = "cargo build --target wasm32-wasi --release"

--- a/tests/testcases/head-rust-sdk-mqtt/src/lib.rs
+++ b/tests/testcases/head-rust-sdk-mqtt/src/lib.rs
@@ -1,0 +1,10 @@
+use spin_sdk::mqtt_component;
+
+#[mqtt_component]
+fn on_message(message: bytes::Bytes) -> anyhow::Result<()> {
+    println!(
+        "Got message: '{}'",
+        std::str::from_utf8(&*message).unwrap_or("<MESSAGE NOT UTF8>")
+    );
+    Ok(())
+}

--- a/wit/preview2/inbound-mqtt.wit
+++ b/wit/preview2/inbound-mqtt.wit
@@ -1,0 +1,6 @@
+interface inbound-mqtt {
+  use mqtt-types.{payload, error}
+
+  // The entrypoint for a Mqtt handler.
+  handle-message: func(message: payload) -> result<_, error>
+}

--- a/wit/preview2/mqtt-types.wit
+++ b/wit/preview2/mqtt-types.wit
@@ -5,6 +5,13 @@ interface mqtt-types {
       error,
   }
 
+  // MQTT QoS levels.
+  enum qos {
+      at-most-once,
+      at-least-once,
+      exactly-once,
+  }
+
   // The message payload.
   type payload = list<u8>
 }

--- a/wit/preview2/mqtt-types.wit
+++ b/wit/preview2/mqtt-types.wit
@@ -1,0 +1,10 @@
+interface mqtt-types {
+  // General purpose error.
+  enum error {
+      success,
+      error,
+  }
+
+  // The message payload.
+  type payload = list<u8>
+}

--- a/wit/preview2/mqtt.wit
+++ b/wit/preview2/mqtt.wit
@@ -1,6 +1,6 @@
 interface mqtt {
-  use mqtt-types.{payload, error}
+  use mqtt-types.{payload, error, qos}
 
   // Publish an MQTT message to the specified topic and return an error, if any.
-  publish: func(address: string, topic: string, payload: payload) -> result<_, error>    
+  publish: func(address: string, qos: qos, topic: string, payload: payload) -> result<_, error>
 }

--- a/wit/preview2/mqtt.wit
+++ b/wit/preview2/mqtt.wit
@@ -1,0 +1,6 @@
+interface mqtt {
+  use mqtt-types.{payload, error}
+
+  // Publish an MQTT message to the specified topic and return an error, if any.
+  publish: func(address: string, topic: string, payload: payload) -> result<_, error>    
+}

--- a/wit/preview2/reactor.wit
+++ b/wit/preview2/reactor.wit
@@ -1,17 +1,22 @@
 package fermyon:spin
 
 world reactor {
+  // interfaces imported in to spin wasm module as sdk for making outbound calls.
   import config
   import postgres
   import mysql
   import sqlite
   import redis
+  import mqtt
   import key-value
   import http
+  // interfaces exported from spin wasm module to allow pushing triggers' events.
   export inbound-http
   export inbound-redis
+  export inbound-mqtt
 }
 
+// Redis world with all outbound sdks and redis inbound
 world redis-trigger {
   import config
   import postgres
@@ -20,9 +25,11 @@ world redis-trigger {
   import redis
   import key-value
   import http
+  import mqtt
   export inbound-redis
 }
 
+// Http world with all outbound sdks and http inbound
 world http-trigger {
   import config
   import postgres
@@ -31,5 +38,19 @@ world http-trigger {
   import redis
   import key-value
   import http
+  import mqtt
   export inbound-http
+}
+
+// Mqtt world with all outbound sdks and mqtt inbound
+world mqtt-trigger {
+  import config
+  import postgres
+  import mysql
+  import sqlite
+  import redis
+  import key-value
+  import http
+  import mqtt
+  export inbound-mqtt
 }


### PR DESCRIPTION
This initial (and relatively large :panda_face:) PR adds MQTT support in Spin, following are the key changes for initial review before it moves out of draft:
1. Added support for MQTT trigger
2. Added support for MQTT outbound in SDK
3. Updated examples and templates
4. Updated WIT definitions to support MQTT functions
5. Updated tests

Primary reason for adding MQTT support in this instance to allow us to run Spin based Wasm components on the edge where MQTT is more prevalent. 

P.S. I'll be revisiting MQTT code and WIT definitions this week to cover any gaps and potential performance bottlenecks. If you do spot anything I missed, please do let me know. Thanks.
