### PR TITLE
Rescue space for Linux unit tests to run for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,13 @@ jobs:
           nomad: true
           hippo: true
 
+      # FIXME: THIS IS THE SHORTEST-TERM OF ALL SHORT-TERM FIXES
+      - name: Rescue some space for Linux tests
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          rm -rf ./target/debug/deps
+          rm -rf ./target/debug/build
+
       - name: Cargo Unit Tests
         run: |
           make test-unit


### PR DESCRIPTION
This seems to free up enough space for unit tests to pass.  It's not a long term solution though.  We need to figure out a proper plan, whether that's using the same larger runner as for e2e, or breaking things up a bit more, or what.