### PR TITLE
docs(README.md): sqlite storage is now supported in the go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The table below summarizes the [feature support](https://developer.fermyon.com/s
 | [Outbound HTTP](https://developer.fermyon.com/spin/rust-components.md#sending-outbound-http-requests) | Supported | Supported | Supported | Supported | Supported |
 | [Configuration Variables](https://developer.fermyon.com/spin/variables) | Supported | Supported | Supported | Supported | Supported |
 | [Key Value Storage](https://developer.fermyon.com/spin/kv-store-api-guide) | Supported | Supported | Supported | Supported | Not Supported |
-| [Sqlite Storage](https://developer.fermyon.com/spin/sqlite-api-guide) | Supported | Supported | Supported | Not Supported | Not Supported |
+| [Sqlite Storage](https://developer.fermyon.com/spin/sqlite-api-guide) | Supported | Supported | Supported | Supported | Not Supported |
 | [MySQL](https://developer.fermyon.com/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported | Not Supported | Not Supported | Not Supported | Not Supported |
 | [PostgreSQL](https://developer.fermyon.com/spin/rdbms-storage#using-mysql-and-postgresql-from-applications) | Supported | Not Supported | Not Supported | Not Supported | Supported |
 | [Outbound Redis](https://developer.fermyon.com/spin/rust-components.md#storing-data-in-redis-from-rust-components) | Supported | Supported | Supported | Supported | Supported |


### PR DESCRIPTION
Ref https://github.com/fermyon/spin/pull/1714

Depends on:

- [x] https://github.com/fermyon/developer/pull/883
- [x] Spin 1.5 release