### PR TITLE
CI: give permissions to lint job to cancel entire workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
   lint-rust:
     name: Lint Rust
     runs-on: "ubuntu-latest"
+    permissions:
+      ## Allow this job to potentially cancel the running workflow (on failure)
+      actions: write
     steps:
       - uses: actions/checkout@v3
 
@@ -36,9 +39,7 @@ jobs:
           rust-cache: true
 
       - name: Run lints
-        run: |
-            BUILD_SPIN_EXAMPLES=0 make lint
-            git diff --name-status --exit-code . || (echo "Git working tree dirtied by lints. Run 'make update-cargo-locks' and check in changes" && exit 1)
+        run: BUILD_SPIN_EXAMPLES=0 make lint
 
       - name: Cancel everything if linting fails
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,10 @@ lint: lint-rust-examples-and-testcases
 .PHONY: lint-rust-examples-and-testcases
 lint-rust-examples-and-testcases:
 	for manifest_path in $$(find examples tests/testcases -name Cargo.toml); do \
-		cargo clippy --manifest-path "$${manifest_path}" -- -D warnings \
+		echo "Linting $${manifest_path}" \
+		&& cargo clippy --manifest-path "$${manifest_path}" -- -D warnings \
 		&& cargo fmt --manifest-path "$${manifest_path}" -- --check \
+		&& (git diff --name-status --exit-code . || (echo "Git working tree dirtied by lints. Run 'make update-cargo-locks' and check in changes" && false)) \
 		|| exit 1 ; \
 	done
 


### PR DESCRIPTION
The lint work flow is supposed to cancel the entire workflow on failure, but it does not have permissions. This gives it permissions. This also should fail the workflow faster since the check for a dirty working tree is done in `make lint` instead of after it.

I tested this with a change that failed the lint, and [it successfully canceled the entire workflow](https://github.com/fermyon/spin/actions/runs/6559338362/job/17814773146#step:5:9).