### PR TITLE
sqlite sdk throws "database full" error when too many connections are opened

### DIFF
--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -83,9 +83,9 @@ impl spin_world::sqlite::Host for SqliteDispatch {
             .await
             .and_then(|conn| conn.ok_or(spin_world::sqlite::Error::NoSuchDatabase))
             .and_then(|conn| {
-                self.connections
-                    .push(conn)
-                    .map_err(|()| spin_world::sqlite::Error::DatabaseFull)
+                self.connections.push(conn).map_err(|()| {
+                    spin_world::sqlite::Error::Io("too many connections opened".to_string())
+                })
             }))
     }
 


### PR DESCRIPTION
It seems like we maintain the list of sqlite connections and it has limited size. Due to a bug in golang sdk, I was opening connection for each execute statement, and was hitting this issue.

The error msg `Database full` didn't help either and I was searching internet for what could be causing that. But was finally able to figure out the connection issue in the golang sdk.

This PR changes the error msg to make it more clear as to what the problem is. I am happy to change the error msg if there are other suggestions. thank you
