### PR TITLE
Application startup entrypoint

### DIFF
--- a/wit/preview2/app-start.wit
+++ b/wit/preview2/app-start.wit
@@ -1,0 +1,5 @@
+interface app-start {
+    type error = string
+
+    handle-app-start: func() -> result<_, error>
+}


### PR DESCRIPTION
This was a vague experiment in relation to #604 that accidentally worked and now I am not sure what to do with it.

My test case wasn't in the Spin repo but basically it was:

```
// WIT
use fermyon:spin/inbound-http
use fermyon:spin/app-start
use fermyon:spin/sqlite

world example {
    export inbound-http
    export app-start
    import sqlite
}
```

```rust
// Rust
impl crate::bindings::exports::fermyon::spin::app_start::Guest for Component {
    fn handle_app_start() -> Result<(), String> {
        let conn = crate::bindings::fermyon::spin::sqlite::open("default")
            .map_err(|e| format!("{e:?}"))?;
        crate::bindings::fermyon::spin::sqlite::execute(conn, "CREATE TABLE IF NOT EXISTS test (message TEXT)", &[])
            .map_err(|e| format!("{e:?}"))?;
        Ok(())
    }
}
```

...and then the HTTP handler implementation was able to use the SQLite table without me needing to initialise it in `spin up`.

So I guess I am interested in knowing whether people feel this is the right way / place to do this (with suitable tidying), and whether we would like to productionise it (which, apart from agreeing a WIT and defining desired behaviour, would of course have Cloud implications that are likely the real difficulty with the feature!).
