### PR TITLE
Add Azure Key Vault config provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "async-priority-channel"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,13 +325,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f20eb684aea745292c540173304383c9cba9697d1c31d307620a57d6f878fa9"
+dependencies = [
+ "async-trait",
+ "base64 0.21.3",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.8",
+ "http-types",
+ "log",
+ "paste",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "time 0.3.20",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "azure_data_cosmos"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73dede39a91e205b2050f250f6e31ed7c4c72be7ee694930c155c4d7636fe8e1"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.11.0",
  "bytes",
  "futures",
  "hmac",
@@ -334,6 +369,43 @@ dependencies = [
  "time 0.3.20",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15ab021e72fa7196fa8406951f7e85a3476e4968568b2ce3866d2ceed831655"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core 0.15.0",
+ "fix-hidden-lifetime-bug",
+ "futures",
+ "log",
+ "oauth2",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time 0.3.20",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_security_keyvault"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ad719cf9f226fde9519a025b67c3b3bd93da4819e5355b95beceef94eb29a2"
+dependencies = [
+ "async-trait",
+ "azure_core 0.15.0",
+ "const_format",
+ "futures",
+ "serde",
+ "serde_json",
+ "time 0.3.20",
+ "url",
 ]
 
 [[package]]
@@ -1103,6 +1175,26 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1961,6 +2053,26 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fix-hidden-lifetime-bug"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ae9c2016a663983d4e40a9ff967d6dcac59819672f0b47f2b17574e99c33c8"
+dependencies = [
+ "fix-hidden-lifetime-bug-proc_macros",
+]
+
+[[package]]
+name = "fix-hidden-lifetime-bug-proc_macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c81935e123ab0741c4c4f0d9b8377e5fb21d3de7e062fa4b1263b1fbcba1ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5710,6 +5822,9 @@ version = "1.6.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "azure_core 0.15.0",
+ "azure_identity",
+ "azure_security_keyvault",
  "dotenvy",
  "once_cell",
  "serde",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -7,6 +7,9 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+azure_core = "0.15.0"
+azure_identity = "0.15.0"
+azure_security_keyvault = "0.15.0"
 dotenvy = "0.15"
 once_cell = "1"
 spin-app = { path = "../app" }

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -7,6 +7,7 @@ use crate::Key;
 /// Environment variable based provider.
 pub mod env;
 pub mod vault;
+pub mod azkv;
 
 /// A config provider.
 #[async_trait]

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 
 use crate::Key;
 
+pub mod azkv;
 /// Environment variable based provider.
 pub mod env;
 pub mod vault;
-pub mod azkv;
 
 /// A config provider.
 #[async_trait]

--- a/crates/config/src/provider/azkv.rs
+++ b/crates/config/src/provider/azkv.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use azure_core::StatusCode;
+use azure_identity::{ClientSecretCredential, TokenCredentialOptions};
+use azure_security_keyvault::KeyvaultClient;
+
+use crate::{Key, Provider};
+
+/// A config Provider that uses Azure Key Vault.
+#[derive(Debug)]
+pub struct AzureKeyVaultProvider {
+    client_id: String,
+    client_secret: String,
+    tenant_id: String,
+    url: String,
+}
+
+impl AzureKeyVaultProvider {
+    pub fn new(
+        client_id: impl Into<String>,
+        client_secret: impl Into<String>,
+        tenant_id: impl Into<String>,
+        url: impl Into<String>,
+    ) -> Self {
+        Self {
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            tenant_id: tenant_id.into(),
+            url: url.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for AzureKeyVaultProvider {
+    async fn get(&self, key: &Key) -> Result<Option<String>> {
+        let http_client = azure_core::new_http_client();
+        let creds = ClientSecretCredential::new(
+            http_client,
+            self.tenant_id.clone(),
+            self.client_id.clone(),
+            self.client_secret.clone(),
+            TokenCredentialOptions::default(),
+        );
+
+        let kv_client = KeyvaultClient::new(&self.url, Arc::new(creds))?;
+        let secret_client = kv_client.secret_client();
+
+        match secret_client.get(key.0).await {
+            Ok(secret) => Ok(Some(secret.value)),
+            Err(err) => {
+                let Some(http_err) = err.as_http_error() else {
+                    return Err(err).context("Failed to check Azure Key Vault for config");
+                };
+                let StatusCode::NotFound = http_err.status() else {
+                    return Err(err).context("Failed to check Azure Key Vault for config");
+                };
+                Ok(None)
+            }
+        }
+    }
+}

--- a/crates/trigger/src/runtime_config/config_provider.rs
+++ b/crates/trigger/src/runtime_config/config_provider.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use serde::Deserialize;
-use spin_config::provider::{env::EnvProvider, vault::VaultProvider};
+use spin_config::provider::{env::EnvProvider, vault::VaultProvider, azkv::AzureKeyVaultProvider};
 
 use super::RuntimeConfig;
 
@@ -15,6 +15,7 @@ const DEFAULT_ENV_PREFIX: &str = "SPIN_CONFIG";
 pub enum ConfigProviderOpts {
     Env(EnvConfigProviderOpts),
     Vault(VaultConfigProviderOpts),
+    AzureKeyVault(AzureKeyVaultConfigProviderOpts),
 }
 
 impl ConfigProviderOpts {
@@ -26,6 +27,7 @@ impl ConfigProviderOpts {
         match self {
             Self::Env(opts) => opts.build_provider(),
             Self::Vault(opts) => opts.build_provider(),
+            Self::AzureKeyVault(opts) => opts.build_provider(),
         }
     }
 }
@@ -75,6 +77,26 @@ impl VaultConfigProviderOpts {
             &self.token,
             &self.mount,
             self.prefix.as_deref(),
+        ))
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AzureKeyVaultConfigProviderOpts {
+    pub client_id: String,
+    pub client_secret: String,
+    pub tenant_id: String,
+    pub url: String,
+}
+
+impl AzureKeyVaultConfigProviderOpts {
+    pub fn build_provider(&self) -> ConfigProvider {
+        Box::new(AzureKeyVaultProvider::new(
+            &self.client_id,
+            &self.client_secret,
+            &self.tenant_id,
+            &self.url,
         ))
     }
 }

--- a/crates/trigger/src/runtime_config/config_provider.rs
+++ b/crates/trigger/src/runtime_config/config_provider.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use serde::Deserialize;
-use spin_config::provider::{env::EnvProvider, vault::VaultProvider, azkv::AzureKeyVaultProvider};
+use spin_config::provider::{azkv::AzureKeyVaultProvider, env::EnvProvider, vault::VaultProvider};
 
 use super::RuntimeConfig;
 

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -265,8 +265,8 @@ impl WatchCommand {
         };
         let wasm_globs = manifest.components.iter().filter_map(|c| {
             let RawModuleSource::FileReference(path) = &c.source else {
-                    return None;
-                };
+                return None;
+            };
             path.to_str().map(String::from)
         });
         let asset_globs = manifest


### PR DESCRIPTION
This PR adds **Azure Key Vault** as config provider to `spin` as suggest in #1737

## Authentication

Authentication is implemented using `ClientCredentialFlow` leveraging `clientId` and `clientSecret`  of an Azure Service Principal (SP).

The SP must have the `Key Vault Secrets User` role assigned on the scope of the desired Azure Key Vault instance. Additionally, RBAC must be enabled on the Azure Key Vault instance.

## Loading Secret Values

Although Azure Key Vault supports multiple versions per secret, this implementation loads the latest version of a particular secret. 

## Runtime Configuration File

Once necessary SP and Azure Key Vault have been provisioned and Role Assignment is in place, users must provide a corresponding runtime config file:

```toml
[[config_provider]]
type = "azure_key_vault"
url = "https://mysecrets.vault.azure.net/"
client_id = "00000000-0000-0000-0000-000000000000"
client_secret = "SomeSauce"
tenant_id = "00000000-0000-0000-0000-000000000000"
```