### PR TITLE
Make local llm support an on-by-default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,13 +97,14 @@ vergen = { version = "^8.2.1", default-features = false, features = [
 ] }
 
 [features]
-default = []
+default = ["llm"]
 all-tests = ["e2e-tests", "outbound-redis-tests", "config-provider-tests"]
 config-provider-tests = []
 e2e-tests = []
 outbound-redis-tests = []
-llm-metal = ["spin-trigger-http/llm-metal"]
-llm-cublas = ["spin-trigger-http/llm-cublas"]
+llm = ["spin-trigger-http/llm"]
+llm-metal = ["llm", "spin-trigger-http/llm-metal"]
+llm-cublas = ["llm", "spin-trigger-http/llm-cublas"]
 
 [workspace]
 members = ["crates/*", "sdk/rust", "sdk/rust/macro"]

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8.5"
 safetensors = "0.3.3"
 serde = { version = "1.0.150", features = ["derive"] }
 spin-core = { path = "../core" }
-spin-llm = { path = "../llm"}
+spin-llm = { path = "../llm" }
 spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
 tokenizers = "0.13.4"

--- a/crates/llm-local/src/lib.rs
+++ b/crates/llm-local/src/lib.rs
@@ -21,11 +21,6 @@ use std::{
 };
 use tokenizers::PaddingParams;
 
