### PR TITLE
syntax fix to run only on linux/amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Copy Binary to S3 - ${{ env.RELEASE_VERSION }}
-        if: runner.os == 'linux' && matrix.config.arch == 'amd64' && ${{ github.repository_owner == 'fermyon' }}
+        if: runner.os == 'linux' && matrix.config.arch == 'amd64' && github.repository_owner == 'fermyon'
         run: |
           aws s3 cp _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz s3://${{ secrets.SPIN_RELEASE_ARTIFACTS_REPO }}/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz --acl public-read
 


### PR DESCRIPTION
This seems like a weird syntax thing with GitHub actions

`runner.os == 'linux' && matrix.config.arch == 'amd64' && github.repository_owner == 'fermyon'` works but `runner.os == 'linux' && matrix.config.arch == 'amd64' && ${{ github.repository_owner == 'fermyon' }}`  does not.

tried it here: https://github.com/rajatjindal/test-action/blob/main/.github/workflows/arch2.yaml