### PR TITLE
Allow `spin add` to add variables to the manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5856,6 +5856,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.5.11",
+ "toml_edit 0.20.2",
  "url",
  "walkdir",
 ]
@@ -6498,7 +6499,7 @@ checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.1",
+ "toml_datetime 0.6.3",
  "toml_edit 0.19.8",
 ]
 
@@ -6513,9 +6514,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
@@ -6542,8 +6543,19 @@ dependencies = [
  "indexmap 1.9.2",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.1",
- "winnow",
+ "toml_datetime 0.6.3",
+ "winnow 0.4.1",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.0.0",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.16",
 ]
 
 [[package]]
@@ -7790,6 +7802,15 @@ name = "winnow"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -30,5 +30,6 @@ spin-loader = { path = "../loader" }
 tempfile = "3.3.0"
 tokio = { version = "1.23", features = ["fs", "process", "rt", "macros"] }
 toml = "0.5"
+toml_edit = "0.20.2"
 url = "2.2.2"
 walkdir = "2"

--- a/crates/templates/src/renderer.rs
+++ b/crates/templates/src/renderer.rs
@@ -18,7 +18,12 @@ pub(crate) enum TemplateContent {
 
 pub(crate) enum RenderOperation {
     AppendToml(PathBuf, TemplateContent),
+    MergeToml(PathBuf, MergeTarget, TemplateContent), // file to merge into, table to merge into, content to merge
     WriteFile(PathBuf, TemplateContent),
+}
+
+pub(crate) enum MergeTarget {
+    Application(&'static str),
 }
 
 impl TemplateRenderer {
@@ -63,6 +68,12 @@ impl RenderOperation {
                 let rendered = content.render(globals)?;
                 let rendered_text = String::from_utf8(rendered)?;
                 Ok(TemplateOutput::AppendToml(path, rendered_text))
+            }
+            Self::MergeToml(path, target, content) => {
+                let rendered = content.render(globals)?;
+                let rendered_text = String::from_utf8(rendered)?;
+                let MergeTarget::Application(target_table) = target;
+                Ok(TemplateOutput::MergeToml(path, target_table, rendered_text))
             }
         }
     }

--- a/crates/templates/src/run.rs
+++ b/crates/templates/src/run.rs
@@ -11,6 +11,7 @@ use walkdir::WalkDir;
 use crate::{
     cancellable::Cancellable,
     interaction::{InteractionStrategy, Interactive, Silent},
+    renderer::MergeTarget,
     template::TemplateVariantInfo,
 };
 use crate::{
@@ -248,9 +249,20 @@ impl Run {
                         Err(anyhow::anyhow!("Spin doesn't know what to do with a 'component' snippet outside an 'add component' operation")),
                 }
             },
+            "variables" => {
+                match &self.options.variant {
+                    TemplateVariantInfo::AddComponent { manifest_path } =>
+                        Ok(RenderOperation::MergeToml(
+                            manifest_path.clone(),
+                            MergeTarget::Application("variables"),
+                            content,
+                        )),
+                    TemplateVariantInfo::NewApplication =>
+                        Err(anyhow::anyhow!("Spin doesn't know what to do with a 'variables' snippet outside an 'add component' operation")),
+                }
+            },
             _ => Err(anyhow::anyhow!(
-                "Spin doesn't know what to do with snippet {}",
-                id
+                "Spin doesn't know what to do with snippet {id}",
             )),
         }
     }

