### PR TITLE
Changes to the `spin new` experience

### DIFF
--- a/crates/e2e-testing/src/spin.rs
+++ b/crates/e2e-testing/src/spin.rs
@@ -30,7 +30,14 @@ pub fn new_app<'a>(
     mut args: Vec<&'a str>,
 ) -> Result<Output> {
     let basedir = utils::testcases_base_dir();
-    let mut cmd = vec!["spin", "new", template_name, app_name, "--accept-defaults"];
+    let mut cmd = vec![
+        "spin",
+        "new",
+        app_name,
+        "-t",
+        template_name,
+        "--accept-defaults",
+    ];
     if !args.is_empty() {
         cmd.append(&mut args);
     }

--- a/crates/templates/src/interaction.rs
+++ b/crates/templates/src/interaction.rs
@@ -42,7 +42,7 @@ impl InteractionStrategy for Interactive {
     fn allow_generate_into(&self, target_dir: &Path) -> Cancellable<(), anyhow::Error> {
         if !is_directory_empty(target_dir) {
             let prompt = format!(
-                "{} already contains other files. Generate into it anyway?",
+                "Directory '{}' already contains other files. Generate into it anyway?",
                 target_dir.display()
             );
             match crate::interaction::confirm(&prompt) {

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -35,8 +35,12 @@ pub struct TemplateNewCommandCore {
 
     /// The directory in which to create the new application or component.
     /// The default is the name argument.
-    #[clap(short = 'o', long = "output")]
+    #[clap(short = 'o', long = "output", group = "location")]
     pub output_path: Option<PathBuf>,
+
+    /// Create the new application or component in the current directory.
+    #[clap(long = "init", takes_value = false, group = "location")]
+    pub init: bool,
 
     /// Parameter values to be passed to the template (in name=value format).
     #[clap(short = 'v', long = "value", multiple_occurrences = true)]
@@ -158,7 +162,12 @@ impl TemplateNewCommandCore {
             None => prompt_name(&variant).await?,
         };
 
-        let output_path = self.output_path.clone().unwrap_or_else(|| path_safe(&name));
+        let output_path = if self.init {
+            PathBuf::from(".")
+        } else {
+            self.output_path.clone().unwrap_or_else(|| path_safe(&name))
+        };
+
         let values = {
             let mut values = match self.values_file.as_ref() {
                 Some(file) => values_from_file(file.as_path()).await?,


### PR DESCRIPTION
Fixes #1525.

~**WIP:** There are more changes requested in #1525, but I'm getting it under way immediately because the e2e tests use `spin new` quite a bit and I want to know where they blow up sooner rather than later.  I fixed one place but I'm sure there will be others!~  This now has everything except the proposal to generate a blank component on `spin new` with no template, on which I'd like to gather more feedback before implementing.  That can be a follow-up PR if necessary.

And you don't know how much I wanted to call this PR "The new `new` thing."