### PR TITLE
Update MSRV to reflect Wasmtime requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 license = "Apache-2.0 WITH LLVM-exception"
-rust-version = "1.67"
+rust-version = "1.71"
 
 [workspace.package]
 version = "1.6.0-pre0"


### PR DESCRIPTION
Wasmtime's minimum supported Rust version is now 1.71.  CI is already updated but this puts it in Cargo.toml to be visible to contributors.