### PR TITLE
point templates at canary tag

### DIFF
--- a/templates/http-rust/content/Cargo.toml
+++ b/templates/http-rust/content/Cargo.toml
@@ -16,6 +16,6 @@ bytes = "1"
 # General-purpose crate with common HTTP types.
 http = "0.2"
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.4.2" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "canary" }
 
 [workspace]


### PR DESCRIPTION
Update templates to point at the canary tag to allow for installing templates for `llm`.