### PR TITLE
Adjust outbound HTTP Requests in wasi-http

### DIFF
--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
@@ -13,7 +13,7 @@ async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
             .uri("/hello") // relative routes are not yet supported in cloud
             .body(())?,
     )
-    .await?;
+    .await??;
     res.headers_mut()
         .insert("spin-component", "rust-outbound-http".try_into()?);
     println!("{:?}", res);

--- a/examples/http-rust-outbound-http/outbound-http/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http/src/lib.rs
@@ -7,13 +7,13 @@ use spin_sdk::{
 /// Send an HTTP request and return the response.
 #[http_component]
 async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
-    let mut res: http::Response<()> = spin_sdk::http::send(
+    let mut res: http::Response<String> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")
             .uri("https://random-data-api.fermyon.app/animals/json")
             .body(())?,
     )
-    .await?;
+    .await??;
     res.headers_mut()
         .insert("spin-component", "rust-outbound-http".try_into()?);
     println!("{:?}", res);

--- a/examples/wasi-http-rust-streaming-outgoing-body/src/lib.rs
+++ b/examples/wasi-http-rust-streaming-outgoing-body/src/lib.rs
@@ -108,7 +108,7 @@ async fn hash(url: &Url) -> Result<String> {
         &Headers::new(&[]),
     );
 
-    let response: IncomingResponse = send(request).await?;
+    let response: IncomingResponse = send(request).await??;
 
     let status = response.status();
 

--- a/tests/testcases/outbound-http-to-same-app/outbound-http-component/src/lib.rs
+++ b/tests/testcases/outbound-http-to-same-app/outbound-http-component/src/lib.rs
@@ -13,7 +13,7 @@ async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
             .uri("/test/hello")
             .body(())?,
     )
-    .await?;
+    .await??;
     res.headers_mut()
         .insert("spin-component", "outbound-http-component".try_into()?);
     println!("{:?}", res);


### PR DESCRIPTION
Changes the outbound HTTP API.

The `send` function takes any type that implements `Sendable` which are all request like types. It then returns the result of trying to turn the response into the desired type. See some examples for how this will work. 

This API isn't the cleanest unfortunately, but so far I've not come up with anything better. 