### PR TITLE
Report `cargo fmt` and `clippy` errors more quickly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,11 @@ jobs:
           rust-wasm: true
           rust-cache: true
 
-      - name: Run lints
+      - name: Run lints on main code
         run: BUILD_SPIN_EXAMPLES=0 make lint
+
+      - name: Run lints on examples
+        run: BUILD_SPIN_EXAMPLES=0 make lint-rust-examples-and-testcases
 
       - name: Cancel everything if linting fails
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install:
 test: lint test-unit test-integration
 
 .PHONY: lint
-lint: lint-rust-examples-and-testcases
+lint:
 	cargo clippy --all --all-targets --features all-tests -- -D warnings
 	cargo fmt --all -- --check
 
@@ -66,6 +66,9 @@ lint-rust-examples-and-testcases:
 		&& (git diff --name-status --exit-code . || (echo "Git working tree dirtied by lints. Run 'make update-cargo-locks' and check in changes" && false)) \
 		|| exit 1 ; \
 	done
+
+.PHONY: lint-all
+lint-all: lint lint-rust-examples-and-testcases
 
 ## Bring all of the checked in `Cargo.lock` files up-to-date
 .PHONY: update-cargo-locks


### PR DESCRIPTION
Previously ~if~ when I forgot to run `cargo fmt` I got a red mark in 2-3 minutes.  It now takes 20-25 minutes.  This PR proposes running lints on the core code separately from lints on the examples, so that we can get feedback more quickly in cases where the examples haven't changed (and don't need to change).

This also makes the `make lint` target do "core" code only, with `make lint-all` to lint, er, all.  If we prefer we could keep `lint` as being everything and have a `lint-spin`  target for the "core" code - I wasn't sure what people would prefer to be the default.

