### PR TITLE
chore(docs): re-add base config to spin.toml

### DIFF
--- a/docs/spin.toml
+++ b/docs/spin.toml
@@ -3,7 +3,7 @@ name = "spin-docs"
 version = "0.1.0"
 description = "The Spin documentation website running on... Spin."
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
-trigger = { type = "http" }
+trigger = { type = "http", base = "/" }
 
 [[component]]
 id = "redirect-download"


### PR DESCRIPTION
We're still pinned to an earlier version of spin when [publishing (via bindle)](https://github.com/fermyon/spin/blob/main/deploy/publish-spin-docs.nomad) and deploying the spin docs 'website' (comprised of redirects from spin.fermyon.dev -> developer.fermyon.com/spin), so for now, we need the `base` config.

Fixes deployment error as seen recentlly in https://github.com/fermyon/spin/actions/runs/6317502067

Otherwise, the issue to move the website deployment to cloud is https://github.com/fermyon/spin/issues/1819 (and we can then use latest spin, cloud plugin, etc via https://github.com/fermyon/actions)