### PR TITLE
use upstream release-action and update version from 1.10.0 to 1.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
           delete_release: true
 
       - name: Recreate canary tag and release
-        uses: rajatjindal/release-action@v0.0.1
+        uses: ncipollo/release-action@v1.13.0
         with:
           tag: canary
           allowUpdates: true


### PR DESCRIPTION
this reverts to using the upstream version of release-action (instead of fork under my account). These were changed as part of #1620 