-#[derive(Default)]
-pub struct LLmOptions {
-    pub use_gpu: bool,
-}
-
 #[derive(Clone)]
 pub struct LocalLlmEngine {
     registry: PathBuf,

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -49,6 +49,6 @@ name = "baseline"
 harness = false
 
 [features]
-default = []
-llm-metal = ["spin-trigger/llm-metal"]
-llm-cublas = ["spin-trigger/llm-cublas"]
+llm = ["spin-trigger/llm"]
+llm-metal = ["llm", "spin-trigger/llm-metal"]
+llm-cublas = ["llm", "spin-trigger/llm-cublas"]

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -26,7 +26,7 @@ spin-sqlite-inproc = { path = "../sqlite-inproc" }
 spin-sqlite-libsql = { path = "../sqlite-libsql" }
 spin-world = { path = "../world" }
 spin-llm = { path = "../llm" }
-spin-llm-local = { path = "../llm-local" }
+spin-llm-local = { path = "../llm-local", optional = true }
 spin-llm-remote-http = { path = "../llm-remote-http" }
 sanitize-filename = "0.4"
 serde = "1.0"
@@ -50,6 +50,6 @@ toml = "0.5"
 tokio = { version = "1.23", features = ["rt", "macros"] }
 
 [features]
-default = []
-llm-metal = ["spin-llm-local/metal"]
-llm-cublas = ["spin-llm-local/cublas"]
+llm = ["spin-llm-local"]
+llm-metal = ["llm", "spin-llm-local/metal"]
+llm-cublas = ["llm", "spin-llm-local/cublas"]

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -6,6 +6,7 @@ use serde::de::DeserializeOwned;
 use spin_app::Loader;
 use spin_common::{arg_parser::parse_kv, sloth};
 
+use crate::runtime_config::llm::LLmOptions;
 use crate::runtime_config::sqlite::SqlitePersistenceMessageHook;
 use crate::stdio::StdioLoggingTriggerHooks;
 use crate::{
@@ -150,7 +151,7 @@ where
         let init_data = crate::HostComponentInitData::new(
             &*self.key_values,
             &*self.sqlite_statements,
-            spin_llm_local::LLmOptions { use_gpu: true },
+            LLmOptions { use_gpu: true },
         );
 
         let loader = TriggerLoader::new(working_dir, self.allow_transient_write);

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, marker::PhantomData, path::PathBuf};
 use anyhow::{anyhow, Context, Result};
 pub use async_trait::async_trait;
 use indexmap::IndexMap;
+use runtime_config::llm::LLmOptions;
 use serde::de::DeserializeOwned;
 
 use spin_app::{App, AppComponent, AppLoader, AppTrigger, Loader, OwnedApp};
@@ -164,7 +165,7 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
 pub struct HostComponentInitData {
     kv: Vec<(String, String)>,
     sqlite: Vec<String>,
-    llm: spin_llm_local::LLmOptions,
+    llm: LLmOptions,
 }
 
 impl HostComponentInitData {
@@ -174,7 +175,7 @@ impl HostComponentInitData {
     pub fn new(
         key_value_init_values: impl Into<Vec<(String, String)>>,
         sqlite_init_statements: impl Into<Vec<String>>,
-        llm: spin_llm_local::LLmOptions,
+        llm: LLmOptions,
     ) -> Self {
         Self {
             kv: key_value_init_values.into(),

--- a/crates/trigger/src/runtime_config/llm.rs
+++ b/crates/trigger/src/runtime_config/llm.rs
@@ -1,19 +1,32 @@
-use spin_llm_local::LocalLlmEngine;
+use async_trait::async_trait;
+use spin_llm::LlmEngine;
 use spin_llm_remote_http::RemoteHttpLlmEngine;
+use spin_world::llm as wasi_llm;
 use url::Url;
+
+#[derive(Default)]
+pub struct LLmOptions {
+    pub use_gpu: bool,
+}
 
 pub(crate) async fn build_component(
     runtime_config: &crate::RuntimeConfig,
     use_gpu: bool,
 ) -> spin_llm::LlmComponent {
     match runtime_config.llm_compute() {
+        #[cfg(feature = "llm")]
         LlmComputeOpts::Spin => {
             let path = runtime_config
                 .state_dir()
                 .unwrap_or_default()
                 .join("ai-models");
-            let engine = LocalLlmEngine::new(path, use_gpu).await;
+            let engine = spin_llm_local::LocalLlmEngine::new(path, use_gpu).await;
             spin_llm::LlmComponent::new(move || Box::new(engine.clone()))
+        }
+        #[cfg(not(feature = "llm"))]
+        LlmComputeOpts::Spin => {
+            let _ = use_gpu;
+            spin_llm::LlmComponent::new(move || Box::new(NoopLlmEngine.clone()))
         }
         LlmComputeOpts::RemoteHttp(config) => {
             tracing::log::info!("Using remote compute for LLMs");
@@ -35,4 +48,31 @@ pub enum LlmComputeOpts {
 pub struct RemoteHttpComputeOpts {
     url: Url,
     auth_token: String,
+}
+
+#[derive(Clone)]
+struct NoopLlmEngine;
+
+#[async_trait]
+impl LlmEngine for NoopLlmEngine {
+    async fn infer(
+        &mut self,
+        _model: wasi_llm::InferencingModel,
+        _prompt: String,
+        _params: wasi_llm::InferencingParams,
+    ) -> Result<wasi_llm::InferencingResult, wasi_llm::Error> {
+        Err(wasi_llm::Error::RuntimeError(
+            "Local LLM operations are not supported in this version of Spin.".into(),
+        ))
+    }
+
+    async fn generate_embeddings(
+        &mut self,
+        _model: wasi_llm::EmbeddingModel,
+        _data: Vec<String>,
+    ) -> Result<wasi_llm::EmbeddingsResult, wasi_llm::Error> {
+        Err(wasi_llm::Error::RuntimeError(
+            "Local LLM operations are not supported in this version of Spin.".into(),
+        ))
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/fermyon/spin/issues/1786

This moves local llm support to an on-by-default feature - the default experience of using Spin does not change at all. For those users who need to run Spin in an environment where local llm support does not make sense, then building Spin without this feature might be the right path for them. This can be done with `cargo build --no-default-features -F llm`. 

If the feature is not enabled but the user still tries to run llm inferencing locally, they will get a runtime error saying that their build of Spin does not support local llm operations.