### PR TITLE
Run lints on Rust test cases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,9 @@ jobs:
           rust-wasm: true
           rust-cache: true
 
-      - name: Cargo Format
+      - name: Run lints
         run:
-          BUILD_SPIN_EXAMPLES=0 cargo fmt --all -- --check
-
-      - name: Cargo Clippy
-        run:
-          BUILD_SPIN_EXAMPLES=0 cargo clippy --workspace --all-targets --features all-tests -- -D warnings
+          BUILD_SPIN_EXAMPLES=0 make lint
 
   ## This is separated out to remove e2e-tests dependency on windows/mac builds
   build-rust-ubuntu:
@@ -176,19 +172,3 @@ jobs:
           chmod +x `pwd`/target/release/spin
           export E2E_VOLUME_MOUNT="-v `pwd`/target/release/spin:/usr/local/bin/spin"
           make run-test-spin-up
-          
-  lint-examples:
-    name: Lint Examples
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up dependencies
-        uses: ./.github/actions/spin-ci-dependencies
-        with:
-          rust: true
-          rust-wasm: true
-          rust-cache: true
-
-      - name: Lint examples
-        run: make check-rust-examples

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         run:
           BUILD_SPIN_EXAMPLES=0 make lint
 
-      - name: Cancel everything if this fails
+      - name: Cancel everything if linting fails
         if: failure()
         uses: andymckay/cancel-action@0.2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,14 @@ jobs:
         run:
           BUILD_SPIN_EXAMPLES=0 make lint
 
+      - name: Cancel everything if this fails
+        if: failure()
+        uses: andymckay/cancel-action@0.2
+
   ## This is separated out to remove e2e-tests dependency on windows/mac builds
   build-rust-ubuntu:
     name: Build Spin Ubuntu
     runs-on: ubuntu-latest
-    needs: [lint-rust]
     steps:
       - uses: actions/checkout@v3
 
@@ -68,7 +71,6 @@ jobs:
   build-rust:
     name: Build Spin
     runs-on: ${{ matrix.os }}
-    needs: [lint-rust]
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
@@ -97,7 +99,6 @@ jobs:
   test-rust:
     name: Test Spin SDK - Rust
     runs-on: ${{ matrix.runner }}
-    needs: [lint-rust]
     strategy:
       matrix:
         runner: [ubuntu-22.04-4core-spin, macos-latest]

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,13 @@ install:
 test: lint test-unit test-integration
 
 .PHONY: lint
-lint:
-	cargo clippy --all-targets --all-features -- -D warnings
+lint: lint-rust-examples-and-testcases
+	cargo clippy --all --all-targets --all-features -- -D warnings
 	cargo fmt --all -- --check
 
