### PR TITLE
Changes to outbound redis interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,6 +3965,7 @@ dependencies = [
  "redis",
  "spin-core",
  "spin-world",
+ "table",
  "tokio",
  "tracing",
 ]
@@ -5531,6 +5532,7 @@ dependencies = [
  "spin-app",
  "spin-core",
  "spin-world",
+ "table",
  "tokio",
  "tracing",
 ]
@@ -5773,8 +5775,8 @@ dependencies = [
  "async-trait",
  "spin-app",
  "spin-core",
- "spin-key-value",
  "spin-world",
+ "table",
  "tokio",
 ]
 
@@ -6087,6 +6089,10 @@ dependencies = [
  "windows-sys 0.48.0",
  "winx",
 ]
+
+[[package]]
+name = "table"
+version = "2.0.0-pre0"
 
 [[package]]
 name = "tap"

--- a/crates/key-value/Cargo.toml
+++ b/crates/key-value/Cargo.toml
@@ -9,9 +9,10 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1", features = [ "macros", "sync" ] }
+tokio = { version = "1", features = ["macros", "sync"] }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }
+table = { path = "../table" }
 tracing = { workspace = true }
 lru = "0.9.0"

--- a/crates/key-value/src/lib.rs
+++ b/crates/key-value/src/lib.rs
@@ -6,7 +6,6 @@ use std::{collections::HashSet, sync::Arc};
 use table::Table;
 
 mod host_component;
-pub mod table;
 mod util;
 
 pub use host_component::{manager, KeyValueComponent};

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -12,5 +12,6 @@ anyhow = "1.0"
 redis = { version = "0.21", features = ["tokio-comp", "tokio-native-tls-comp"] }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }
+table = { path = "../table" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }

