### PR TITLE
Replace foo-bar header with content-type

### DIFF
--- a/templates/http-rust/content/src/lib.rs
+++ b/templates/http-rust/content/src/lib.rs
@@ -10,6 +10,6 @@ fn handle_{{project-name | snake_case}}(req: Request) -> Result<Response> {
     println!("{:?}", req.headers());
     Ok(http::Response::builder()
         .status(200)
-        .header("foo", "bar")
+        .header("content-type", "text/plain")
         .body(Some("Hello, Fermyon".into()))?)
 }


### PR DESCRIPTION
YOU HAVE TAUNTED ME LONG ENOUGH RUST-HTTP TEMPLATE

(All the other HTTP templates already use `content-type` as their example header.)
