### PR TITLE
Allow other ai models besides while known ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,7 +3174,12 @@ version = "0.2.0-dev"
 source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663#2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663"
 dependencies = [
  "llm-base",
+ "llm-bloom",
+ "llm-gpt2",
+ "llm-gptj",
+ "llm-gptneox",
  "llm-llama",
+ "llm-mpt",
  "serde",
  "tracing",
 ]
@@ -3200,12 +3205,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "llm-bloom"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663#2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663"
+dependencies = [
+ "llm-base",
+]
+
+[[package]]
+name = "llm-gpt2"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663#2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663"
+dependencies = [
+ "bytemuck",
+ "llm-base",
+]
+
+[[package]]
+name = "llm-gptj"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663#2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663"
+dependencies = [
+ "llm-base",
+]
+
+[[package]]
+name = "llm-gptneox"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663#2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663"
+dependencies = [
+ "llm-base",
+]
+
+[[package]]
 name = "llm-llama"
 version = "0.2.0-dev"
 source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663#2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663"
 dependencies = [
  "llm-base",
  "tracing",
+]
+
+[[package]]
+name = "llm-mpt"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663#2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663"
+dependencies = [
+ "llm-base",
 ]
 
 [[package]]

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 bytesize = "1.1"
 llm = { git = "https://github.com/rustformers/llm", rev = "2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663", features = [
     "tokenizers-remote",
-    "llama",
+    "models",
 ], default-features = false }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod host_component;
 
-use llm::ModelArchitecture;
 use spin_app::MetadataKey;
 use spin_core::async_trait;
 use spin_world::llm::{self as wasi_llm};
@@ -69,22 +68,6 @@ impl wasi_llm::Host for LlmDispatch {
             return Ok(Err(access_denied_error(&m)));
         }
         Ok(self.engine.generate_embeddings(m, data).await)
-    }
-}
-
-pub fn model_name(model: &wasi_llm::InferencingModel) -> Result<&str, wasi_llm::Error> {
-    match model.as_str() {
-        "llama2-chat" | "codellama-instruct" => Ok(model.as_str()),
-        _ => Err(wasi_llm::Error::ModelNotSupported),
-    }
-}
-
-pub fn model_arch(
-    model: &wasi_llm::InferencingModel,
-) -> Result<ModelArchitecture, wasi_llm::Error> {
-    match model.as_str() {
-        "llama2-chat" | "codellama-instruct" => Ok(ModelArchitecture::Llama),
-        _ => Err(wasi_llm::Error::ModelNotSupported),
     }
 }
 


### PR DESCRIPTION
This allows other AI models besides the two well known models: llama2-chat and codellama. 

In order to use other models, the user must first place their model in the right location in the model registry (i.e., in `.spin/ai-models`). The well known models continue to work if the are placed at the top-level of the registry. However, any other model can be placed in a subdirectory named after their model architecture (e.g., llama based models go in `.spin/ai-models/llama`, bloom based models in `.spin/ai-models/bloom`, etc.). The model binary must be named after the model itself. So if you're using a llama based model called "llama2-norwegian" it should be at the path `.spin/ai-models/llama/llama2-norwegian`. 

Spin first checks for well known models and then traverses the model registry for the model file. 

All models must be in the GGML format, and the supported models can be found at [this link](https://github.com/rustformers/llm/blob/84800b02a7a96f62c0c9c03a38c36cb23bf4b2ec/crates/llm/src/lib.rs#L174-L181).

**Note**: this is currently only for inferencing. I would imagine that the exact same scheme could be used for embeddings, but I simply ran out of time to implement it today. If everyone is happy with this approach, I will add the same support for embeddings models. 

Note also that some SDKs still have an allow list of models that are supported. Those will need to be updated as well. 