--- a/crates/outbound-redis/src/host_component.rs
+++ b/crates/outbound-redis/src/host_component.rs
@@ -10,24 +10,8 @@ impl HostComponent for OutboundRedisComponent {
         linker: &mut spin_core::Linker<T>,
         get: impl Fn(&mut spin_core::Data<T>) -> &mut Self::Data + Send + Sync + Copy + 'static,
     ) -> anyhow::Result<()> {
+        spin_world::v1::redis::add_to_linker(linker, get)?;
         spin_world::v2::redis::add_to_linker(linker, get)
-    }
-
-    fn build_data(&self) -> Self::Data {
-        Default::default()
-    }
-}
-
-pub struct LegacyOutboundRedisComponent;
-
-impl HostComponent for LegacyOutboundRedisComponent {
-    type Data = OutboundRedis;
-
-    fn add_to_linker<T: Send>(
-        linker: &mut spin_core::Linker<T>,
-        get: impl Fn(&mut spin_core::Data<T>) -> &mut Self::Data + Send + Sync + Copy + 'static,
-    ) -> anyhow::Result<()> {
-        spin_world::v1::redis::add_to_linker(linker, get)
     }
 
     fn build_data(&self) -> Self::Data {

--- a/crates/outbound-redis/src/host_component.rs
+++ b/crates/outbound-redis/src/host_component.rs
@@ -6,12 +6,28 @@ pub struct OutboundRedisComponent;
 
 impl HostComponent for OutboundRedisComponent {
     type Data = OutboundRedis;
+    fn add_to_linker<T: Send>(
+        linker: &mut spin_core::Linker<T>,
+        get: impl Fn(&mut spin_core::Data<T>) -> &mut Self::Data + Send + Sync + Copy + 'static,
+    ) -> anyhow::Result<()> {
+        spin_world::v2::redis::add_to_linker(linker, get)
+    }
+
+    fn build_data(&self) -> Self::Data {
+        Default::default()
+    }
+}
+
+pub struct LegacyOutboundRedisComponent;
+
+impl HostComponent for LegacyOutboundRedisComponent {
+    type Data = OutboundRedis;
 
     fn add_to_linker<T: Send>(
         linker: &mut spin_core::Linker<T>,
         get: impl Fn(&mut spin_core::Data<T>) -> &mut Self::Data + Send + Sync + Copy + 'static,
     ) -> anyhow::Result<()> {
-        super::outbound_redis::add_to_linker(linker, get)
+        spin_world::v1::redis::add_to_linker(linker, get)
     }
 
     fn build_data(&self) -> Self::Data {

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -79,7 +79,7 @@ impl v2::HostConnection for OutboundRedis {
         &mut self,
         connection: Resource<RedisConnection>,
         key: String,
-    ) -> Result<Result<Vec<u8>, Error>> {
+    ) -> Result<Result<Option<Vec<u8>>, Error>> {
         Ok(async {
             let conn = self.get_conn(connection).await.map_err(other_error)?;
             let value = conn.get(&key).await.map_err(other_error)?;
@@ -236,7 +236,7 @@ impl v1::Host for OutboundRedis {
     }
 
     async fn get(&mut self, address: String, key: String) -> Result<Result<Vec<u8>, v1::Error>> {
-        delegate!(self.get(address, key))
+        delegate!(self.get(address, key)).map(|v| v.map(|v| v.unwrap_or_default()))
     }
 
     async fn set(

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -119,7 +119,7 @@ impl v2::HostConnection for OutboundRedis {
         &mut self,
         connection: Resource<RedisConnection>,
         keys: Vec<String>,
-    ) -> Result<Result<i64, Error>> {
+    ) -> Result<Result<u32, Error>> {
         Ok(async {
             let conn = self.get_conn(connection).await.map_err(other_error)?;
             let value = conn.del(&keys).await.map_err(other_error)?;
@@ -133,7 +133,7 @@ impl v2::HostConnection for OutboundRedis {
         connection: Resource<RedisConnection>,
         key: String,
         values: Vec<String>,
-    ) -> Result<Result<i64, Error>> {
+    ) -> Result<Result<u32, Error>> {
         Ok(async {
             let conn = self.get_conn(connection).await.map_err(other_error)?;
             let value = conn.sadd(&key, &values).await.map_err(|e| {
@@ -166,7 +166,7 @@ impl v2::HostConnection for OutboundRedis {
         connection: Resource<RedisConnection>,
         key: String,
         values: Vec<String>,
-    ) -> Result<Result<i64, Error>> {
+    ) -> Result<Result<u32, Error>> {
         Ok(async {
             let conn = self.get_conn(connection).await.map_err(other_error)?;
             let value = conn.srem(&key, &values).await.map_err(other_error)?;
@@ -253,7 +253,7 @@ impl v1::Host for OutboundRedis {
     }
 
     async fn del(&mut self, address: String, keys: Vec<String>) -> Result<Result<i64, v1::Error>> {
-        delegate!(self.del(address, keys))
+        delegate!(self.del(address, keys)).map(|v| v.map(|v| v as i64))
     }
 
     async fn sadd(
@@ -262,7 +262,7 @@ impl v1::Host for OutboundRedis {
         key: String,
         values: Vec<String>,
     ) -> Result<Result<i64, v1::Error>> {
-        delegate!(self.sadd(address, key, values))
+        delegate!(self.sadd(address, key, values)).map(|v| v.map(|v| v as i64))
     }
 
     async fn smembers(
@@ -279,7 +279,7 @@ impl v1::Host for OutboundRedis {
         key: String,
         values: Vec<String>,
     ) -> Result<Result<i64, v1::Error>> {
-        delegate!(self.srem(address, key, values))
+        delegate!(self.srem(address, key, values)).map(|v| v.map(|v| v as i64))
     }
 
     async fn execute(

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -212,11 +212,11 @@ macro_rules! delegate {
     ($self:ident.$name:ident($address:expr, $($arg:expr),*)) => {{
         let connection = match <Self as v2::HostConnection>::open($self, $address).await? {
             Ok(c) => c,
-            Err(e) => return Ok(Err(to_legacy_error(e))),
+            Err(_) => return Ok(Err(V1Error::Error)),
         };
         Ok(<Self as v2::HostConnection>::$name($self, connection, $($arg),*)
             .await?
-            .map_err(to_legacy_error))
+            .map_err(|_| V1Error::Error))
     }};
 }
 
@@ -297,8 +297,4 @@ impl OutboundRedis {
             .get_mut(connection.rep())
             .ok_or(Error::Io("could not find connection for resource".into()))
     }
-}
-
-fn to_legacy_error(_error: Error) -> V1Error {
-    V1Error::Error
 }

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -5,10 +5,10 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = "1.0"
 async-trait = "0.1.68"
 spin-core = { path = "../core" }
 spin-app = { path = "../app" }
-spin-key-value = { path = "../key-value" }
 spin-world = { path = "../world" }
-anyhow = "1.0"
+table = { path = "../table" }
 tokio = "1"

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -2,7 +2,6 @@ mod host_component;
 
 use spin_app::{async_trait, MetadataKey};
 use spin_core::wasmtime::component::Resource;
-use spin_key_value::table;
 use spin_world::v2::sqlite;
 use std::{collections::HashSet, sync::Arc};
 

--- a/crates/table/Cargo.toml
+++ b/crates/table/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "table"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/table/src/lib.rs
+++ b/crates/table/src/lib.rs
@@ -1,6 +1,3 @@
-// TODO: there's nothing key-value-specific about this utility, so it could be moved elsewhere, e.g. to a utility
-// crate of some kind.
-
 use std::collections::HashMap;
 
 /// This is a table for generating unique u32 identifiers for each element in a dynamically-changing set of
@@ -10,7 +7,6 @@ use std::collections::HashMap;
 /// [wasi-common](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi-common) and serves the same
 /// purpose: allow opaque resources and their lifetimes to be managed across an interface boundary, analogous to
 /// how file handles work across the user-kernel boundary.
-///
 pub struct Table<V> {
     capacity: u32,
     next_key: u32,
@@ -54,6 +50,11 @@ impl<V> Table<V> {
     /// Get a reference to the resource identified by the specified `key`, if it exists.
     pub fn get(&self, key: u32) -> Option<&V> {
         self.tuples.get(&key)
+    }
+
+    /// Get a mutable reference to the resource identified by the specified `key`, if it exists.
+    pub fn get_mut(&mut self, key: u32) -> Option<&mut V> {
+        self.tuples.get_mut(&key)
     }
 
     /// Remove the resource identified by the specified `key`, if present.

--- a/examples/rust-outbound-redis/src/lib.rs
+++ b/examples/rust-outbound-redis/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use spin_sdk::{
     http::{internal_server_error, Request, Response},
     http_component, redis,
@@ -22,22 +22,28 @@ fn publish(_req: Request) -> Result<Response> {
     let address = std::env::var(REDIS_ADDRESS_ENV)?;
     let channel = std::env::var(REDIS_CHANNEL_ENV)?;
 
+    let conn = redis::Connection::open(&address)?;
+
     // Get the message to publish from the Redis key "mykey"
-    let payload = redis::get(&address, "mykey").map_err(|_| anyhow!("Error querying Redis"))?;
+    let payload = conn
+        .get("mykey")
+        .map_err(|_| anyhow!("Error querying Redis"))?
+        .context("no value for key 'mykey'")?;
 
     // Set the Redis key "spin-example" to value "Eureka!"
-    redis::set(&address, "spin-example", &"Eureka!".to_owned().into_bytes())
+    conn.set("spin-example", &"Eureka!".to_owned().into_bytes())
         .map_err(|_| anyhow!("Error executing Redis set command"))?;
 
     // Set the Redis key "int-key" to value 0
-    redis::set(&address, "int-key", &format!("{:x}", 0).into_bytes())
+    conn.set("int-key", &format!("{:x}", 0).into_bytes())
         .map_err(|_| anyhow!("Error executing Redis set command"))?;
-    let int_value = redis::incr(&address, "int-key")
+    let int_value = conn
+        .incr("int-key")
         .map_err(|_| anyhow!("Error executing Redis incr command",))?;
     assert_eq!(int_value, 1);
 
     // Publish to Redis
-    match redis::publish(&address, &channel, &payload) {
+    match conn.publish(&channel, &payload) {
         Ok(()) => Ok(http::Response::builder().status(200).body(None)?),
         Err(_e) => internal_server_error(),
     }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -600,16 +600,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -628,29 +628,29 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 
 [[package]]
 name = "cranelift-control"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -658,8 +658,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -669,13 +669,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 
 [[package]]
 name = "cranelift-native"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -684,8 +684,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.102.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.101.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2533,6 +2533,7 @@ dependencies = [
  "redis",
  "spin-core",
  "spin-world",
+ "table",
  "tokio",
  "tracing",
 ]
@@ -3596,6 +3597,7 @@ dependencies = [
  "spin-app",
  "spin-core",
  "spin-world",
+ "table",
  "tokio",
  "tracing",
 ]
@@ -3720,8 +3722,8 @@ dependencies = [
  "async-trait",
  "spin-app",
  "spin-core",
- "spin-key-value",
  "spin-world",
+ "table",
  "tokio",
 ]
 
@@ -3964,6 +3966,10 @@ dependencies = [
  "windows-sys 0.48.0",
  "winx",
 ]
+
+[[package]]
+name = "table"
+version = "2.0.0-pre0"
 
 [[package]]
 name = "tap"
@@ -4506,8 +4512,8 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4528,8 +4534,8 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
@@ -4547,8 +4553,8 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4686,8 +4692,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4725,16 +4731,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -4752,8 +4758,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4766,13 +4772,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4795,8 +4801,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4810,8 +4816,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -4832,8 +4838,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4845,8 +4851,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4871,8 +4877,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "object",
  "once_cell",
@@ -4882,8 +4888,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4892,8 +4898,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "cc",
@@ -4921,8 +4927,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -4933,8 +4939,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4943,8 +4949,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4978,8 +4984,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4994,8 +5000,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "heck",
@@ -5005,8 +5011,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 
 [[package]]
 name = "wast"
@@ -5066,8 +5072,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5080,8 +5086,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "heck",
@@ -5094,8 +5100,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "15.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "14.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5136,8 +5142,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.13.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+version = "0.12.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5340,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.1"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=4c34504efb258a0c51c6a5f3f8a5b24d987993b9#4c34504efb258a0c51c6a5f3f8a5b24d987993b9"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=c796ce7376a57a40605f03e74bd78cefcc9acf3a#c796ce7376a57a40605f03e74bd78cefcc9acf3a"
 dependencies = [
  "anyhow",
  "log",

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -86,8 +86,8 @@ pub mod http {
 pub mod redis {
     use std::hash::{Hash, Hasher};
 
-    pub use super::wit::v1::redis_types::*;
-    pub use super::wit::v2::redis::Connection;
+    pub use super::wit::v1::redis_types::{Payload, RedisParameter, RedisResult};
+    pub use super::wit::v2::redis::{Connection, Error};
 
     impl PartialEq for RedisResult {
         fn eq(&self, other: &Self) -> bool {

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -86,8 +86,8 @@ pub mod http {
 pub mod redis {
     use std::hash::{Hash, Hasher};
 
-    pub use super::wit::v1::redis::{del, execute, get, incr, publish, sadd, set, smembers, srem};
     pub use super::wit::v1::redis_types::*;
+    pub use super::wit::v2::redis::Connection;
 
     impl PartialEq for RedisResult {
         fn eq(&self, other: &Self) -> bool {

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use spin_sdk::{
     http::{Request, Response},
     http_component,
@@ -19,9 +19,10 @@ fn test(_req: Request) -> Result<Response> {
 
     let payload = connection
         .get("spin-example-get-set")
-        .map_err(|_| anyhow!("Error querying Redis"))?;
+        .map_err(|_| anyhow!("Error querying Redis"))?
+        .context("no value found for key 'spin-example-get-set'")?;
 
-    assert_eq!(std::str::from_utf8(&payload).unwrap(), "Eureka!");
+    assert_eq!(std::str::from_utf8(&payload)?, "Eureka!");
 
     connection
         .set("spin-example-incr", &b"0".to_vec())

--- a/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
+++ b/tests/outbound-redis/http-rust-outbound-redis/src/lib.rs
@@ -11,110 +11,105 @@ const REDIS_ADDRESS_ENV: &str = "REDIS_ADDRESS";
 #[http_component]
 fn test(_req: Request) -> Result<Response> {
     let address = std::env::var(REDIS_ADDRESS_ENV)?;
+    let connection = redis::Connection::open(&address)?;
 
-    redis::set(&address, "spin-example-get-set", &b"Eureka!".to_vec())
+    connection
+        .set("spin-example-get-set", &b"Eureka!".to_vec())
         .map_err(|_| anyhow!("Error executing Redis set command"))?;
 
-    let payload = redis::get(&address, "spin-example-get-set")
+    let payload = connection
+        .get("spin-example-get-set")
         .map_err(|_| anyhow!("Error querying Redis"))?;
 
     assert_eq!(std::str::from_utf8(&payload).unwrap(), "Eureka!");
 
-    redis::set(&address, "spin-example-incr", &b"0".to_vec())
+    connection
+        .set("spin-example-incr", &b"0".to_vec())
         .map_err(|_| anyhow!("Error querying Redis set command"))?;
 
-    let int_value = redis::incr(&address, "spin-example-incr")
+    let int_value = connection
+        .incr("spin-example-incr")
         .map_err(|_| anyhow!("Error executing Redis incr command"))?;
 
     assert_eq!(int_value, 1);
 
     let keys = vec!["spin-example-get-set".into(), "spin-example-incr".into()];
 
-    let del_keys =
-        redis::del(&address, &keys).map_err(|_| anyhow!("Error executing Redis incr command"))?;
+    let del_keys = connection
+        .del(&keys)
+        .map_err(|_| anyhow!("Error executing Redis incr command"))?;
 
     assert_eq!(del_keys, 2);
 
-    redis::execute(
-        &address,
-        "set",
-        &[
-            RedisParameter::Binary(b"spin-example".to_vec()),
-            RedisParameter::Binary(b"Eureka!".to_vec()),
-        ],
-    )
-    .map_err(|_| anyhow!("Error executing Redis set command"))?;
+    connection
+        .execute(
+            "set",
+            &[
+                RedisParameter::Binary(b"spin-example".to_vec()),
+                RedisParameter::Binary(b"Eureka!".to_vec()),
+            ],
+        )
+        .map_err(|_| anyhow!("Error executing Redis set command"))?;
 
-    redis::execute(
-        &address,
-        "append",
-        &[
-            RedisParameter::Binary(b"spin-example".to_vec()),
-            RedisParameter::Binary(b" I've got it!".to_vec()),
-        ],
-    )
-    .map_err(|_| anyhow!("Error executing Redis append command via `execute`"))?;
+    connection
+        .execute(
+            "append",
+            &[
+                RedisParameter::Binary(b"spin-example".to_vec()),
+                RedisParameter::Binary(b" I've got it!".to_vec()),
+            ],
+        )
+        .map_err(|_| anyhow!("Error executing Redis append command via `execute`"))?;
 
-    let values = redis::execute(
-        &address,
-        "get",
-        &[RedisParameter::Binary(b"spin-example".to_vec())],
-    )
-    .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
+    let values = connection
+        .execute("get", &[RedisParameter::Binary(b"spin-example".to_vec())])
+        .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
 
     assert_eq!(
         values,
         &[RedisResult::Binary(b"Eureka! I've got it!".to_vec())]
     );
 
-    redis::execute(
-        &address,
-        "set",
-        &[
-            RedisParameter::Binary(b"int-key".to_vec()),
-            RedisParameter::Int64(0),
-        ],
-    )
-    .map_err(|_| anyhow!("Error executing Redis set command via `execute`"))?;
+    connection
+        .execute(
+            "set",
+            &[
+                RedisParameter::Binary(b"int-key".to_vec()),
+                RedisParameter::Int64(0),
+            ],
+        )
+        .map_err(|_| anyhow!("Error executing Redis set command via `execute`"))?;
 
-    let values = redis::execute(
-        &address,
-        "incr",
-        &[RedisParameter::Binary(b"int-key".to_vec())],
-    )
-    .map_err(|_| anyhow!("Error executing Redis incr command via `execute`"))?;
+    let values = connection
+        .execute("incr", &[RedisParameter::Binary(b"int-key".to_vec())])
+        .map_err(|_| anyhow!("Error executing Redis incr command via `execute`"))?;
 
     assert_eq!(values, &[RedisResult::Int64(1)]);
 
-    let values = redis::execute(
-        &address,
-        "get",
-        &[RedisParameter::Binary(b"int-key".to_vec())],
-    )
-    .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
+    let values = connection
+        .execute("get", &[RedisParameter::Binary(b"int-key".to_vec())])
+        .map_err(|_| anyhow!("Error executing Redis get command via `execute`"))?;
 
     assert_eq!(values, &[RedisResult::Binary(b"1".to_vec())]);
 
-    redis::execute(&address, "del", &[RedisParameter::Binary(b"foo".to_vec())])
+    connection
+        .execute("del", &[RedisParameter::Binary(b"foo".to_vec())])
         .map_err(|_| anyhow!("Error executing Redis del command via `execute`"))?;
 
-    redis::execute(
-        &address,
-        "sadd",
-        &[
-            RedisParameter::Binary(b"foo".to_vec()),
-            RedisParameter::Binary(b"bar".to_vec()),
-            RedisParameter::Binary(b"baz".to_vec()),
-        ],
-    )
-    .map_err(|_| anyhow!("Error executing Redis sadd command via `execute`"))?;
+    connection
+        .execute(
+            "sadd",
+            &[
+                RedisParameter::Binary(b"foo".to_vec()),
+                RedisParameter::Binary(b"bar".to_vec()),
+                RedisParameter::Binary(b"baz".to_vec()),
+            ],
+        )
+        .map_err(|_| anyhow!("Error executing Redis sadd command via `execute`"))?;
 
-    let values = redis::execute(
-        &address,
-        "smembers",
-        &[RedisParameter::Binary(b"foo".to_vec())],
-    )
-    .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
+    let values = connection
+        .execute("smembers", &[RedisParameter::Binary(b"foo".to_vec())])
+        .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
 
     assert_eq!(
         values.into_iter().collect::<HashSet<_>>(),
@@ -126,22 +121,19 @@ fn test(_req: Request) -> Result<Response> {
         .collect::<HashSet<_>>()
     );
 
-    redis::execute(
-        &address,
-        "srem",
-        &[
-            RedisParameter::Binary(b"foo".to_vec()),
-            RedisParameter::Binary(b"baz".to_vec()),
-        ],
-    )
-    .map_err(|_| anyhow!("Error executing Redis srem command via `execute`"))?;
+    connection
+        .execute(
+            "srem",
+            &[
+                RedisParameter::Binary(b"foo".to_vec()),
+                RedisParameter::Binary(b"baz".to_vec()),
+            ],
+        )
+        .map_err(|_| anyhow!("Error executing Redis srem command via `execute`"))?;
 
-    let values = redis::execute(
-        &address,
-        "smembers",
-        &[RedisParameter::Binary(b"foo".to_vec())],
-    )
-    .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
+    let values = connection
+        .execute("smembers", &[RedisParameter::Binary(b"foo".to_vec())])
+        .map_err(|_| anyhow!("Error executing Redis smembers command via `execute`"))?;
 
     assert_eq!(
         values.into_iter().collect::<HashSet<_>>(),

--- a/wit/preview2/deps/spin@1.0.0/redis-types.wit
+++ b/wit/preview2/deps/spin@1.0.0/redis-types.wit
@@ -5,16 +5,16 @@ interface redis-types {
       error,
   }
 
-  // The message payload.
+  /// The message payload.
   type payload = list<u8>
 
-  // A parameter type for the general-purpose `execute` function.
+  /// A parameter type for the general-purpose `execute` function.
   variant redis-parameter {
       int64(s64),
       binary(payload)
   }
 
-  // A return type for the general-purpose `execute` function.
+  /// A return type for the general-purpose `execute` function.
   variant redis-result {
       nil,
       status(string),

--- a/wit/preview2/redis.wit
+++ b/wit/preview2/redis.wit
@@ -37,17 +37,17 @@ interface redis {
 
     /// Removes the specified keys.
     ///
-    /// A key is ignored if it does not exist.
-    del: func(keys: list<string>) -> result<s64, error>
+    /// A key is ignored if it does not exist. Returns the number of keys deleted.
+    del: func(keys: list<string>) -> result<u32, error>
 
     /// Add the specified `values` to the set named `key`, returning the number of newly-added values.
-    sadd: func(key: string, values: list<string>) -> result<s64, error>
+    sadd: func(key: string, values: list<string>) -> result<u32, error>
 
     /// Retrieve the contents of the set named `key`.
     smembers: func(key: string) -> result<list<string>, error>
 
     /// Remove the specified `values` from the set named `key`, returning the number of newly-removed values.
-    srem: func(key: string, values: list<string>) -> result<s64, error>
+    srem: func(key: string, values: list<string>) -> result<u32, error>
 
     /// Execute an arbitrary Redis command and receive the result.
     execute: func(command: string, arguments: list<redis-parameter>) -> result<list<redis-result>, error>

--- a/wit/preview2/redis.wit
+++ b/wit/preview2/redis.wit
@@ -3,6 +3,8 @@ interface redis {
 
   /// Errors related to interacting with Redis
   variant error {
+      /// An invalid address string
+      invalid-address,
       /// There are too many open connections
       too-many-connections,
       /// A retrieved value was not of the correct type

--- a/wit/preview2/redis.wit
+++ b/wit/preview2/redis.wit
@@ -9,8 +9,8 @@ interface redis {
       too-many-connections,
       /// A retrieved value was not of the correct type
       type-error,
-      /// An I/O error occurred
-      io(string),
+      /// Some other error occurred
+      other(string),
   }
   
   resource connection {

--- a/wit/preview2/redis.wit
+++ b/wit/preview2/redis.wit
@@ -1,0 +1,36 @@
+interface redis {
+  use fermyon:spin/redis-types.{payload, redis-parameter, redis-result, error}
+  
+  resource connection {
+    /// Open a connection to the Redis instance at `address`.
+    open: static func(address: string) -> result<connection, error>
+
+    /// Publish a Redis message to the specified channel and return an error, if any.
+    publish: func(channel: string, payload: payload) -> result<_, error>
+
+    /// Get the value of a key.
+    get: func(key: string) -> result<payload, error>
+
+    /// Set key to value. If key already holds a value, it is overwritten.
+    set: func(key: string, value: payload) -> result<_, error>
+
+    /// Increments the number stored at key by one. If the key does not exist, it is set to 0 before performing the operation.
+    /// An error is returned if the key contains a value of the wrong type or contains a string that can not be represented as integer.
+    incr: func(key: string) -> result<s64, error>
+
+    /// Removes the specified keys. A key is ignored if it does not exist.
+    del: func(keys: list<string>) -> result<s64, error>
+
+    /// Add the specified `values` to the set named `key`, returning the number of newly-added values.
+    sadd: func(key: string, values: list<string>) -> result<s64, error>
+
+    /// Retrieve the contents of the set named `key`.
+    smembers: func(key: string) -> result<list<string>, error>
+
+    /// Remove the specified `values` from the set named `key`, returning the number of newly-removed values.
+    srem: func(key: string, values: list<string>) -> result<s64, error>
+
+    /// Execute an arbitrary Redis command and receive the result.
+    execute: func(command: string, arguments: list<redis-parameter>) -> result<list<redis-result>, error>
+  }
+}

--- a/wit/preview2/redis.wit
+++ b/wit/preview2/redis.wit
@@ -1,24 +1,41 @@
 interface redis {
-  use fermyon:spin/redis-types.{payload, redis-parameter, redis-result, error}
+  use fermyon:spin/redis-types.{payload, redis-parameter, redis-result}
+
+  /// Errors related to interacting with Redis
+  variant error {
+      /// There are too many open connections
+      too-many-connections,
+      /// A retrieved value was not of the correct type
+      type-error,
+      /// An I/O error occurred
+      io(string),
+  }
   
   resource connection {
     /// Open a connection to the Redis instance at `address`.
     open: static func(address: string) -> result<connection, error>
 
-    /// Publish a Redis message to the specified channel and return an error, if any.
+    /// Publish a Redis message to the specified channel.
     publish: func(channel: string, payload: payload) -> result<_, error>
 
     /// Get the value of a key.
     get: func(key: string) -> result<payload, error>
 
-    /// Set key to value. If key already holds a value, it is overwritten.
+    /// Set key to value.
+    ///
+    /// If key already holds a value, it is overwritten.
     set: func(key: string, value: payload) -> result<_, error>
 
-    /// Increments the number stored at key by one. If the key does not exist, it is set to 0 before performing the operation.
-    /// An error is returned if the key contains a value of the wrong type or contains a string that can not be represented as integer.
+    /// Increments the number stored at key by one.
+    ///
+    /// If the key does not exist, it is set to 0 before performing the operation.
+    /// An `error::type-error` is returned if the key contains a value of the wrong type
+    /// or contains a string that can not be represented as integer.
     incr: func(key: string) -> result<s64, error>
 
-    /// Removes the specified keys. A key is ignored if it does not exist.
+    /// Removes the specified keys.
+    ///
+    /// A key is ignored if it does not exist.
     del: func(keys: list<string>) -> result<s64, error>
 
     /// Add the specified `values` to the set named `key`, returning the number of newly-added values.

--- a/wit/preview2/redis.wit
+++ b/wit/preview2/redis.wit
@@ -21,7 +21,7 @@ interface redis {
     publish: func(channel: string, payload: payload) -> result<_, error>
 
     /// Get the value of a key.
-    get: func(key: string) -> result<payload, error>
+    get: func(key: string) -> result<option<payload>, error>
 
     /// Set key to value.
     ///

--- a/wit/preview2/world.wit
+++ b/wit/preview2/world.wit
@@ -2,9 +2,7 @@ package fermyon:spin@2.0.0
 
 world host {
   include fermyon:spin/host
-  
-  import sqlite
-  import key-value
+  include platform
 }
 
 world redis-trigger {
@@ -22,9 +20,9 @@ world platform {
   import fermyon:spin/http
   import fermyon:spin/postgres
   import fermyon:spin/mysql
-  import fermyon:spin/redis
   import fermyon:spin/llm
 
+  import redis
   import sqlite
   import key-value
 }


### PR DESCRIPTION
Part of #1866 

The changes to the interface are:

* Uses a connection oriented resource rather than free functions.
* Updates the error type from just being `error` to 4 different error possibilities.
* Moves the functions that returned to `s64` to return `u32` since they should never return anything by positive numbers
* `get` returns `result<option<list<u8>>, error>` rather than `result<list<u8>, error>` returning `ok(none)` when the key does not exist - this mirrors how Redis's server API. 
