### PR TITLE
ci: Print dirty lint paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run lints
         run: |
             BUILD_SPIN_EXAMPLES=0 make lint
-            git diff --quiet . || (echo "Git working tree dirtied by lints. Run `make lint` and check in changes" && exit 1)
+            git diff --name-status --exit-code . || (echo "Git working tree dirtied by lints. Run `make lint` and check in changes" && exit 1)
 
       - name: Cancel everything if linting fails
         if: failure()


### PR DESCRIPTION
This should make it easier to fix "Git working tree dirtied by lints".