### PR TITLE
feat(oci): manifest/config updates to support containerd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3995,10 +3995,10 @@ dependencies = [
 [[package]]
 name = "oci-distribution"
 version = "0.10.0"
-source = "git+https://github.com/fermyon/oci-distribution?rev=05022618d78feef9b99f20b5da8fd6def6bb80d2#05022618d78feef9b99f20b5da8fd6def6bb80d2"
+source = "git+https://github.com/fermyon/oci-distribution?rev=639c907b7c0c4e74716356585410d4abe4aebf4d#639c907b7c0c4e74716356585410d4abe4aebf4d"
 dependencies = [
+ "bytes",
  "chrono",
- "futures",
  "futures-util",
  "http",
  "http-auth",
@@ -4012,7 +4012,6 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
- "tokio-util 0.7.9",
  "tracing",
  "unicase",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "oci-distribution"
 version = "0.10.0"
-source = "git+https://github.com/fermyon/oci-distribution?rev=639c907b7c0c4e74716356585410d4abe4aebf4d#639c907b7c0c4e74716356585410d4abe4aebf4d"
+source = "git+https://github.com/fermyon/oci-distribution?rev=63cbb0925775e0c9c870195cad1d50ac8707a264#63cbb0925775e0c9c870195cad1d50ac8707a264"
 dependencies = [
  "bytes",
  "chrono",

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -14,7 +14,7 @@ dkregistry = { git = "https://github.com/camallo/dkregistry-rs", rev = "37acecb4
 docker_credential = "1.0"
 dirs = "4.0"
 futures-util = "0.3"
-oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "639c907b7c0c4e74716356585410d4abe4aebf4d" }
+oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "63cbb0925775e0c9c870195cad1d50ac8707a264" }
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -14,7 +14,7 @@ dkregistry = { git = "https://github.com/camallo/dkregistry-rs", rev = "37acecb4
 docker_credential = "1.0"
 dirs = "4.0"
 futures-util = "0.3"
-oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "05022618d78feef9b99f20b5da8fd6def6bb80d2" }
+oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "639c907b7c0c4e74716356585410d4abe4aebf4d" }
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -28,11 +28,8 @@ pub const SPIN_APPLICATION_MEDIA_TYPE: &str = "application/vnd.fermyon.spin.appl
 pub const DATA_MEDIATYPE: &str = "application/vnd.wasm.content.layer.v1+data";
 /// Media type for a layer representing a compressed archive of one or more files used by a Spin application
 pub const ARCHIVE_MEDIATYPE: &str = "application/vnd.wasm.content.bundle.v1.tar+gzip";
-// Legacy wasm layer media type used by pre-2.0 versions of Spin
-const WASM_LAYER_MEDIA_TYPE_LEGACY: &str = "application/vnd.wasm.content.layer.v1+wasm";
-
-// TODO: use canonical types defined upstream; see https://github.com/bytecodealliance/registry/pull/146
-const WASM_LAYER_MEDIA_TYPE: &str = "application/vnd.bytecodealliance.wasm.component.layer.v0+wasm";
+// Note: this will be updated with a canonical value once defined upstream
+const WASM_LAYER_MEDIA_TYPE: &str = "application/vnd.wasm.content.layer.v1+wasm";
 
 const CONFIG_FILE: &str = "config.json";
 const LATEST_TAG: &str = "latest";
@@ -326,7 +323,7 @@ impl Client {
                                 .await
                                 .with_context(|| "unable to write locked app config to cache")?;
                         }
-                        WASM_LAYER_MEDIA_TYPE | WASM_LAYER_MEDIA_TYPE_LEGACY => {
+                        WASM_LAYER_MEDIA_TYPE => {
                             this.cache.write_wasm(&bytes, &layer.digest).await?;
                         }
                         ARCHIVE_MEDIATYPE => {

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -174,8 +174,10 @@ impl Client {
         // Construct empty/default OCI config file. Data may be parsed according to
         // the expected config structure per the image spec, so we want to ensure it conforms.
         // (See https://github.com/opencontainers/image-spec/blob/main/config.md)
-        // TODO: Explore adding data applicable to a Spin app.
+        // TODO: Explore adding data applicable to the Spin app being published.
         let oci_config_file = ConfigFile {
+            architecture: oci_distribution::config::Architecture::Wasm,
+            os: oci_distribution::config::Os::Wasip1,
             ..Default::default()
         };
         let oci_config =


### PR DESCRIPTION
Updates per https://github.com/fermyon/spin/issues/1857

- ~~Adds `artifactType: application/vnd.bytecodealliance.component.v1+wasm` to the OCI manifest~~ (https://github.com/fermyon/spin/pull/1882#discussion_r1362574046)
- Adds the locked spin config data as a separate layer
- Updates the OCI manifest config to represent the structure [expected by the spec](https://github.com/opencontainers/image-spec/blob/main/config.md)
  - ⚠️  **This is a breaking change:** older Spin clients won't be able to run Spin apps published by clients with this updated logic.
  - Currently this config uses defaults and we don't yet attempt to push any data specific to a Spin app.  Open to thoughts on what we might want to include.
- ~~Updates the wasm layer media type to `application/vnd.bytecodealliance.wasm.component.layer.v0+wasm`~~ (see https://github.com/fermyon/spin/pull/1882#issuecomment-1773232960)
  - ~~⚠️ **This is a breaking change:** older Spin clients won't be able to run Spin apps published by clients with this updated logic.~~
  - ~~Note that the [corresponding upstream PR](https://github.com/bytecodealliance/registry/pull/146) is still in flight -- is it too early to update the media type?~~
- ~~Adds a notion of the 'legacy' wasm layer media type such that new Spin clients can pull Spin apps published by older clients~~