### PR TITLE
Fix clippy errors from 1.72

### DIFF
--- a/crates/app/src/metadata.rs
+++ b/crates/app/src/metadata.rs
@@ -23,10 +23,7 @@ impl<T> MetadataKey<T> {
 
 impl<T> Clone for MetadataKey<T> {
     fn clone(&self) -> Self {
-        Self {
-            key: self.key,
-            _phantom: PhantomData,
-        }
+        *self
     }
 }
 

--- a/crates/core/src/host_component.rs
+++ b/crates/core/src/host_component.rs
@@ -106,7 +106,7 @@ impl<HC: HostComponent> HostComponentDataHandle<HC> {
 
 impl<HC: HostComponent> Clone for HostComponentDataHandle<HC> {
     fn clone(&self) -> Self {
-        Self::from_any(self.inner)
+        *self
     }
 }
 

--- a/crates/e2e-testing/src/metadata_extractor.rs
+++ b/crates/e2e-testing/src/metadata_extractor.rs
@@ -42,7 +42,7 @@ pub fn extract_version_from_logs(appname: &str, logs: &str) -> String {
 
 /// Extracts routes of app being deployed by parsing logs
 pub fn extract_routes_from_logs(logs: &str) -> Vec<AppRoute> {
-    let re: Regex = Regex::new(r##"^\s*(.*): (https?://[^\s^\\(]+)(.*)$"##).unwrap();
+    let re: Regex = Regex::new(r"^\s*(.*): (https?://[^\s^\\(]+)(.*)$").unwrap();
     let mut route_start = false;
     let lines = logs.split('\n');
     let mut routes: Vec<AppRoute> = vec![];

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -39,7 +39,7 @@ impl<C> RawAppManifestAnyVersionImpl<C> {
     pub fn from_manifest(manifest: RawAppManifestImpl<C>) -> Self {
         Self {
             manifest,
-            spin_manifest_version: FixedStringVersion::default(),
+            spin_manifest_version: FixedStringVersion,
         }
     }
     /// Converts `RawAppManifestAnyVersionImpl` into underlying V1 manifest

--- a/src/watch_filter.rs
+++ b/src/watch_filter.rs
@@ -35,7 +35,7 @@ impl Filter {
 
     /// A default set of ignore patterns that can be used by the consumer of Filter.
     pub fn default_ignore_patterns() -> Vec<WatchPattern> {
-        vec!["*.swp"]
+        ["*.swp"]
             .iter()
             .map(|i| WatchPattern {
                 glob: i.to_string(),


### PR DESCRIPTION
This fixes clippy errors with the version of clippy shipped with 1.72