### PR TITLE
Update spin-componentize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5685,7 +5685,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=3653d24ee95b4efcc39de52b5c988b435f87712a#3653d24ee95b4efcc39de52b5c988b435f87712a"
+source = "git+https://github.com/fermyon/spin-componentize?rev=0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d#0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d"
 dependencies = [
  "anyhow",
  "wasm-encoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ tracing = { version = "0.1", features = ["log"] }
 wasmtime-wasi = { version = "10.0.1", features = ["tokio"] }
 wasi-common-preview1 = { package = "wasi-common", version = "10.0.1" }
 wasmtime = { version = "10.0.1", features = ["component-model"] }
-spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "3653d24ee95b4efcc39de52b5c988b435f87712a" }
+spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d" }
 
 [workspace.dependencies.bindle]
 git = "https://github.com/fermyon/bindle"


### PR DESCRIPTION
Closes #1748 

This is based off of this PR in spin-componentize: https://github.com/fermyon/spin-componentize/pull/20

Opening this PR now so we can run CI against it. Once that passes, we'll merge the spin-componentize PR and update this PR to point to the new commit on main. 