### PR TITLE
Update redis-* and http-go templates

### DIFF
--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -869,12 +869,9 @@ mod tests {
         {
             let template = manager.get("http-empty").unwrap().unwrap();
 
-            let values = [
-                ("project-description".to_owned(), "my desc".to_owned()),
-                ("http-base".to_owned(), "/".to_owned()),
-            ]
-            .into_iter()
-            .collect();
+            let values = [("project-description".to_owned(), "my desc".to_owned())]
+                .into_iter()
+                .collect();
             let options = RunOptions {
                 variant: crate::template::TemplateVariantInfo::NewApplication,
                 output_path: application_dir.clone(),

--- a/templates/http-empty/content/spin.toml
+++ b/templates/http-empty/content/spin.toml
@@ -1,6 +1,7 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name}}"
+version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"
-name = "{{project-name}}"
-trigger = { type = "http", base = "{{http-base}}" }
-version = "0.1.0"

--- a/templates/http-empty/metadata/spin-template.toml
+++ b/templates/http-empty/metadata/spin-template.toml
@@ -5,4 +5,3 @@ tags = ["http"]
 
 [parameters]
 project-description = { type = "string",  prompt = "Description", default = "" }
-http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }

--- a/templates/http-go/content/spin.toml
+++ b/templates/http-go/content/spin.toml
@@ -1,16 +1,18 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name}}"
+version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"
-name = "{{project-name}}"
-trigger = { type = "http", base = "{{http-base}}" }
-version = "0.1.0"
 
-[[component]]
-id = "{{project-name | kebab_case}}"
+[[trigger.http]]
+route = "{{http-path}}"
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
 source = "main.wasm"
 allowed_http_hosts = []
-[component.trigger]
-route = "{{http-path}}"
-[component.build]
+[component.{{project-name | kebab_case}}.build]
 command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]

--- a/templates/http-go/metadata/snippets/component.txt
+++ b/templates/http-go/metadata/snippets/component.txt
@@ -1,10 +1,11 @@
-[[component]]
-id = "{{project-name | kebab_case}}"
+[[trigger.http]]
+route = "{{http-path}}"
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
 source = "{{ output-path }}/main.wasm"
 allowed_http_hosts = []
-[component.trigger]
-route = "{{http-path}}"
-[component.build]
+[component.{{project-name | kebab_case}}.build]
 command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
 workdir = "{{ output-path }}"
 watch = ["**/*.go", "go.mod"]

--- a/templates/http-go/metadata/spin-template.toml
+++ b/templates/http-go/metadata/spin-template.toml
@@ -5,11 +5,9 @@ tags = ["http", "go"]
 
 [add_component]
 skip_files = ["spin.toml"]
-skip_parameters = ["http-base"]
 [add_component.snippets]
 component = "component.txt"
 
 [parameters]
 project-description = { type = "string",  prompt = "Description", default = "" }
-http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }

--- a/templates/redis-go/content/spin.toml
+++ b/templates/redis-go/content/spin.toml
@@ -1,15 +1,20 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name}}"
+version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"
-name = "{{project-name}}"
-trigger = { type = "redis", address = "{{redis-address}}" }
-version = "0.1.0"
 
-[[component]]
-id = "{{project-name | kebab_case}}"
+[application.trigger.redis]
+address = "{{redis-address}}"
+
+[[trigger.redis]]
+channel = "{{redis-channel}}"
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
 source = "main.wasm"
 allowed_http_hosts = []
-[component.trigger]
-channel = "{{redis-channel}}"
-[component.build]
+[component.{{project-name | kebab_case}}.build]
 command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"

--- a/templates/redis-rust/content/spin.toml
+++ b/templates/redis-rust/content/spin.toml
@@ -1,15 +1,20 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name}}"
+version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"
-name = "{{project-name}}"
-trigger = { type = "redis", address = "{{redis-address}}" }
-version = "0.1.0"
 
-[[component]]
-id = "{{project-name | kebab_case}}"
+[application.trigger.redis]
+address = "{{redis-address}}"
+
+[[trigger.redis]]
+channel = "{{redis-channel}}"
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
 source = "target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
 allowed_http_hosts = []
-[component.trigger]
-channel = "{{redis-channel}}"
-[component.build]
+[component.{{project-name | kebab_case}}.build]
 command = "cargo build --target wasm32-wasi --release"


### PR DESCRIPTION
NOTE: I was not able to get a `redis-go` application to build locally.  However the error was the same as if I used the existing template, so I don't believe I've introduced a bug.

Well, not _that_ bug anyway.
