### PR TITLE
Plugins search

### DIFF
--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -29,6 +29,9 @@ pub enum PluginCommands {
     /// List available or installed plugins.
     List(List),
 
+    /// Search for plugins by name.
+    Search(Search),
+
     /// Remove a plugin from your installation.
     Uninstall(Uninstall),
 
@@ -44,6 +47,7 @@ impl PluginCommands {
         match self {
             PluginCommands::Install(cmd) => cmd.run().await,
             PluginCommands::List(cmd) => cmd.run().await,
+            PluginCommands::Search(cmd) => cmd.run().await,
             PluginCommands::Uninstall(cmd) => cmd.run().await,
             PluginCommands::Upgrade(cmd) => cmd.run().await,
             PluginCommands::Update => update().await,
@@ -316,7 +320,7 @@ impl Upgrade {
     }
 }
 
-/// Install plugins from remote source
+/// List available or installed plugins.
 #[derive(Parser, Debug)]
 pub struct List {
     /// List only installed plugins.
@@ -404,6 +408,24 @@ impl List {
                 println!("{} {}{}{}", p.name, p.version, installed, compat);
             }
         }
+    }
+}
+
+/// Search for plugins by name.
+#[derive(Parser, Debug)]
+pub struct Search {
+    /// The text to search for. If omitted, all plugins are returned.
+    pub filter: Option<String>,
+}
+
+impl Search {
+    async fn run(&self) -> anyhow::Result<()> {
+        let list_cmd = List {
+            installed: false,
+            filter: self.filter.clone(),
+        };
+
+        list_cmd.run().await
     }
 }
 

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -322,6 +322,10 @@ pub struct List {
     /// List only installed plugins.
     #[clap(long = "installed", takes_value = false)]
     pub installed: bool,
+
+    /// Filter the list to plugins containing this string.
+    #[clap(long = "filter")]
+    pub filter: Option<String>,
 }
 
 impl List {
@@ -333,6 +337,10 @@ impl List {
         }?;
 
         plugins.sort_by(|p, q| p.cmp(q));
+
+        if let Some(filter) = self.filter.as_ref() {
+            plugins.retain(|p| p.name.contains(filter));
+        }
 
         Self::print(&plugins);
         Ok(())


### PR DESCRIPTION
Fixes #1716.

* `spin plugins list` now fetches latest before printing list
* `spin plugins list --filter` for filtering list
* `spin plugins search <text>` as alias for `spin plugins list --filter <text>`

#1716 also proposes that `spin plugins list` be changed so that it always behaves per the current `--installed` option.  This is a breaking change, so would need to wait for a major version, so is not included in this PR; it would be good to capture that as a separate issue.

#1716 also includes a proposal to add tags to plugins, and to have filtering check them as well as the name; it would be good to capture that as a separate issue too (as it requires other design decisions about how tags are shown and used).
