### PR TITLE
chore(oci/Cargo.toml): explicitly use compat feature from tokio-util

### DIFF
--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -25,7 +25,7 @@ spin-manifest = { path = "../manifest" }
 spin-trigger = { path = "../trigger" }
 tempfile = "3.3"
 tokio = { version = "1", features = ["fs"] }
-tokio-util = "0.7.9"
+tokio-util = { version = "0.7.9", features = ["compat"] }
 tracing = { workspace = true }
 walkdir = "2.3"
 


### PR DESCRIPTION
Evidentally this [should have been done](https://docs.rs/tokio-util/latest/tokio_util/compat/index.html) in https://github.com/fermyon/spin/pull/1847 but the build didn't complain.

However, in another PR, the build _did_ complain; so making things right here.