### PR TITLE
Use default `flate2` backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -2267,7 +2266,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2535,7 +2534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
  "base64 0.13.1",
- "pem",
+ "pem 1.1.1",
  "ring",
  "serde",
  "serde_json",
@@ -2749,16 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468756f34903b582fe7154dc1ffdebd89d0562c4a43b53c621bb0f1b1043ccb"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +2865,15 @@ name = "lru"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
 dependencies = [
  "hashbrown 0.13.2",
 ]
@@ -3032,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.30.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456207bb9636a0fdade67a64cea7bdebe6730c3c16ee5e34f2c481838ee5a39e"
+checksum = "f5272f59b5b1f93d65f7f826c1f025d6e410e89fb50a67e05aa20b35a55a8c0a"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3043,17 +3041,18 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "lazy_static",
- "lru 0.7.8",
+ "lru 0.10.1",
  "mio",
  "mysql_common",
  "native-tls",
  "once_cell",
- "pem",
+ "pem 2.0.1",
  "percent-encoding",
  "pin-project",
+ "priority-queue",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.5.3",
  "thiserror",
  "tokio",
  "tokio-native-tls",
@@ -3064,13 +3063,13 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.29.2"
+version = "0.30.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9006c95034ccf7b903d955f210469119f6c3477fc9c9e7a7845ce38a3e665c2a"
+checksum = "57349d5a326b437989b6ee4dc8f2f34b0cc131202748414712a8e7d98952fc8c"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bindgen",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "bitvec",
  "byteorder",
  "bytes",
@@ -3092,6 +3091,7 @@ dependencies = [
  "smallvec",
  "subprocess",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -3566,6 +3566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.0",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,6 +3791,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "priority-queue"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff39edfcaec0d64e8d0da38564fad195d2d51b680940295fcc307366e101e61"
+dependencies = [
+ "autocfg",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -4740,6 +4760,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,7 +5702,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.45.0",
 ]
@@ -5717,7 +5747,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tokio-util 0.7.7",
 ]

--- a/crates/outbound-mysql/Cargo.toml
+++ b/crates/outbound-mysql/Cargo.toml
@@ -9,9 +9,11 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-mysql_async = { version = "0.30.0", default-features = false }
-flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }
-mysql_common = { version = "0.29.1", default-features = false }
+flate2 = "1.0.17"
+# Removing default features for mysql_async to remove flate2/zlib feature
+mysql_async = { version = "0.32.2", default-features = false, features = ["native-tls-tls"] }
+# Removing default features for mysql_common to remove flate2/zlib feature
+mysql_common = { version = "0.30.6", default-features = false }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }
 tokio = { version = "1", features = [ "rt-multi-thread" ] }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -10,7 +10,7 @@ bytes = "1.1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "4.0"
 fd-lock = "3.0.12"
-flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }
+flate2 = "1.0.17"
 is-terminal = "0.4"
 path-absolutize = "3.0.11"
 reqwest = { version = "0.11", features = ["json"] }

--- a/e2e-tests-aarch64.Dockerfile
+++ b/e2e-tests-aarch64.Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_SPIN=false
 ARG SPIN_VERSION=canary
 
 WORKDIR /root
-RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config redis clang libicu-dev docker.io cmake
+RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config redis clang libicu-dev docker.io
 
 # nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -

--- a/e2e-tests.Dockerfile
+++ b/e2e-tests.Dockerfile
@@ -5,7 +5,7 @@ ARG FETCH_SPIN=true
 ARG SPIN_VERSION=canary
 
 WORKDIR /root
-RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config redis clang libicu-dev docker.io cmake
+RUN apt-get update && apt-get install -y wget sudo xz-utils gcc git pkg-config redis clang libicu-dev docker.io
 
 # nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -


### PR DESCRIPTION
This amends https://github.com/fermyon/spin/pull/1603 to consistently use the default pure Rust `flate2` backend rather than `zlib-ng`.

Also bumps `mysql_async` version and adds `native-tls-tls` feature in order to ensure we don't loose that feature in later version bumps.