### PR TITLE
Handle locally installed plugin with same name and version as a registry one

### DIFF
--- a/crates/plugins/src/manifest.rs
+++ b/crates/plugins/src/manifest.rs
@@ -60,7 +60,7 @@ impl PluginManifest {
     }
     pub fn is_installed_in(&self, store: &PluginStore) -> bool {
         match store.read_plugin_manifest(&self.name) {
-            Ok(m) => m.version == self.version,
+            Ok(m) => m.eq(self),
             Err(_) => false,
         }
     }


### PR DESCRIPTION
Fixes #1805.

It still prints two entries, but only one is shown as installed - see `cloud 0.2.0` in the list below.

```
$ spin plugins list
ai-models 0.2.0 [installed]
check-for-update 0.0.1
check-for-update 0.1.0
cloud 0.1.0
cloud 0.1.1
cloud 0.1.2
cloud 0.2.0
cloud 0.2.0 [installed]
cloud 0.3.0
cloud-gpu 0.1.0post.1696303530 [installed]
```
