### PR TITLE
Remove Hippo dependency

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -45,17 +45,6 @@ inputs:
     required: false
     type: string
 
-  hippo:
-    description: 'setup hippo'
-    required: false
-    default: 'false'
-    type: bool
-  hippo-version:
-    description: 'Hippo version to setup'
-    default: 'v0.19.0'
-    required: false
-    type: string
-
   golang:
     description: 'setup golang'
     required: false
@@ -122,14 +111,6 @@ runs:
       if: ${{ inputs.nomad == 'true' }}
       with:
         version: ${{ inputs.nomad-version }}
-
-
-    ## Install hippo
-    - name: Install hippo
-      uses: rajatjindal/setup-actions/hippo@v0.0.1
-      if: ${{ inputs.hippo == 'true' }}
-      with:
-        version: ${{ inputs.hippo-version }}
 
     ## Install wasmtime
     - name: Install wasmtime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,6 @@ jobs:
           rust-cache: true
           bindle: true
           nomad: true
-          hippo: true
 
       # FIXME: THIS IS THE SHORTEST-TERM OF ALL SHORT-TERM FIXES
       - name: Rescue some space for Linux tests

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -45,7 +45,6 @@ jobs:
           rust-wasm: true
           bindle: true
           nomad: true
-          hippo: true
 
       - name: Install cargo-tarpaulin binary crate
         uses: actions-rs/install@v0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
  "oauth2",
  "rand 0.7.3",
  "reqwest",
- "semver 1.0.16",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -1047,17 +1047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,18 +1606,6 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61579ada4ec0c6031cfac3f86fdba0d195a7ebeb5e36693bd53cb5999a25beeb"
-dependencies = [
- "console",
- "lazy_static",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
-name = "dialoguer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
@@ -1841,19 +1818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2572,50 +2536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hippo"
-version = "0.16.1"
-source = "git+https://github.com/deislabs/hippo-cli?tag=v0.16.1#73315f55fadd2bb027bb2277c2d42c8fd4843922"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap 3.2.24",
- "colored",
- "dialoguer 0.9.0",
- "dirs 4.0.0",
- "dunce",
- "env_logger",
- "futures",
- "glob",
- "hippo-openapi",
- "itertools 0.10.5",
- "log",
- "mime_guess",
- "regex",
- "reqwest",
- "semver 0.11.0",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tokio",
- "toml 0.5.11",
- "uuid",
-]
-
-[[package]]
-name = "hippo-openapi"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02b15373ff8d49727e8a61f6fd27bea15115fd80030bd240bbb1a18e08bd130"
-dependencies = [
- "reqwest",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,12 +2618,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -4906,7 +4820,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -5014,7 +4927,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver",
 ]
 
 [[package]]
@@ -5249,30 +5162,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -5650,7 +5544,7 @@ dependencies = [
  "mime_guess",
  "regex",
  "reqwest",
- "semver 1.0.16",
+ "semver",
  "serde",
  "serde_json",
  "spin-app",
@@ -5695,14 +5589,12 @@ dependencies = [
  "comfy-table",
  "command-group",
  "ctrlc",
- "dialoguer 0.10.3",
+ "dialoguer",
  "dirs 4.0.0",
  "dunce",
  "e2e-testing",
  "futures",
  "glob",
- "hippo",
- "hippo-openapi",
  "hyper",
  "indicatif 0.17.6",
  "is-terminal",
@@ -5718,7 +5610,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rpassword",
- "semver 1.0.16",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -5973,7 +5865,7 @@ dependencies = [
  "path-absolutize",
  "regex",
  "reqwest",
- "semver 1.0.16",
+ "semver",
  "serde",
  "serde_json",
  "shellexpand 3.1.0",
@@ -6048,7 +5940,7 @@ dependencies = [
  "is-terminal",
  "path-absolutize",
  "reqwest",
- "semver 1.0.16",
+ "semver",
  "serde",
  "serde_json",
  "spin-common",
@@ -6143,7 +6035,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "console",
- "dialoguer 0.10.3",
+ "dialoguer",
  "dirs 3.0.2",
  "fs_extra",
  "heck 0.4.1",
@@ -6157,7 +6049,7 @@ dependencies = [
  "path-absolutize",
  "pathdiff",
  "regex",
- "semver 1.0.16",
+ "semver",
  "serde",
  "spin-common",
  "spin-loader",
@@ -7069,7 +6961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.8",
- "serde",
 ]
 
 [[package]]
@@ -7359,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
 dependencies = [
  "indexmap 1.9.2",
- "semver 1.0.16",
+ "semver",
 ]
 
 [[package]]
@@ -7369,7 +7260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e986b010f47fcce49cf8ea5d5f9e5d2737832f12b53ae8ae785bbe895d0877bf"
 dependencies = [
  "indexmap 2.0.0",
- "semver 1.0.16",
+ "semver",
 ]
 
 [[package]]
@@ -8307,7 +8198,7 @@ dependencies = [
  "indexmap 1.9.2",
  "log",
  "pulldown-cmark 0.8.0",
- "semver 1.0.16",
+ "semver",
  "unicode-xid",
  "url",
 ]
@@ -8323,7 +8214,7 @@ dependencies = [
  "indexmap 2.0.0",
  "log",
  "pulldown-cmark 0.9.3",
- "semver 1.0.16",
+ "semver",
  "unicode-xid",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,6 @@ dirs = "4.0"
 dunce = "1.0"
 futures = "0.3"
 glob = "0.3.1"
-hippo-openapi = "0.10"
-hippo = { git = "https://github.com/deislabs/hippo-cli", tag = "v0.16.1" }
 indicatif = "0.17.3"
 is-terminal = "0.4"
 itertools = "0.11.0"


### PR DESCRIPTION
I can't find anywhere these are used in the code.  Hippo _is_ alluded to in the CI dependencies (e.g. https://github.com/fermyon/spin/blob/268883366d57712de1a9cc33135238b46013fe86/.github/workflows/build.yml#L119) - I am not sure if that signals that the Hippo crates are still needed somewhere?  (Or if that's redundant too?)
