### PR TITLE
Fix "duplicate package" warning when referencing Spin crates

### DIFF
--- a/examples/wasi-http-rust/Cargo.lock
+++ b/examples/wasi-http-rust/Cargo.lock
@@ -174,16 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-rust"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "http",
- "serde",
- "spin-sdk",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +455,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi-http-rust"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "http",
+ "serde",
+ "spin-sdk",
+]
 
 [[package]]
 name = "wasm-encoder"

--- a/examples/wasi-http-rust/Cargo.toml
+++ b/examples/wasi-http-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http-rust"
+name = "wasi-http-rust"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/wasi-http-rust/spin.toml
+++ b/examples/wasi-http-rust/spin.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 
 [[component]]
 id = "hello"
-source = "target/wasm32-wasi/release/http_rust.wasm"
+source = "target/wasm32-wasi/release/wasi_http_rust.wasm"
 description = "A simple component that returns hello."
 [component.trigger]
 route = "/hello"


### PR DESCRIPTION
When two Rust examples in the Spin repo have the same package name, anyone compiling Rust against _any_ Spin repo GitHub reference - whether Spin crates or the Rust SDK - gets a "warning: skipping duplicate package `...`" message.

We had another `http-rust` one sneak in recently: this should fix it.
