### PR TITLE
Turn back on llm gpu features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cargo Clippy
         run:
-          BUILD_SPIN_EXAMPLES=0 cargo clippy --workspace --all-targets --all-features -- -D warnings
+          BUILD_SPIN_EXAMPLES=0 cargo clippy --workspace --all-targets --features all-tests -- -D warnings
 
   ## This is separated out to remove e2e-tests dependency on windows/mac builds
   build-rust-ubuntu:
@@ -59,7 +59,7 @@ jobs:
           rust-cache: true
 
       - name: Cargo Build
-        run: cargo build --workspace --release --all-targets --all-features --features openssl/vendored
+        run: cargo build --workspace --release --all-targets --features openssl/vendored --features all-tests
         env:
           CARGO_INCREMENTAL: 0
 
@@ -87,7 +87,7 @@ jobs:
           rust-cache: true
 
       - name: Cargo Build
-        run: cargo build --workspace --release --all-targets --all-features
+        run: cargo build --workspace --release --all-targets
         env:
           CARGO_INCREMENTAL: 0
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,7 +22,7 @@ jobs:
           rust-cache: true
 
       - name: Cargo Build
-        run: cargo build --workspace --all-targets --all-features --features openssl/vendored
+        run: cargo build --workspace --all-targets --features all-tests --features openssl/vendored
 
       - name: "Archive executable artifact"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: build release
         shell: bash
-        run: cargo build --all-features --release ${{ matrix.config.extraArgs }}
+        run: cargo build --release ${{ matrix.config.extraArgs }}
 
       - name: Sign the binary with GitHub OIDC token
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,13 +94,12 @@ vergen = { version = "^8.2.1", default-features = false, features = [
 
 [features]
 default = []
+all-tests = ["e2e-tests", "outbound-redis-tests", "config-provider-tests"]
+config-provider-tests = []
 e2e-tests = []
 outbound-redis-tests = []
-config-provider-tests = []
-outbound-pg-tests = []
-outbound-mysql-tests = []
-# llm-metal = ["spin-trigger-http/llm-metal"]
-# llm-cublas = ["spin-trigger-http/llm-cublas"]
+llm-metal = ["spin-trigger-http/llm-metal"]
+llm-cublas = ["spin-trigger-http/llm-cublas"]
 
 [workspace]
 members = ["crates/*", "sdk/rust", "sdk/rust/macro"]

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -30,6 +30,5 @@ uuid = { version = "1.4.1", features = ["v4"] }
 
 [features]
 default = []
-# Currently disabling this because CI is failing when this feature is enabled.
-# metal = ["llm/metal"]
-# cublas = ["llm/cublas"]
+metal = ["llm/metal"]
+cublas = ["llm/cublas"]

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -50,5 +50,5 @@ harness = false
 
 [features]
 default = []
-# llm-metal = ["spin-trigger/llm-metal"]
-# llm-cublas = ["spin-trigger/llm-cublas"]
+llm-metal = ["spin-trigger/llm-metal"]
+llm-cublas = ["spin-trigger/llm-cublas"]

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -49,5 +49,5 @@ tokio = { version = "1.23", features = ["rt", "macros"] }
 
 [features]
 default = []
-# llm-metal = ["spin-llm/metal"]
-# llm-cublas = ["spin-llm/cublas"]
+llm-metal = ["spin-llm/metal"]
+llm-cublas = ["spin-llm/cublas"]


### PR DESCRIPTION
Turns back on the off-by-default features for building llm GPU support (metal and cuda based). 

This tweaks CI to not build with "--all-features" but instead an "--features all-tests". In the future, we might want to consolidate our test feature flags into one feature flag. 