### PR TITLE
Add llm support for wit-bindgen 0.2 based modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d#0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d"
+source = "git+https://github.com/fermyon/spin-componentize?rev=c48303a5b520e21544af864d5ddb585a9c3c0194#c48303a5b520e21544af864d5ddb585a9c3c0194"
 dependencies = [
  "anyhow",
  "wasm-encoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=c48303a5b520e21544af864d5ddb585a9c3c0194#c48303a5b520e21544af864d5ddb585a9c3c0194"
+source = "git+https://github.com/fermyon/spin-componentize?rev=75fd5117d77415737e337a7fd15ed3317e2ad7a5#75fd5117d77415737e337a7fd15ed3317e2ad7a5"
 dependencies = [
  "anyhow",
  "wasm-encoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ tracing = { version = "0.1", features = ["log"] }
 wasmtime-wasi = { version = "10.0.1", features = ["tokio"] }
 wasi-common-preview1 = { package = "wasi-common", version = "10.0.1" }
 wasmtime = { version = "10.0.1", features = ["component-model"] }
-spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d" }
+spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "c48303a5b520e21544af864d5ddb585a9c3c0194" }
 
 [workspace.dependencies.bindle]
 git = "https://github.com/fermyon/bindle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ tracing = { version = "0.1", features = ["log"] }
 wasmtime-wasi = { version = "10.0.1", features = ["tokio"] }
 wasi-common-preview1 = { package = "wasi-common", version = "10.0.1" }
 wasmtime = { version = "10.0.1", features = ["component-model"] }
-spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "c48303a5b520e21544af864d5ddb585a9c3c0194" }
+spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "75fd5117d77415737e337a7fd15ed3317e2ad7a5" }
 
 [workspace.dependencies.bindle]
 git = "https://github.com/fermyon/bindle"


### PR DESCRIPTION
Brings in changes from https://github.com/fermyon/spin-componentize/pull/19 which adds llm interface support for wit-bindgen 0.2 based wasm modules. 