### PR TITLE
Always print warning on blocked outbound HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,6 +4035,7 @@ dependencies = [
  "spin-app",
  "spin-core",
  "spin-world",
+ "terminal",
  "tracing",
  "url",
 ]

--- a/crates/outbound-http/Cargo.toml
+++ b/crates/outbound-http/Cargo.toml
@@ -14,5 +14,6 @@ reqwest = { version = "0.11", features = ["gzip"] }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }
+terminal = { path = "../terminal" }
 tracing = { workspace = true }
 url = "2.2.1"

--- a/crates/outbound-http/src/lib.rs
+++ b/crates/outbound-http/src/lib.rs
@@ -53,6 +53,9 @@ impl outbound_http::Host for OutboundHttp {
                 .map_err(|_| HttpError::RuntimeError)?
             {
                 tracing::log::info!("Destination not allowed: {}", req.uri);
+                terminal::warn!("A component tried to make a HTTP request to '{}'.", req.uri);
+                eprintln!("The component was configured not to allow requests to this host.");
+                eprintln!("To allow requests, add the host to `allowed_http_posts`.");
                 return Err(HttpError::DestinationNotAllowed);
             }
 

--- a/crates/outbound-http/src/lib.rs
+++ b/crates/outbound-http/src/lib.rs
@@ -53,9 +53,10 @@ impl outbound_http::Host for OutboundHttp {
                 .map_err(|_| HttpError::RuntimeError)?
             {
                 tracing::log::info!("Destination not allowed: {}", req.uri);
-                terminal::warn!("A component tried to make a HTTP request to '{}'.", req.uri);
-                eprintln!("The component was configured not to allow requests to this host.");
-                eprintln!("To allow requests, add the host to `allowed_http_posts`.");
+                if let Some(host) = host(&req.uri) {
+                    terminal::warn!("A component tried to make a HTTP request to non-allowed host '{host}'.");
+                    eprintln!("To allow requests, add 'allowed_http_hosts = [\"{host}\"]' to the manifest component section.");
+                }
                 return Err(HttpError::DestinationNotAllowed);
             }
 
@@ -169,4 +170,10 @@ fn response_headers(h: &HeaderMap) -> anyhow::Result<Option<Vec<(String, String)
     }
 
     Ok(Some(res))
+}
+
+fn host(url: &str) -> Option<String> {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host().map(|h| h.to_string()))
 }


### PR DESCRIPTION
Fixes #1090.

With the proposed text, it looks like this:

![image](https://github.com/fermyon/spin/assets/865538/667c6960-e7ac-4f64-9d6d-227c7a35dd83)

Get painting those bikesheds.

(Note that the host component doesn't know which component it's attached to, so we can't provide a component ID without more work (heaven forfend.)
