### PR TITLE
No custom `Request`/`Response` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6023,7 +6023,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/http-rust-outbound-http/http-hello/Cargo.lock
+++ b/examples/http-rust-outbound-http/http-hello/Cargo.lock
@@ -224,12 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.lock
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "outbound-http-to-same-app"
 version = "0.1.0"
 dependencies = [
@@ -395,7 +389,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
@@ -1,12 +1,9 @@
 use anyhow::Result;
-use spin_sdk::{
-    http::{IntoResponse, Request},
-    http_component,
-};
+use spin_sdk::{http::IntoResponse, http_component};
 
 /// Send an HTTP request and return the response.
 #[http_component]
-async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
+async fn send_outbound(_req: http::Request<()>) -> Result<impl IntoResponse> {
     let mut res: http::Response<()> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")

--- a/examples/http-rust-outbound-http/outbound-http/Cargo.lock
+++ b/examples/http-rust-outbound-http/outbound-http/Cargo.lock
@@ -224,12 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/http-rust-outbound-http/outbound-http/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http/src/lib.rs
@@ -1,13 +1,10 @@
 use anyhow::Result;
-use spin_sdk::{
-    http::{IntoResponse, Request},
-    http_component,
-};
+use spin_sdk::{http::IntoResponse, http_component};
 
 /// Send an HTTP request and return the response.
 #[http_component]
-async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
-    let mut res: http::Response<()> = spin_sdk::http::send(
+async fn send_outbound(_req: http::Request<()>) -> Result<impl IntoResponse> {
+    let mut res: http::Response<String> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")
             .uri("https://random-data-api.fermyon.app/animals/json")

--- a/examples/http-rust-router-macro/Cargo.lock
+++ b/examples/http-rust-router-macro/Cargo.lock
@@ -178,6 +178,7 @@ name = "http-rust-router-macro"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "http",
  "spin-sdk",
 ]
 
@@ -221,12 +222,6 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "percent-encoding"
@@ -383,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/http-rust-router-macro/Cargo.toml
+++ b/examples/http-rust-router-macro/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Useful crate to handle errors.
 anyhow = "1"
-# The Spin SDK.
+http = "0.2.9"
 spin-sdk = { path = "../../sdk/rust" }
 
 [workspace]

--- a/examples/http-rust-router/Cargo.lock
+++ b/examples/http-rust-router/Cargo.lock
@@ -178,6 +178,7 @@ name = "http-rust-router"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "http",
  "spin-sdk",
 ]
 
@@ -221,12 +222,6 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "percent-encoding"
@@ -383,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/http-rust-router/Cargo.toml
+++ b/examples/http-rust-router/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Useful crate to handle errors.
 anyhow = "1"
-# The Spin SDK.
+http = "0.2.9"
 spin-sdk = { path = "../../sdk/rust" }
 [workspace]

--- a/examples/http-rust-router/src/lib.rs
+++ b/examples/http-rust-router/src/lib.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use spin_sdk::{
-    http::{IntoResponse, Params, Request, Response, Router},
+    http::{IntoResponse, Params, Router},
     http_component,
 };
 
 /// A Spin HTTP component that internally routes requests.
 #[http_component]
-fn handle_route(req: Request) -> Response {
+fn handle_route(req: http::Request<()>) -> impl IntoResponse {
     let mut router = Router::new();
     router.get("/hello/:planet", api::hello_planet);
     router.any("/*", api::echo_wildcard);
@@ -17,15 +17,19 @@ mod api {
     use super::*;
 
     // /hello/:planet
-    pub fn hello_planet(_req: Request, params: Params) -> Result<impl IntoResponse> {
+    pub fn hello_planet(_req: http::Request<()>, params: Params) -> Result<impl IntoResponse> {
         let planet = params.get("planet").expect("PLANET");
 
-        Ok(Response::new(200, planet.to_string()))
+        Ok(http::Response::builder()
+            .status(200)
+            .body(planet.to_string())?)
     }
 
     // /*
-    pub fn echo_wildcard(_req: Request, params: Params) -> Result<impl IntoResponse> {
+    pub fn echo_wildcard(_req: http::Request<()>, params: Params) -> Result<impl IntoResponse> {
         let capture = params.wildcard().unwrap_or_default();
-        Ok(Response::new(200, capture.to_string()))
+        Ok(http::Response::builder()
+            .status(200)
+            .body(capture.to_string())?)
     }
 }

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/http-rust/src/lib.rs
+++ b/examples/http-rust/src/lib.rs
@@ -1,4 +1,4 @@
-use spin_sdk::http::{IntoResponse, Json, Response};
+use spin_sdk::http::{IntoResponse, Json};
 use spin_sdk::http_component;
 
 #[derive(serde::Deserialize, Debug)]
@@ -9,5 +9,7 @@ struct Greeted {
 /// A simple Spin HTTP component.
 #[http_component]
 fn hello_world(req: http::Request<Json<Greeted>>) -> anyhow::Result<impl IntoResponse> {
-    Ok(Response::new(200, format!("Hello, {}", req.body().name)))
+    Ok(http::Response::builder()
+        .status(200)
+        .body(format!("Hello, {}", req.body().name))?)
 }

--- a/examples/redis-rust/Cargo.lock
+++ b/examples/redis-rust/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +369,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/rust-key-value/Cargo.lock
+++ b/examples/rust-key-value/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/rust-key-value/src/lib.rs
+++ b/examples/rust-key-value/src/lib.rs
@@ -1,9 +1,5 @@
 use http::{Method, StatusCode};
-use spin_sdk::{
-    http::{IntoResponse, Response},
-    http_component,
-    key_value::Store,
-};
+use spin_sdk::{http::IntoResponse, http_component, key_value::Store};
 
 #[http_component]
 fn handle_request(req: http::Request<Vec<u8>>) -> anyhow::Result<impl IntoResponse> {
@@ -40,5 +36,5 @@ fn handle_request(req: http::Request<Vec<u8>>) -> anyhow::Result<impl IntoRespon
         // No other methods are currently supported
         _ => (StatusCode::METHOD_NOT_ALLOWED, None),
     };
-    Ok(Response::new(status, body))
+    Ok(http::Response::builder().status(status).body(body)?)
 }

--- a/examples/rust-outbound-mysql/Cargo.lock
+++ b/examples/rust-outbound-mysql/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +380,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/rust-outbound-pg/Cargo.lock
+++ b/examples/rust-outbound-pg/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/rust-outbound-redis/Cargo.lock
+++ b/examples/rust-outbound-redis/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +265,7 @@ name = "rust-outbound-redis"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "http",
  "spin-sdk",
 ]
 
@@ -383,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/rust-outbound-redis/Cargo.toml
+++ b/examples/rust-outbound-redis/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Useful crate to handle errors.
 anyhow = "1"
-# The Spin SDK.
+http = "0.2.9"
 spin-sdk = { path = "../../sdk/rust" }
 
 [workspace]

--- a/examples/rust-outbound-redis/src/lib.rs
+++ b/examples/rust-outbound-redis/src/lib.rs
@@ -1,9 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use spin_sdk::{
-    http::responses::internal_server_error,
-    http::{IntoResponse, Request, Response},
-    http_component, redis,
-};
+use spin_sdk::{http::responses::internal_server_error, http::IntoResponse, http_component, redis};
 
 // The environment variable set in `spin.toml` that points to the
 // address of the Redis server that the component will publish
@@ -19,7 +15,7 @@ const REDIS_CHANNEL_ENV: &str = "REDIS_CHANNEL";
 /// to a Redis channel. The component is triggered by an HTTP
 /// request served on the route configured in the `spin.toml`.
 #[http_component]
-fn publish(_req: Request) -> Result<impl IntoResponse> {
+fn publish(_req: http::Request<()>) -> Result<impl IntoResponse> {
     let address = std::env::var(REDIS_ADDRESS_ENV)?;
     let channel = std::env::var(REDIS_CHANNEL_ENV)?;
 
@@ -45,7 +41,7 @@ fn publish(_req: Request) -> Result<impl IntoResponse> {
 
     // Publish to Redis
     match conn.publish(&channel, &payload) {
-        Ok(()) => Ok(Response::new(200, ())),
-        Err(_e) => Ok(internal_server_error()),
+        Ok(()) => Ok(http::Response::builder().status(200).body(Vec::new())?),
+        Err(_e) => Ok(internal_server_error().into_response()),
     }
 }

--- a/examples/spin-wagi-http/http-rust/Cargo.lock
+++ b/examples/spin-wagi-http/http-rust/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/variables-rust/Cargo.lock
+++ b/examples/variables-rust/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +369,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",
@@ -389,6 +382,7 @@ name = "spin-variables-example"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "http",
  "spin-sdk",
 ]
 

--- a/examples/variables-rust/Cargo.toml
+++ b/examples/variables-rust/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Useful crate to handle errors.
 anyhow = "1"
-# The Spin SDK.
+http = "0.2.9"
 spin-sdk = { path = "../../sdk/rust" }
 [workspace]

--- a/examples/variables-rust/src/lib.rs
+++ b/examples/variables-rust/src/lib.rs
@@ -1,15 +1,12 @@
-use spin_sdk::{
-    http::{Request, Response},
-    http_component, variables,
-};
+use spin_sdk::{http_component, variables};
 
 /// This endpoint returns the config value specified by key.
 #[http_component]
-fn get(req: Request) -> anyhow::Result<Response> {
-    if req.path_and_query.contains("dotenv") {
+fn get(req: http::Request<()>) -> anyhow::Result<http::Response<String>> {
+    if req.uri().path().contains("dotenv") {
         let val = variables::get("dotenv").expect("Failed to acquire dotenv from spin.toml");
-        return Ok(Response::new(200, val));
+        return Ok(http::Response::builder().status(200).body(val)?);
     }
-    let val = format!("message: {}", variables::get("message")?);
-    Ok(Response::new(200, val))
+    let val = format!("message: {}", config::get("message")?);
+    Ok(http::Response::builder().status(200).body(val)?)
 }

--- a/examples/variables-rust/src/lib.rs
+++ b/examples/variables-rust/src/lib.rs
@@ -7,6 +7,6 @@ fn get(req: http::Request<()>) -> anyhow::Result<http::Response<String>> {
         let val = variables::get("dotenv").expect("Failed to acquire dotenv from spin.toml");
         return Ok(http::Response::builder().status(200).body(val)?);
     }
-    let val = format!("message: {}", config::get("message")?);
+    let val = format!("message: {}", variables::get("message")?);
     Ok(http::Response::builder().status(200).body(val)?)
 }

--- a/examples/wasi-http-rust-streaming-outgoing-body/Cargo.lock
+++ b/examples/wasi-http-rust-streaming-outgoing-body/Cargo.lock
@@ -291,12 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +456,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/wasi-http-rust/Cargo.lock
+++ b/examples/wasi-http-rust/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +369,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/examples/wasi-http-rust/src/lib.rs
+++ b/examples/wasi-http-rust/src/lib.rs
@@ -1,4 +1,4 @@
-use spin_sdk::http::{IntoResponse, Json, Response};
+use spin_sdk::http::{IntoResponse, Json};
 use spin_sdk::http_component;
 
 #[derive(serde::Deserialize, Debug)]
@@ -9,5 +9,7 @@ struct Greeted {
 /// A simple Spin HTTP component.
 #[http_component]
 async fn hello_world(req: http::Request<Json<Greeted>>) -> anyhow::Result<impl IntoResponse> {
-    Ok(Response::new(200, format!("Hello, {}", req.body().name)))
+    Ok(http::Response::builder()
+        .status(200)
+        .body(format!("Hello, {}", req.body().name))?)
 }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -11,21 +11,19 @@ name = "spin_sdk"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.74"
+bytes = { version = "1" }
 form_urlencoded = "1.0"
+futures = "0.3.28"
+hyperium = { package = "http", version = "0.2.9" }
+routefinder = "0.5.3"
+serde_json = { version = "1.0.96", optional = true }
+serde = { version = "1.0.163", optional = true }
 spin-macro = { path = "macro" }
 thiserror = "1.0.37"
 wit-bindgen = "0.13.0"
-routefinder = "0.5.3"
-once_cell = "1.18.0"
-futures = "0.3.28"
-serde_json = { version = "1.0.96", optional = true }
-serde = { version = "1.0.163", optional = true }
-hyperium = { package = "http", version = "0.2", optional = true }
-bytes = { version = "1", optional = true }
 
 [features]
-default = ["export-sdk-language", "http", "json"]
-http = ["dep:hyperium", "dep:bytes"]
+default = ["export-sdk-language", "json"]
 export-sdk-language = []
 json = ["dep:serde", "dep:serde_json"]
 experimental = []

--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -112,7 +112,7 @@ pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             async fn handle_response<R: ::spin_sdk::http::IntoResponse>(response_out: ::spin_sdk::http::ResponseOutparam, resp: R) {
                 let mut response = ::spin_sdk::http::IntoResponse::into_response(resp);
-                let body = std::mem::take(&mut response.body);
+                let body = std::mem::take(response.body_mut());
                 let response = ::std::convert::Into::into(response);
                 if let Err(e) = ::spin_sdk::http::ResponseOutparam::set_with_body(response_out, response, body).await {
                     eprintln!("Could not set `ResponseOutparam`: {e}");

--- a/sdk/rust/readme.md
+++ b/sdk/rust/readme.md
@@ -10,16 +10,14 @@ such a component:
 ```rust
 // lib.rs
 use anyhow::Result;
-use spin_sdk::{
-    http::{Request, Response},
-    http_component,
-};
+use http::{Request, Response};
+use spin_sdk::http_component;
 
 /// A simple Spin HTTP component.
 #[http_component]
-fn hello_world(req: Request) -> Result<Response> {
-    println!("{:?}", req.headers);
-    Ok(Response::new_with_headers(200, &[] "Hello, Fermyon!"))
+fn hello_world(req: Request<()>) -> Result<Response<String>> {
+    println!("{:#?}", req.headers());
+    Ok(http::Response::builder().status(200).body("Hello, Fermyon!".into())?)
 }
 ```
 

--- a/tests/http/headers-env-routes-test/Cargo.lock
+++ b/tests/http/headers-env-routes-test/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,7 +378,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/http/vault-variables-test/Cargo.lock
+++ b/tests/http/vault-variables-test/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +369,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/outbound-redis/http-rust-outbound-redis/Cargo.lock
+++ b/tests/outbound-redis/http-rust-outbound-redis/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/application-variables/Cargo.lock
+++ b/tests/testcases/application-variables/Cargo.lock
@@ -226,12 +226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +391,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/head-rust-sdk-http/Cargo.lock
+++ b/tests/testcases/head-rust-sdk-http/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/head-rust-sdk-redis/Cargo.lock
+++ b/tests/testcases/head-rust-sdk-redis/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/headers-dynamic-env-test/Cargo.lock
+++ b/tests/testcases/headers-dynamic-env-test/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/headers-env-routes-test/Cargo.lock
+++ b/tests/testcases/headers-env-routes-test/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/http-rust-outbound-mysql/Cargo.lock
+++ b/tests/testcases/http-rust-outbound-mysql/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/http-rust-outbound-pg/Cargo.lock
+++ b/tests/testcases/http-rust-outbound-pg/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/key-value-undefined-store/Cargo.lock
+++ b/tests/testcases/key-value-undefined-store/Cargo.lock
@@ -243,12 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,7 +408,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/key-value/Cargo.lock
+++ b/tests/testcases/key-value/Cargo.lock
@@ -243,12 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,7 +408,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/outbound-http-to-same-app/http-component/Cargo.lock
+++ b/tests/testcases/outbound-http-to-same-app/http-component/Cargo.lock
@@ -225,12 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/outbound-http-to-same-app/outbound-http-component/Cargo.lock
+++ b/tests/testcases/outbound-http-to-same-app/outbound-http-component/Cargo.lock
@@ -215,12 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "outbound-http-component"
 version = "0.1.0"
 dependencies = [
@@ -385,7 +379,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/outbound-http-to-same-app/outbound-http-component/src/lib.rs
+++ b/tests/testcases/outbound-http-to-same-app/outbound-http-component/src/lib.rs
@@ -1,12 +1,9 @@
 use anyhow::Result;
-use spin_sdk::{
-    http::{IntoResponse, Request},
-    http_component,
-};
+use spin_sdk::{http::IntoResponse, http_component};
 
 /// Send an HTTP request and return the response.
 #[http_component]
-async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
+async fn send_outbound(_req: http::Request<()>) -> Result<impl IntoResponse> {
     let mut res: http::Response<String> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")

--- a/tests/testcases/sqlite-undefined-db/Cargo.lock
+++ b/tests/testcases/sqlite-undefined-db/Cargo.lock
@@ -230,12 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +395,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",

--- a/tests/testcases/sqlite/Cargo.lock
+++ b/tests/testcases/sqlite/Cargo.lock
@@ -230,12 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +395,6 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "http",
- "once_cell",
  "routefinder",
  "serde",
  "serde_json",


### PR DESCRIPTION
Fixes https://github.com/fermyon/spin/issues/1929

This gets rid of the custom `Request` and `Response` types in favor of using the `http` crate. 

**Why**

This change avoids custom `Requst` and `Response` types. Creating general purpose `Request` and `Response` types is not trivial and would potentially just see us recreating the `http` crate. Instead of this, we rely on the ecosystem standard `http` crate while allowing for future expansion beyond that crate (through other types implementing the various conversion traits). 

**Considerations**

* The SDK does not re-export the `http` crate so users will need to directly depend on the crate themselves.
* Usage of the `http` crate is not *mandatory* though with the current API, it's very difficult to avoid. This is because the request and response types can be any types that implement the appropriate conversion traits. In the future as we support more types that implement these traits, user reliance on the `http` crate may decrease. 
* The `http` crate is not the world's most user-friendly crate. Unfortunately, this means that the Spin SDK de-facto inherits any design worts of the `http` crate. 
* In particular, `http::Response` relies on a builder pattern without very many nice shortcuts. So while previously the user could write `Request::new(200, "my body")` they must now write `Request::builder().status(200).body("my body")?`.

