### PR TITLE
Update spin-componentize to f29cdb2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5352,7 +5352,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=0fa79bfc60f20c172213e2a2c34bd0b3168960b0#0fa79bfc60f20c172213e2a2c34bd0b3168960b0"
+source = "git+https://github.com/fermyon/spin-componentize?rev=f29cdb26a6b1700ae1fe48c94bbef26a8069d566#f29cdb26a6b1700ae1fe48c94bbef26a8069d566"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.32.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ tracing = { version = "0.1", features = ["log"] }
 wasmtime-wasi = { version = "13.0.0", features = ["tokio"] }
 wasi-common-preview1 = { version = "13.0.0", package = "wasi-common" }
 wasmtime = { version = "13.0.0", features = ["component-model"] }
-spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "0fa79bfc60f20c172213e2a2c34bd0b3168960b0" }
+spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "f29cdb26a6b1700ae1fe48c94bbef26a8069d566" }
 
 [[bin]]
 name = "spin"


### PR DESCRIPTION
[[diff]](https://github.com/fermyon/spin-componentize/compare/0fa79bfc...f29cdb)

The change makes spin-componentize's build script run *much* quicker. 