### PR TITLE
oci: Inline small content into manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,7 +296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32568c56fda7f2f1173430298bddeb507ed44e99bd989ba1156a25534bff5d98"
 dependencies = [
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.3",
  "bytes",
  "dyn-clone",
  "futures",
@@ -374,9 +368,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64ct"
@@ -2609,7 +2603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16b4e41e289da3fd60e64f245246a97e78fab7b3788c6d8147b3ae7d9f5e533"
 dependencies = [
  "anyhow",
- "base64 0.21.0",
+ "base64 0.21.3",
  "serde",
  "serde_json",
 ]
@@ -2971,6 +2965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,7 +3221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19eb636edc7f6da0a1306e5258440c94b630993a2b5e4a93e69fd2bfc00287af"
 dependencies = [
  "anyhow",
- "base64 0.21.0",
+ "base64 0.21.3",
  "futures",
  "hrana-client-proto",
  "num-traits",
@@ -3667,7 +3670,7 @@ version = "0.30.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57349d5a326b437989b6ee4dc8f2f34b0cc131202748414712a8e7d98952fc8c"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.3",
  "bindgen",
  "bitflags 2.4.0",
  "bitvec",
@@ -4031,25 +4034,27 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "ouroboros"
-version = "0.15.6"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+checksum = "1c86de06555b970aec45229b27291b53154f21a5743a163419f4e4c0b065dcde"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
+ "static_assertions",
 ]
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.15.6"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+checksum = "8cad0c4b129e9696e37cb712b243777b90ef489a0bfaa0ac34e7d9b860e4f134"
 dependencies = [
- "Inflector",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4247,7 +4252,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.3",
  "serde",
 ]
 
@@ -4821,7 +4826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20b9b67e2ca7dd9e9f9285b759de30ff538aab981abaaf7bc9bd90b84a0126c3"
 dependencies = [
  "async-compression 0.4.1",
- "base64 0.21.0",
+ "base64 0.21.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5063,7 +5068,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.3",
 ]
 
 [[package]]
@@ -5549,6 +5554,7 @@ version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.3",
  "ouroboros",
  "serde",
  "serde_json",
@@ -5905,7 +5911,7 @@ name = "spin-oci"
 version = "1.5.0-pre0"
 dependencies = [
  "anyhow",
- "base64 0.21.0",
+ "base64 0.21.3",
  "dirs 4.0.0",
  "dkregistry",
  "docker_credential",
@@ -6839,7 +6845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7288,7 +7294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc78cfe1a758d1336f447a47af6ec05e0df2c03c93440d70faf80e17fbb001e"
 dependencies = [
  "anyhow",
- "base64 0.21.0",
+ "base64 0.21.3",
  "bincode",
  "directories-next",
  "file-per-thread-logger",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -7,7 +7,8 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-ouroboros = "0.15"
+base64 = "0.21.3"
+ouroboros = "0.18.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spin-core = { path = "../core" }


### PR DESCRIPTION
This adds support for inlining content into the spin manifest. The immediate goal is to work around a problem with OCI implementations (discussed here: https://github.com/distribution/distribution/discussions/4029). Additionally, inlining small content should be an overall bandwith saver as each OCI layer has to be fetched in a separate HTTP request.

This PR starts inlining small (<=128 bytes) content, but continues to also upload layers for this content unless `SPIN_OCI_SKIP_INLINED_FILES` is set. Once downstream infrastructure supports content inlining we can make this the default.