### PR TITLE
chore(*): pre-release version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-testing"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
@@ -5550,7 +5550,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-app"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "spin-bindle"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "bindle",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5679,7 +5679,7 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5851,7 +5851,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "indexmap",
  "serde",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.21.3",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5991,7 +5991,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "http",
@@ -6086,7 +6086,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6164,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "wasmtime",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 rust-version = "1.67"
 
 [workspace.package]
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,4 +1,4 @@
-SDK_VERSION ?= v1.5.0-pre0
+SDK_VERSION ?= v1.6.0-pre0
 
 bump-versions: bump-go-versions bump-rust-versions
 

--- a/tests/http/headers-env-routes-test/Cargo.lock
+++ b/tests/http/headers-env-routes-test/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.5.0-pre0"
+version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
1.5.0 will be out shortly; bumps versions to indicate main uses a 1.6.0-pre0 version