### PR TITLE
Add make command for updating all lock files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run lints
         run: |
             BUILD_SPIN_EXAMPLES=0 make lint
-            git diff --name-status --exit-code . || (echo "Git working tree dirtied by lints. Run `make lint` and check in changes" && exit 1)
+            git diff --name-status --exit-code . || (echo "Git working tree dirtied by lints. Run 'make update-cargo-locks' and check in changes" && exit 1)
 
       - name: Cancel everything if linting fails
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,16 @@ lint-rust-examples-and-testcases:
 		|| exit 1 ; \
 	done
 
+## Bring all of the checked in `Cargo.lock` files up-to-date
+.PHONY: update-cargo-locks
+update-cargo-locks: 
+	echo "Updating Cargo.toml"
+	cargo update -w --offline; \
+	for manifest_path in $$(find examples tests/testcases -name Cargo.toml); do \
+		echo "Updating $${manifest_path}" && \
+		cargo update --manifest-path "$${manifest_path}" -w --offline; \
+	done
+
 .PHONY: test-unit
 test-unit:
 	RUST_LOG=$(LOG_LEVEL) cargo test --all --no-fail-fast -- --skip integration_tests --skip spinup_tests --skip cloud_tests --nocapture


### PR DESCRIPTION
Instead of doing the full `clippy` and `rustfmt` run, we can now run `make update-cargo-locks` which will do the minimal work to update the lock files. 