### PR TITLE
e2e-tests: disable connection pool

### DIFF
--- a/crates/e2e-testing/src/http_asserts.rs
+++ b/crates/e2e-testing/src/http_asserts.rs
@@ -67,7 +67,9 @@ pub async fn create_request(method: Method, url: &str, body: &str) -> Result<Req
 
 pub fn create_client() -> Client<HttpsConnector<HttpConnector>> {
     let connector = HttpsConnector::new();
-    Client::builder().build::<_, hyper::Body>(connector)
+    Client::builder()
+        .pool_max_idle_per_host(0)
+        .build::<_, hyper::Body>(connector)
 }
 
 pub async fn make_request(method: Method, path: &str, body: &str) -> Result<Response<Body>> {


### PR DESCRIPTION
We have been seeing error `104 connection reset by peer` when running e2e tests with cloud. There have been some issues reported around connection pool in hyper. The suggested workaround is to disable the idle connection pool. This PR disables the idle connection pool for hyper while making http requests during test assertions. 