### PR TITLE
Try building aarch64 linux canary build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,15 +34,14 @@ jobs:
               target: "",
               targetDir: "target/release",
             }
-          # Temporarily turning off Linux aarch64 builds so we can generate a canary release.
-          # - {
-          #     os: "ubuntu-20.04",
-          #     arch: "aarch64",
-          #     extension: "",
-          #     extraArgs: "--features openssl/vendored --target aarch64-unknown-linux-gnu",
-          #     target: "aarch64-unknown-linux-gnu",
-          #     targetDir: "target/aarch64-unknown-linux-gnu/release",
-          #   }
+          - {
+              os: "ubuntu-20.04",
+              arch: "aarch64",
+              extension: "",
+              extraArgs: "--features openssl/vendored --target aarch64-unknown-linux-gnu",
+              target: "aarch64-unknown-linux-gnu",
+              targetDir: "target/aarch64-unknown-linux-gnu/release",
+            }
           - {
               os: "macos-latest",
               arch: "amd64",
@@ -112,6 +111,7 @@ jobs:
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
+          echo 'rustflags = ["-Ctarget-feature=+fp16"]' >> ${HOME}/.cargo/config.toml
 
       - name: build release
         shell: bash


### PR DESCRIPTION
This tries turning back on the aarch64 linux build.

It does this by passing the `+fp16` CPU feature to rustc to build with. This CPU feature is needed for simd instructions carried out by candle. I don't think this will present problems for users, but if we ever hear about anyone who wants to run Spin on a Linux aarch64 machine without that CPU feature, we can decide what to do then. 