-.PHONY: check-rust-examples
-check-rust-examples:
-	for manifest_path in examples/*/Cargo.toml; do \
+.PHONY: lint-rust-examples-and-testcases
+lint-rust-examples-and-testcases:
+	for manifest_path in examples/*/Cargo.toml tests/testcases/*/Cargo.toml; do \
 		cargo clippy --manifest-path "$${manifest_path}" -- -D warnings \
 		&& cargo fmt --manifest-path "$${manifest_path}" -- --check \
 		|| exit 1 ; \

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test: lint test-unit test-integration
 
 .PHONY: lint
 lint: lint-rust-examples-and-testcases
-	cargo clippy --all --all-targets --all-features -- -D warnings
+	cargo clippy --all --all-targets --features all-tests -- -D warnings
 	cargo fmt --all -- --check
 
 .PHONY: lint-rust-examples-and-testcases

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ lint: lint-rust-examples-and-testcases
 
 .PHONY: lint-rust-examples-and-testcases
 lint-rust-examples-and-testcases:
-	for manifest_path in examples/*/Cargo.toml tests/testcases/*/Cargo.toml; do \
+	for manifest_path in $$(find examples tests/testcases -name Cargo.toml); do \
 		cargo clippy --manifest-path "$${manifest_path}" -- -D warnings \
 		&& cargo fmt --manifest-path "$${manifest_path}" -- --check \
 		|| exit 1 ; \

--- a/examples/spin-wagi-http/http-rust/Cargo.lock
+++ b/examples/spin-wagi-http/http-rust/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "autocfg"
@@ -22,15 +22,21 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fnv"
@@ -48,6 +54,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "goodbyerust"
 version = "0.1.0"
 dependencies = [
@@ -59,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -101,11 +196,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
  "serde",
 ]
@@ -130,9 +225,15 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "percent-encoding"
@@ -141,19 +242,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.60"
+name = "pin-project-lite"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
 dependencies = [
  "bitflags 1.3.2",
  "memchr",
@@ -180,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,23 +306,49 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smartcow"
@@ -226,6 +371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b19b32ed6d899ab23174302ff105c1577e45a06b08d4fe0a9dd13ce804bbbf71"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "spin-macro"
 version = "0.1.0"
 dependencies = [
@@ -239,12 +393,14 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "1.4.0-pre0"
+version = "2.0.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
  "form_urlencoded",
+ "futures",
  "http",
+ "once_cell",
  "routefinder",
  "spin-macro",
  "thiserror",
@@ -270,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -375,31 +531,33 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.29.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+checksum = "34180c89672b3e4825c3a8db4b61a674f1447afd5fe2445b2d22c3d8b6ea086c"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.8.0"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e5156581ff4a302405c44ca7c85347563ca431d15f1a773f12c9c7b9a6cdc9"
+checksum = "4f2c051ef041d348324b01ff0419f6f6593f094b4897d93c9cf52d5d1ac879ba"
 dependencies = [
  "anyhow",
  "indexmap",
  "serde",
+ "serde_json",
+ "spdx",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.107.0"
+version = "0.113.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
+checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
 dependencies = [
  "indexmap",
  "semver",
@@ -407,19 +565,17 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392d16e9e46cc7ca98125bc288dd5e4db469efe8323d3e0dac815ca7f2398522"
+version = "0.12.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=46fba30bb667a3a4962f63b1cc28b84427b49114#46fba30bb667a3a4962f63b1cc28b84427b49114"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.4.0",
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d422d36cbd78caa0e18c3371628447807c66ee72466b69865ea7e33682598158"
+version = "0.12.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=46fba30bb667a3a4962f63b1cc28b84427b49114#46fba30bb667a3a4962f63b1cc28b84427b49114"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -428,36 +584,25 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b76db68264f5d2089dc4652581236d8e75c5b89338de6187716215fd0e68ba3"
+version = "0.12.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=46fba30bb667a3a4962f63b1cc28b84427b49114#46fba30bb667a3a4962f63b1cc28b84427b49114"
 dependencies = [
+ "anyhow",
  "heck",
  "wasm-metadata",
  "wit-bindgen-core",
- "wit-bindgen-rust-lib",
  "wit-component",
 ]
 
 [[package]]
-name = "wit-bindgen-rust-lib"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c50f334bc08b0903a43387f6eea6ef6aa9eb2a085729f1677b29992ecef20ba"
-dependencies = [
- "heck",
- "wit-bindgen-core",
-]
-
-[[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced38a5e174940c6a41ae587babeadfd2e2c2dc32f3b6488bcdca0e8922cf3f3"
+version = "0.12.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=46fba30bb667a3a4962f63b1cc28b84427b49114#46fba30bb667a3a4962f63b1cc28b84427b49114"
 dependencies = [
  "anyhow",
  "proc-macro2",
- "syn 2.0.18",
+ "quote",
+ "syn 2.0.38",
  "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-component",
@@ -465,14 +610,16 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.11.0"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbd4c7f8f400327c482c88571f373844b7889e61460650d650fc5881bb3575c"
+checksum = "2e2bf941487fc5afa9e3fc94761f6b80ecef5a2bed6239b959d23d9de69e3448"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "indexmap",
  "log",
+ "serde",
+ "serde_json",
  "wasm-encoder",
  "wasm-metadata",
  "wasmparser",
@@ -481,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6daec9f093dbaea0e94043eeb92ece327bbbe70c86b1f41aca9bbfefd7f050f0"
+checksum = "a39edca9abb16309def3843af73b58d47d243fe33a9ceee572446bcc57556b9a"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -491,6 +638,8 @@ dependencies = [
  "log",
  "pulldown-cmark",
  "semver",
+ "serde",
+ "serde_json",
  "unicode-xid",
  "url",
 ]

--- a/tests/testcases/head-rust-sdk-redis/src/lib.rs
+++ b/tests/testcases/head-rust-sdk-redis/src/lib.rs
@@ -4,7 +4,7 @@ use spin_sdk::redis_component;
 fn on_message(message: bytes::Bytes) -> anyhow::Result<()> {
     println!(
         "Got message: '{}'",
-        std::str::from_utf8(&*message).unwrap_or("<MESSAGE NOT UTF8>")
+        std::str::from_utf8(&message).unwrap_or("<MESSAGE NOT UTF8>")
     );
     Ok(())
 }

--- a/tests/testcases/headers-dynamic-env-test/src/lib.rs
+++ b/tests/testcases/headers-dynamic-env-test/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use spin_sdk::{
     http::{Request, Response},
-    http_component
+    http_component,
 };
 
 // This handler does the following:
@@ -11,13 +11,14 @@ use spin_sdk::{
 fn handle_http_request(req: Request) -> Result<Response> {
     match append_headers(http::Response::builder(), &req) {
         Err(e) => anyhow::bail!("Unable to append headers to response: {}", e),
-        Ok(resp) => Ok(resp
-            .status(200)
-            .body(Some("I'm a teapot".into()))?)
+        Ok(resp) => Ok(resp.status(200).body(Some("I'm a teapot".into()))?),
     }
 }
 
-fn append_headers(mut resp: http::response::Builder, req: &Request) -> Result<http::response::Builder> {
+fn append_headers(
+    mut resp: http::response::Builder,
+    req: &Request,
+) -> Result<http::response::Builder> {
     for (k, v) in std::env::vars() {
         resp = resp.header(format!("ENV_{}", k), v);
     }

--- a/tests/testcases/headers-env-routes-test/src/lib.rs
+++ b/tests/testcases/headers-env-routes-test/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use spin_sdk::{
     http::{Request, Response},
-    http_component
+    http_component,
 };
 
 // This handler does the following:
@@ -11,13 +11,14 @@ use spin_sdk::{
 fn handle_http_request(req: Request) -> Result<Response> {
     match append_headers(http::Response::builder(), &req) {
         Err(e) => anyhow::bail!("Unable to append headers to response: {}", e),
-        Ok(resp) => Ok(resp
-            .status(200)
-            .body(Some("I'm a teapot".into()))?)
+        Ok(resp) => Ok(resp.status(200).body(Some("I'm a teapot".into()))?),
     }
 }
 
-fn append_headers(mut resp: http::response::Builder, req: &Request) -> Result<http::response::Builder> {
+fn append_headers(
+    mut resp: http::response::Builder,
+    req: &Request,
+) -> Result<http::response::Builder> {
     for (k, v) in std::env::vars() {
         resp = resp.header(format!("ENV_{}", k), v);
     }

--- a/tests/testcases/http-rust-outbound-mysql/src/lib.rs
+++ b/tests/testcases/http-rust-outbound-mysql/src/lib.rs
@@ -2,7 +2,8 @@
 use anyhow::{anyhow, Result};
 use spin_sdk::{
     http::{Request, Response},
-    http_component, mysql::{self, Decode},
+    http_component,
+    mysql::{self, Decode},
 };
 
 // The environment variable set in `spin.toml` that points to the
@@ -34,7 +35,7 @@ struct CharacterRow {
     rchar: String,
     rbinary: Vec<u8>,
     rvarbinary: Vec<u8>,
-    rblob: Vec<u8>
+    rblob: Vec<u8>,
 }
 
 #[http_component]

--- a/tests/testcases/http-rust-outbound-pg/src/lib.rs
+++ b/tests/testcases/http-rust-outbound-pg/src/lib.rs
@@ -234,12 +234,12 @@ fn test_general_types(_req: Request) -> Result<Response> {
 
     pg::execute(&address, create_table_sql, &[])?;
 
-    let insert_sql = r#"
+    let insert_sql = r"
         INSERT INTO test_general_types
             (rbool, rbytea)
         VALUES
             (TRUE, '\176'::bytea);
-    "#;
+    ";
 
     pg::execute(&address, insert_sql, &[])?;
 

--- a/tests/testcases/key-value-undefined-store/src/lib.rs
+++ b/tests/testcases/key-value-undefined-store/src/lib.rs
@@ -1,13 +1,11 @@
-use anyhow::{ensure, Result};
-use itertools::sorted;
+use anyhow::Result;
 use spin_sdk::{
     http::{Request, Response},
     http_component,
-    key_value::{Error, Store},
 };
 
 #[http_component]
-fn handle_request(req: Request) -> Result<Response> {
+fn handle_request(_req: Request) -> Result<Response> {
     // We don't need to do anything here: it should never get called because
     // spin up should fail at K/V validation.
     Ok(http::Response::builder().status(200).body(None)?)

--- a/tests/testcases/key-value/src/lib.rs
+++ b/tests/testcases/key-value/src/lib.rs
@@ -43,9 +43,9 @@ fn handle_request(req: Request) -> Result<Response> {
     ensure!(b"wow" as &[_] == &store.get("bar")?);
 
     ensure!(
-        init_val.as_bytes() == &store.get(&init_key)?,
+        init_val.as_bytes() == store.get(init_key)?,
         "Expected to look up {init_key} and get {init_val} but actually got {}",
-        String::from_utf8_lossy(&store.get(&init_key)?)
+        String::from_utf8_lossy(&store.get(init_key)?)
     );
 
     ensure!(
@@ -57,7 +57,7 @@ fn handle_request(req: Request) -> Result<Response> {
     );
 
     store.delete("bar")?;
-    store.delete(&init_key)?;
+    store.delete(init_key)?;
 
     ensure!(&[] as &[String] == &store.get_keys()?);
 

--- a/tests/testcases/sqlite-undefined-db/src/lib.rs
+++ b/tests/testcases/sqlite-undefined-db/src/lib.rs
@@ -1,13 +1,11 @@
-use anyhow::{ensure, Result};
-use itertools::sorted;
+use anyhow::Result;
 use spin_sdk::{
     http::{Request, Response},
     http_component,
-    key_value::{Error, Store},
 };
 
 #[http_component]
-fn handle_request(req: Request) -> Result<Response> {
+fn handle_request(_req: Request) -> Result<Response> {
     // We don't need to do anything here: it should never get called because
     // spin up should fail at SQLite validation.
     Ok(http::Response::builder().status(200).body(None)?)


### PR DESCRIPTION
Runs linting over "tests/testcases/*/Cargo.toml" and changes Rust linting in CI to happen all together.

Unfortunately the linting job takes much longer now which would delay the other jobs from getting started. Instead of gating on linting passing, we now let everything run and cancel if linting fails. 