### PR TITLE
chore(templates/tests): bump spin-fileserver version

### DIFF
--- a/templates/static-fileserver/content/spin.toml
+++ b/templates/static-fileserver/content/spin.toml
@@ -6,7 +6,7 @@ trigger = { type = "http", base = "{{http-base}}" }
 version = "0.1.0"
 
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.3/spin_static_fs.wasm", digest = "sha256:38bf971900228222f7f6b2ccee5051f399adca58d71692cdfdea98997965fd0d" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
 id = "{{ project-name }}"
 files = [{ source = "{{ files-path }}", destination = "/" }]
 [component.trigger]

--- a/templates/static-fileserver/metadata/snippets/component.txt
+++ b/templates/static-fileserver/metadata/snippets/component.txt
@@ -1,5 +1,5 @@
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.3/spin_static_fs.wasm", digest = "sha256:38bf971900228222f7f6b2ccee5051f399adca58d71692cdfdea98997965fd0d" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
 id = "{{ project-name }}"
 files = [ { source = "{{ files-path }}", destination = "/" } ]
 [component.trigger]

--- a/tests/testcases/assets-test/spin.toml
+++ b/tests/testcases/assets-test/spin.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 
 [[component]]
 id = "fs"
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
 files = [{source = "static/thisshouldbemounted", destination = "/thisshouldbemounted"}]
 exclude_files = ["static/thisshouldbemounted/thisshouldbeexcluded/*"]
 [component.trigger]

--- a/tests/watch/static-fileserver/spin.toml
+++ b/tests/watch/static-fileserver/spin.toml
@@ -6,7 +6,7 @@ trigger = { type = "http" }
 version = "0.1.0"
 
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.1/spin_static_fs.wasm", digest = "sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
 id = "static-fileserver"
 files = [ { source = "assets", destination = "/" } ]
 [component.trigger]


### PR DESCRIPTION
Bump to latest [v0.1.0](https://github.com/fermyon/spin-fileserver/releases/tag/v0.1.0) release of the spin-fileserver module.