### PR TITLE
Log use of remote LLM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5598,6 +5598,7 @@ dependencies = [
  "spin-core",
  "spin-llm",
  "spin-world",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/llm-remote-http/Cargo.toml
+++ b/crates/llm-remote-http/Cargo.toml
@@ -14,3 +14,4 @@ spin-core = { path = "../core" }
 spin-llm = { path = "../llm" }
 spin-world = { path = "../world" }
 reqwest = { version = "0.11", features = ["gzip", "json"] }
+tracing = { workspace = true }

--- a/crates/llm-remote-http/src/lib.rs
+++ b/crates/llm-remote-http/src/lib.rs
@@ -84,13 +84,14 @@ impl LlmEngine for RemoteHttpLlmEngine {
         }))
         .map_err(|_| wasi_llm::Error::RuntimeError("Failed to serialize JSON".to_string()))?;
 
+        let infer_url = self
+            .url
+            .join("/infer")
+            .map_err(|_| wasi_llm::Error::RuntimeError("Failed to create URL".to_string()))?;
+        tracing::info!("Sending remote inference request to {infer_url}");
+
         let resp = client
-            .request(
-                http::Method::POST,
-                self.url.join("/infer").map_err(|_| {
-                    wasi_llm::Error::RuntimeError("Failed to create URL".to_string())
-                })?,
-            )
+            .request(http::Method::POST, infer_url)
             .headers(headers)
             .body(body)
             .send()


### PR DESCRIPTION
Fixes #1850.

```
ivan@hecate:~/testing/llmmadness$ RUST_LOG=info spin up --runtime-config-file rt.toml 
2023-10-04T21:27:51.022957Z  INFO spin_trigger::runtime_config::llm: Using remote compute for LLMs    
Logging component stdio to ".spin/logs/"

Serving http://127.0.0.1:3000
2023-10-04T21:27:51.720827Z  INFO spin_trigger_http: Serving http://127.0.0.1:3000    
Available Routes:
  llmmadness: http://127.0.0.1:3000 (wildcard)
2023-10-04T21:27:54.715899Z  INFO spin_trigger_http: Processing request for application llmmadness on URI http://127.0.0.1:3000/    
2023-10-04T21:27:54.779043Z  INFO spin_llm_remote_http: Sending remote inference request to https://fermyon-cloud-gpu-yshdf2gz.fermyon.app/infer
```
