### PR TITLE
Fail the CI lint if running linting dirties work tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,9 @@ jobs:
           rust-cache: true
 
       - name: Run lints
-        run:
-          BUILD_SPIN_EXAMPLES=0 make lint
+        run: |
+            BUILD_SPIN_EXAMPLES=0 make lint
+            git diff --quiet . || (echo "Git working tree dirtied by lints. Run `make lint` and check in changes" && exit 1)
 
       - name: Cancel everything if linting fails
         if: failure()

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -3588,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=ed1305044fd1455ded4bb47a4d3b1ed8a505fc86#ed1305044fd1455ded4bb47a4d3b1ed8a505fc86"
+source = "git+https://github.com/fermyon/spin-componentize?rev=0c68c5f2afae65c2011fa23b30fd136682506e2a#0c68c5f2afae65c2011fa23b30fd136682506e2a"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.35.0",


### PR DESCRIPTION
We currently don't require that examples and tests have their Cargo.lock files updated when a PR is opened.

If a future PR author does run an example locally, they will end up with changes to the Cargo.lock file unrelated to their changes. This change fails CI if the examples or tests produce new Cargo.lock files.

This does mean that if a PR author does change a dependency they will need to run `make lint` locally so that everything is updated properly. 

~~Note: this PR will fail tests when first opened but #1893 being merged and this being rebased on top of that will fix it.~~