### PR TITLE
chore(oci): pub utils::archive,unarchive, media types

### DIFF
--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -1,3 +1,5 @@
+//! Spin's client for distributing applications via OCI registries
+
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -24,10 +26,14 @@ use walkdir::WalkDir;
 use crate::auth::AuthConfig;
 
 // TODO: the media types for application, wasm module, data and archive layer are not final.
-const SPIN_APPLICATION_MEDIA_TYPE: &str = "application/vnd.fermyon.spin.application.v1+config";
+/// Media type for a layer representing a locked Spin application configuration
+pub const SPIN_APPLICATION_MEDIA_TYPE: &str = "application/vnd.fermyon.spin.application.v1+config";
+// Note: we hope to use a canonical value defined upstream for this media type
 const WASM_LAYER_MEDIA_TYPE: &str = "application/vnd.wasm.content.layer.v1+wasm";
-const DATA_MEDIATYPE: &str = "application/vnd.wasm.content.layer.v1+data";
-const ARCHIVE_MEDIATYPE: &str = "application/vnd.wasm.content.bundle.v1.tar+gzip";
+/// Media type for a layer representing a generic data file used by a Spin application
+pub const DATA_MEDIATYPE: &str = "application/vnd.wasm.content.layer.v1+data";
+/// Media type for a layer representing a compressed archive of one or more files used by a Spin application
+pub const ARCHIVE_MEDIATYPE: &str = "application/vnd.wasm.content.bundle.v1.tar+gzip";
 
 const CONFIG_FILE: &str = "config.json";
 const LATEST_TAG: &str = "latest";

--- a/crates/oci/src/lib.rs
+++ b/crates/oci/src/lib.rs
@@ -2,9 +2,9 @@
 #![deny(missing_docs)]
 
 mod auth;
-mod client;
+pub mod client;
 mod loader;
-mod utils;
+pub mod utils;
 
 pub use client::Client;
 pub use loader::OciLoader;

--- a/crates/oci/src/utils.rs
+++ b/crates/oci/src/utils.rs
@@ -1,3 +1,5 @@
+//! Utilities related to distributing Spin apps via OCI registries
+
 use anyhow::{Context, Result};
 use async_compression::tokio::bufread::GzipDecoder;
 use async_compression::tokio::write::GzipEncoder;


### PR DESCRIPTION
Intention with this one is to make some of the Spin-specific media types public, as well as the archive/unarchive methods in the utils crate, for use by other repos.

I see the two pre-existing [pub uses for Client and OciLoader](https://github.com/fermyon/spin/blob/main/crates/oci/src/lib.rs#L9-L10) -- not sure if something like this would be preferred over making all of the client and utils crates public.