--- a/crates/templates/src/writer.rs
+++ b/crates/templates/src/writer.rs
@@ -9,6 +9,7 @@ pub(crate) struct TemplateOutputs {
 pub(crate) enum TemplateOutput {
     WriteFile(PathBuf, Vec<u8>),
     AppendToml(PathBuf, String),
+    MergeToml(PathBuf, &'static str, String), // only have to worry about merging into root table for now
 }
 
 impl TemplateOutputs {
@@ -47,7 +48,110 @@ impl TemplateOutput {
                     .await
                     .with_context(|| format!("Can't save changes to {}", path.display()))?;
             }
+            TemplateOutput::MergeToml(path, target, text) => {
+                let existing_toml = tokio::fs::read_to_string(path)
+                    .await
+                    .with_context(|| format!("Can't open {} to append", path.display()))?;
+                let new_toml = merge_toml(&existing_toml, target, text)?;
+                tokio::fs::write(path, new_toml)
+                    .await
+                    .with_context(|| format!("Can't save changes to {}", path.display()))?;
+            }
         }
         Ok(())
+    }
+}
+
+fn merge_toml(existing: &str, target: &str, text: &str) -> anyhow::Result<String> {
+    use toml_edit::{Document, Entry, Item};
+
+    let mut doc: Document = existing
+        .parse()
+        .context("Can't merge into the existing manifest - it's not valid TOML")?;
+    let merging: Document = text
+        .parse()
+        .context("Can't merge snippet - it's not valid TOML")?;
+    let merging = merging.as_table();
+    match doc.get_mut(target) {
+        Some(item) => {
+            let Some(table) = item.as_table_mut() else {
+                anyhow::bail!("Cannot merge template data into {target} as it is not a table");
+            };
+            for (key, value) in merging {
+                match table.entry(key) {
+                    Entry::Occupied(mut e) => {
+                        let existing_val = e.get_mut();
+                        *existing_val = value.clone();
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(value.clone());
+                    }
+                }
+            }
+        }
+        None => {
+            let table = Item::Table(merging.clone());
+            doc.insert(target, table);
+        }
+    };
+    Ok(doc.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn can_insert_variables_in_manifest() {
+        let manifest = r#"spin_version = "1"
+
+[[component]]
+id = "dummy"
+"#;
+
+        let variables = r#"url = { required = true }"#;
+
+        let new = merge_toml(manifest, "variables", variables).unwrap();
+
+        assert_eq!(
+            r#"spin_version = "1"
+
+[[component]]
+id = "dummy"
+
+[variables]
+url = { required = true }
+"#,
+            new
+        );
+    }
+
+    #[test]
+    fn can_merge_variables_into_manifest() {
+        let manifest = r#"spin_version = "1"
+
+[variables]
+secret = { default = "1234 but don't tell anyone!" }
+
+[[component]]
+id = "dummy"
+"#;
+
+        let variables = r#"url = { required = true }"#;
+
+        let new = merge_toml(manifest, "variables", variables).unwrap();
+
+        assert_eq!(
+            r#"spin_version = "1"
+
+[variables]
+secret = { default = "1234 but don't tell anyone!" }
+url = { required = true }
+
+[[component]]
+id = "dummy"
+"#,
+            new
+        );
     }
 }

--- a/crates/templates/tests/templates/add-variables/metadata/snippets/variables.txt
+++ b/crates/templates/tests/templates/add-variables/metadata/snippets/variables.txt
@@ -1,0 +1,2 @@
+secret = { required = true }
+url = { default = "{{ service-url }}" }

--- a/crates/templates/tests/templates/add-variables/metadata/spin-template.toml
+++ b/crates/templates/tests/templates/add-variables/metadata/spin-template.toml
@@ -1,0 +1,14 @@
+manifest_version = "1"
+id = "add-variables"
+description = "Tests variables in spin add"
+trigger_type = "http"
+
+[new_application]
+supported = false
+
+[add_component]
+[add_component.snippets]
+variables = "variables.txt"
+
+[parameters]
+service-url = { type = "string", prompt = "Service URL" }


### PR DESCRIPTION
Syntax:

```
// spin-template.toml
[add_component]
[add_component.snippets]
variables = "variables.txt"

// snippets/variables.txt
secret = { required = true }
url = { default = "{{ service-url }}" }
```

Questions:

* Should the variables be merged into `component.txt`?  Splitting them makes it easier to implement because we don't need to analyse which bits of the snippet need to be merged and which appended - we can instead use the snippet key to infer the semantics.
* Should `variables.txt` include the `[variables]` header?  It is not needed for the implementation but `component.txt` has it so maybe for consistency?
* If the manifest being added to already has a variable with the same name as one given in the snippet, the one from the snippet takes precedence.  Do we just need to document this, or do we need to ask the user if we are about to change an existing value?  (The danger being that the user may not know how to decide.)

