### PR TITLE
Require user to add redis host to list of allowed listed hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,12 +4193,12 @@ dependencies = [
  "spin-app",
  "spin-core",
  "spin-locked-app",
+ "spin-outbound-networking",
  "spin-world",
  "table",
  "terminal",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -5913,6 +5913,7 @@ dependencies = [
  "spin-common",
  "spin-locked-app",
  "spin-manifest",
+ "spin-outbound-networking",
  "tempfile",
  "terminal",
  "thiserror",
@@ -5990,6 +5991,14 @@ dependencies = [
  "tokio-util 0.7.9",
  "tracing",
  "walkdir",
+]
+
+[[package]]
+name = "spin-outbound-networking"
+version = "2.0.0-pre0"
+dependencies = [
+ "anyhow",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,9 +4190,12 @@ version = "2.0.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
+ "spin-app",
  "spin-core",
+ "spin-locked-app",
  "spin-world",
  "table",
+ "terminal",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,6 +4198,7 @@ dependencies = [
  "terminal",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 mime_guess = { version = "2.0" }
 outbound-http = { path = "../outbound-http", default-features = false }
+spin-outbound-networking = { path = "../outbound-networking" }
 path-absolutize = "3.0.11"
 regex = "1.5.4"
 reqwest = "0.11.9"
@@ -30,7 +31,7 @@ spin-manifest = { path = "../manifest" }
 tempfile = "3.8.0"
 terminal = { path = "../terminal" }
 thiserror = "1.0.49"
-tokio = { version = "1.23", features = [ "full" ] }
+tokio = { version = "1.23", features = ["full"] }
 tokio-util = "0.6"
 toml = "0.8.2"
 tracing = { workspace = true }

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -114,6 +114,7 @@ impl LocalLoader {
         let metadata = ValuesMapBuilder::new()
             .string("description", component.description)
             .string_array("allowed_http_hosts", component.allowed_http_hosts)
+            .string_array("allowed_redis_hosts", component.allowed_redis_hosts)
             .string_array("key_value_stores", component.key_value_stores)
             .string_array("databases", component.sqlite_databases)
             .string_array("ai_models", component.ai_models)

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -114,7 +114,7 @@ impl LocalLoader {
         let metadata = ValuesMapBuilder::new()
             .string("description", component.description)
             .string_array("allowed_http_hosts", component.allowed_http_hosts)
-            .string_array("allowed_redis_hosts", component.allowed_redis_hosts)
+            .string_array_option("allowed_redis_hosts", component.allowed_redis_hosts)
             .string_array("key_value_stores", component.key_value_stores)
             .string_array("databases", component.sqlite_databases)
             .string_array("ai_models", component.ai_models)

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -111,6 +111,10 @@ impl LocalLoader {
         component: v2::Component,
     ) -> Result<LockedComponent> {
         outbound_http::allowed_http_hosts::parse_allowed_http_hosts(&component.allowed_http_hosts)?;
+        if let Some(hosts) = &component.allowed_outbound_hosts {
+            spin_outbound_networking::AllowedHosts::parse(hosts)
+                .context("`allowed_outbound_hosts` is malformed")?;
+        }
         let metadata = ValuesMapBuilder::new()
             .string("description", component.description)
             .string_array("allowed_http_hosts", component.allowed_http_hosts)

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -114,7 +114,7 @@ impl LocalLoader {
         let metadata = ValuesMapBuilder::new()
             .string("description", component.description)
             .string_array("allowed_http_hosts", component.allowed_http_hosts)
-            .string_array_option("allowed_redis_hosts", component.allowed_redis_hosts)
+            .string_array_option("allowed_outbound_hosts", component.allowed_outbound_hosts)
             .string_array("key_value_stores", component.key_value_stores)
             .string_array("databases", component.sqlite_databases)
             .string_array("ai_models", component.ai_models)

--- a/crates/loader/tests/ui/insecure-allow-all-with-invalid-url.lock
+++ b/crates/loader/tests/ui/insecure-allow-all-with-invalid-url.lock
@@ -28,7 +28,8 @@
         "allowed_http_hosts": [
           "insecure:allow-all",
           "random-data-api.fermyon.app"
-        ]
+        ],
+        "allowed_outbound_hosts": null
       },
       "source": {
         "content_type": "application/wasm",

--- a/crates/loader/tests/ui/invalid-manifest-duplicate-id.lock
+++ b/crates/loader/tests/ui/invalid-manifest-duplicate-id.lock
@@ -32,6 +32,9 @@
   "components": [
     {
       "id": "hello",
+      "metadata": {
+        "allowed_outbound_hosts": null
+      },
       "source": {
         "content_type": "application/wasm",
         "source": "file://<test-dir>/wasm/dummy.wasm"

--- a/crates/loader/tests/ui/valid-manifest.lock
+++ b/crates/loader/tests/ui/valid-manifest.lock
@@ -49,6 +49,9 @@
   "components": [
     {
       "id": "four-lights",
+      "metadata": {
+        "allowed_outbound_hosts": null
+      },
       "source": {
         "content_type": "application/wasm",
         "source": "file://<test-dir>/wasm/dummy.wasm"
@@ -60,6 +63,9 @@
     },
     {
       "id": "old-test",
+      "metadata": {
+        "allowed_outbound_hosts": null
+      },
       "source": {
         "content_type": "application/wasm",
         "source": "file://<test-dir>/wasm/dummy.wasm"
@@ -67,6 +73,9 @@
     },
     {
       "id": "web",
+      "metadata": {
+        "allowed_outbound_hosts": null
+      },
       "source": {
         "content_type": "application/wasm",
         "source": "file://<cache-dir>/spin/registry/wasm/sha256:0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/loader/tests/ui/valid-with-files/spin.lock
+++ b/crates/loader/tests/ui/valid-with-files/spin.lock
@@ -30,6 +30,9 @@
   "components": [
     {
       "id": "fs",
+      "metadata": {
+        "allowed_outbound_hosts": null
+      },
       "source": {
         "content_type": "application/wasm",
         "source": "file://<test-dir>/spin-fs.wasm"

--- a/crates/loader/tests/ui/wagi-custom-entrypoint.lock
+++ b/crates/loader/tests/ui/wagi-custom-entrypoint.lock
@@ -31,6 +31,9 @@
   "components": [
     {
       "id": "fs",
+      "metadata": {
+        "allowed_outbound_hosts": null
+      },
       "source": {
         "content_type": "application/wasm",
         "source": "file://<test-dir>/wasm/dummy.wasm"

--- a/crates/locked-app/src/values.rs
+++ b/crates/locked-app/src/values.rs
@@ -58,6 +58,20 @@ impl ValuesMapBuilder {
         self.entry(key, entries)
     }
 
+    /// Inserts an optional list of strings
+    pub fn string_array_option(
+        &mut self,
+        key: impl Into<String>,
+        value: Option<impl IntoIterator<Item = impl Into<String>>>,
+    ) -> &mut Self {
+        if let Some(value) = value {
+            let entries = value.into_iter().map(|s| s.into()).collect::<Vec<_>>();
+            self.entry(key, entries)
+        } else {
+            self.entry(key, Value::Null)
+        }
+    }
+
     /// Inserts an entry into the map using the value's `impl Into<Value>`.
     pub fn entry(&mut self, key: impl Into<String>, value: impl Into<Value>) -> &mut Self {
         self.0.insert(key.into(), value.into());

--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -69,7 +69,7 @@ pub fn v1_to_v2_app(manifest: v1::AppManifestV1) -> Result<v2::AppManifest, Erro
                 sqlite_databases,
                 ai_models,
                 build: component.build,
-                allowed_redis_hosts: component.allowed_redis_hosts,
+                allowed_outbound_hosts: component.allowed_outbound_hosts,
             },
         );
         triggers

--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -69,6 +69,7 @@ pub fn v1_to_v2_app(manifest: v1::AppManifestV1) -> Result<v2::AppManifest, Erro
                 sqlite_databases,
                 ai_models,
                 build: component.build,
+                allowed_redis_hosts: component.allowed_redis_hosts,
             },
         );
         triggers

--- a/crates/manifest/src/schema/v1.rs
+++ b/crates/manifest/src/schema/v1.rs
@@ -78,9 +78,9 @@ pub struct ComponentV1 {
     /// `allowed_http_hosts = ["example.com"]`
     #[serde(default)]
     pub allowed_http_hosts: Vec<String>,
-    /// `allowed_redis_hosts` = ["redis://redis.com:6379"]`
+    /// `allowed_outbound_hosts` = ["redis://redis.com:6379"]`
     #[serde(default)]
-    pub allowed_redis_hosts: Option<Vec<String>>,
+    pub allowed_outbound_hosts: Option<Vec<String>>,
     /// `key_value_stores = ["default"]`
     #[serde(default)]
     pub key_value_stores: Vec<String>,

--- a/crates/manifest/src/schema/v1.rs
+++ b/crates/manifest/src/schema/v1.rs
@@ -78,6 +78,9 @@ pub struct ComponentV1 {
     /// `allowed_http_hosts = ["example.com"]`
     #[serde(default)]
     pub allowed_http_hosts: Vec<String>,
+    /// `allowed_redis_hosts` = ["redis://redis.com:6379"]`
+    #[serde(default)]
+    pub allowed_redis_hosts: Vec<String>,
     /// `key_value_stores = ["default"]`
     #[serde(default)]
     pub key_value_stores: Vec<String>,

--- a/crates/manifest/src/schema/v1.rs
+++ b/crates/manifest/src/schema/v1.rs
@@ -80,7 +80,7 @@ pub struct ComponentV1 {
     pub allowed_http_hosts: Vec<String>,
     /// `allowed_redis_hosts` = ["redis://redis.com:6379"]`
     #[serde(default)]
-    pub allowed_redis_hosts: Vec<String>,
+    pub allowed_redis_hosts: Option<Vec<String>>,
     /// `key_value_stores = ["default"]`
     #[serde(default)]
     pub key_value_stores: Vec<String>,

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -102,6 +102,9 @@ pub struct Component {
     /// `allowed_http_hosts = ["example.com"]`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_http_hosts: Vec<String>,
+    /// `allowed_redis_hosts = ["myredishost.com"]`
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_redis_hosts: Vec<String>,
     /// `key_value_stores = ["default"]`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key_value_stores: Vec<SnakeId>,

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -103,8 +103,8 @@ pub struct Component {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_http_hosts: Vec<String>,
     /// `allowed_redis_hosts = ["myredishost.com"]`
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub allowed_redis_hosts: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_none_or_empty")]
+    pub allowed_redis_hosts: Option<Vec<String>>,
     /// `key_value_stores = ["default"]`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key_value_stores: Vec<SnakeId>,
@@ -117,6 +117,11 @@ pub struct Component {
     /// Build configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<ComponentBuildConfig>,
+}
+
+/// Used to skip serializing if the value is either `None` or `Some(v)` where `v` is empty
+fn is_none_or_empty<T>(value: &Option<Vec<T>>) -> bool {
+    value.as_ref().map(|s| !s.is_empty()).unwrap_or_default()
 }
 
 mod one_or_many {

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -121,7 +121,7 @@ pub struct Component {
 
 /// Used to skip serializing if the value is either `None` or `Some(v)` where `v` is empty
 fn is_none_or_empty<T>(value: &Option<Vec<T>>) -> bool {
-    value.as_ref().map(|s| !s.is_empty()).unwrap_or_default()
+    value.as_ref().map(|s| s.is_empty()).unwrap_or(true)
 }
 
 mod one_or_many {

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -102,9 +102,9 @@ pub struct Component {
     /// `allowed_http_hosts = ["example.com"]`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_http_hosts: Vec<String>,
-    /// `allowed_redis_hosts = ["myredishost.com"]`
+    /// `allowed_outbound_hosts = ["myredishost.com"]`
     #[serde(default, skip_serializing_if = "is_none_or_empty")]
-    pub allowed_redis_hosts: Option<Vec<String>>,
+    pub allowed_outbound_hosts: Option<Vec<String>>,
     /// `key_value_stores = ["default"]`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key_value_stores: Vec<SnakeId>,

--- a/crates/outbound-networking/Cargo.toml
+++ b/crates/outbound-networking/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "spin-outbound-networking"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow = "1.0"
+url = "2.4.1"

--- a/crates/outbound-networking/src/lib.rs
+++ b/crates/outbound-networking/src/lib.rs
@@ -1,0 +1,255 @@
+use anyhow::Context;
+use url::Url;
+
+/// Try to parse the url that may or not include the provided scheme.
+///
+/// If the parsing fails, the url is appended with the scheme and parsing
+/// is tried again.
+pub fn parse_url_with_host(url: &str, scheme: &str) -> anyhow::Result<Url> {
+    match Url::parse(url) {
+        Ok(url) if url.has_host() => Ok(url),
+        first_try => {
+            let second_try = format!("{scheme}://{url}")
+                .as_str()
+                .try_into()
+                .context("could not convert into a url");
+            match (second_try, first_try.map_err(|e| e.into())) {
+                (Ok(u), _) => Ok(u),
+                // Return an error preferring the error from the first attempt if present
+                (_, Err(e)) | (Err(e), _) => Err(e),
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum AllowedHosts {
+    All,
+    SpecificHosts(Vec<AllowedHost>),
+}
+
+impl AllowedHosts {
+    pub fn parse<S: AsRef<str>>(hosts: &[S]) -> anyhow::Result<AllowedHosts> {
+        // TODO: do we support this?
+        // if hosts.len() == 1 && hosts[0].as_ref() == "insecure:allow-all" {
+        //     return Ok(Self::All);
+        // }
+        let mut allowed = Vec::with_capacity(hosts.len());
+        for host in hosts {
+            allowed.push(AllowedHost::parse(host)?)
+        }
+        Ok(Self::SpecificHosts(allowed))
+    }
+
+    pub fn allows<U: TryInto<Url>>(&self, url: U) -> bool {
+        match self {
+            AllowedHosts::All => true,
+            AllowedHosts::SpecificHosts(hosts) => {
+                let Ok(url) = url.try_into() else {
+                    return false;
+                };
+                hosts.iter().any(|h| h.allows(&url))
+            }
+        }
+    }
+}
+
+impl Default for AllowedHosts {
+    fn default() -> Self {
+        Self::SpecificHosts(Vec::new())
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct AllowedHost {
+    scheme: Option<String>,
+    host: String,
+    port: u16,
+}
+
+impl AllowedHost {
+    fn parse<U: AsRef<str>>(url: U) -> anyhow::Result<Self> {
+        let url_str = url.as_ref();
+        let url: anyhow::Result<Url> = url_str
+            .try_into()
+            .with_context(|| format!("could not convert {url_str:?} into a url"));
+        let (url, has_scheme) = match url {
+            Ok(url) if url.has_host() => (url, true),
+            first_try => {
+                // If the url doesn't successfully parse try again with an added scheme.
+                // This resolves the ambiguity between 'spin.fermyon.com:80' and 'unix:80'.
+                // Technically according to the spec a valid url *must* contain a scheme. However,
+                // we allow url-like strings without schemes, and we interpret the first part as the host.
+                let second_try = format!("scheme://{url_str}")
+                    .as_str()
+                    .try_into()
+                    .context("could not convert into a url");
+                match (second_try, first_try) {
+                    (Ok(u), _) => (u, false),
+                    // Return an error preferring the error from the first attempt if present
+                    (_, Err(e)) | (Err(e), _) => return Err(e),
+                }
+            }
+        };
+        let host = url.host_str().context("the url has no host")?.to_owned();
+
+        if !["", "/"].contains(&url.path()) {
+            anyhow::bail!("url contains a path")
+        }
+        if url.query().is_some() {
+            anyhow::bail!("url contains a query string")
+        }
+        Ok(Self {
+            scheme: has_scheme.then(|| url.scheme().to_owned()),
+            host,
+            port: url
+                .port_or_known_default()
+                .context("url did not contain port")?,
+        })
+    }
+
+    fn allows(&self, url: &Url) -> bool {
+        let scheme_matches = self
+            .scheme
+            .as_ref()
+            .map(|s| s == url.scheme())
+            .unwrap_or(true);
+        let host_matches = url.host_str().unwrap_or_default() == self.host;
+        let port_matches = url.port_or_known_default().unwrap_or_default() == self.port;
+
+        scheme_matches && host_matches && port_matches
+    }
+}
+
+#[cfg(test)]
+mod test {
+    impl AllowedHost {
+        fn new(scheme: Option<&str>, host: impl Into<String>, port: u16) -> Self {
+            Self {
+                scheme: scheme.map(Into::into),
+                host: host.into(),
+                port,
+            }
+        }
+    }
+
+    use super::*;
+
+    #[test]
+    fn test_allowed_hosts_accepts_http_url() {
+        assert_eq!(
+            AllowedHost::new(Some("http"), "spin.fermyon.dev", 80),
+            AllowedHost::parse("http://spin.fermyon.dev").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(Some("http"), "spin.fermyon.dev", 80),
+            AllowedHost::parse("http://spin.fermyon.dev/").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(Some("https"), "spin.fermyon.dev", 443),
+            AllowedHost::parse("https://spin.fermyon.dev").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_accepts_http_url_with_port() {
+        assert_eq!(
+            AllowedHost::new(Some("http"), "spin.fermyon.dev", 4444),
+            AllowedHost::parse("http://spin.fermyon.dev:4444").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(Some("http"), "spin.fermyon.dev", 4444),
+            AllowedHost::parse("http://spin.fermyon.dev:4444/").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(Some("https"), "spin.fermyon.dev", 5555),
+            AllowedHost::parse("https://spin.fermyon.dev:5555").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_does_not_accept_plain_host_without_port() {
+        assert!(AllowedHost::parse("spin.fermyon.dev").is_err());
+    }
+
+    #[test]
+    fn test_allowed_hosts_accepts_plain_host_with_port() {
+        assert_eq!(
+            AllowedHost::new(None, "spin.fermyon.dev", 7777),
+            AllowedHost::parse("spin.fermyon.dev:7777").unwrap()
+        )
+    }
+
+    // #[test]
+    // fn test_allowed_hosts_accepts_self() {
+    // TODO: do we support this?
+    //     assert_eq!(
+    //         AllowedHost::host("self"),
+    //         parse_allowed_http_host("self").unwrap()
+    //     );
+    // }
+
+    #[test]
+    fn test_allowed_hosts_accepts_localhost_addresses() {
+        assert!(AllowedHost::parse("localhost").is_err());
+        assert_eq!(
+            AllowedHost::new(Some("http"), "localhost", 80),
+            AllowedHost::parse("http://localhost").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(None, "localhost", 3001),
+            AllowedHost::parse("localhost:3001").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(Some("http"), "localhost", 3001),
+            AllowedHost::parse("http://localhost:3001").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_accepts_ip_addresses() {
+        assert_eq!(
+            AllowedHost::new(Some("http"), "192.168.1.1", 80),
+            AllowedHost::parse("http://192.168.1.1").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(Some("http"), "192.168.1.1", 3002),
+            AllowedHost::parse("http://192.168.1.1:3002").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(None, "192.168.1.1", 3002),
+            AllowedHost::parse("192.168.1.1:3002").unwrap()
+        );
+        assert_eq!(
+            AllowedHost::new(Some("http"), "[::1]", 8001),
+            AllowedHost::parse("http://[::1]:8001").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_rejects_path() {
+        assert!(AllowedHost::parse("http://spin.fermyon.dev/a").is_err());
+        assert!(AllowedHost::parse("http://spin.fermyon.dev:6666/a/b").is_err());
+    }
+
+    #[test]
+    fn test_allowed_hosts_respects_allow_all() {
+        // TODO: do we support this?
+        // assert_eq!(
+        //     AllowedHosts::All,
+        //     AllowedHosts::parse(&["insecure:allow-all"]).unwrap()
+        // );
+        assert!(AllowedHosts::parse(&["insecure:allow-all"]).is_err());
+        assert!(AllowedHosts::parse(&["spin.fermyon.dev", "insecure:allow-all"]).is_err());
+    }
+
+    #[test]
+    fn test_allowed_hosts_can_be_specific() {
+        let allowed =
+            AllowedHosts::parse(&["spin.fermyon.dev:443", "http://example.com:8383"]).unwrap();
+        assert!(allowed.allows(Url::parse("http://example.com:8383/foo/bar").unwrap()));
+        assert!(allowed.allows(Url::parse("https://spin.fermyon.dev/").unwrap()));
+        assert!(!allowed.allows(Url::parse("http://example.com/").unwrap()));
+        assert!(!allowed.allows(Url::parse("http://google.com/").unwrap()));
+    }
+}

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -18,3 +18,4 @@ table = { path = "../table" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }
 terminal = { path = "../terminal" }
+url = "2.4.1"

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -14,8 +14,8 @@ spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-locked-app = { path = "../locked-app" }
 spin-world = { path = "../world" }
+spin-outbound-networking = { path = "../outbound-networking" }
 table = { path = "../table" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }
 terminal = { path = "../terminal" }
-url = "2.4.1"

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -10,8 +10,11 @@ doctest = false
 [dependencies]
 anyhow = "1.0"
 redis = { version = "0.21", features = ["tokio-comp", "tokio-native-tls-comp"] }
+spin-app = { path = "../app" }
 spin-core = { path = "../core" }
+spin-locked-app = { path = "../locked-app" }
 spin-world = { path = "../world" }
 table = { path = "../table" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }
+terminal = { path = "../terminal" }

--- a/crates/outbound-redis/src/host_component.rs
+++ b/crates/outbound-redis/src/host_component.rs
@@ -1,3 +1,4 @@
+use spin_app::DynamicHostComponent;
 use spin_core::HostComponent;
 
 use crate::OutboundRedis;
@@ -16,5 +17,19 @@ impl HostComponent for OutboundRedisComponent {
 
     fn build_data(&self) -> Self::Data {
         Default::default()
+    }
+}
+
+impl DynamicHostComponent for OutboundRedisComponent {
+    fn update_data(
+        &self,
+        data: &mut Self::Data,
+        component: &spin_app::AppComponent,
+    ) -> anyhow::Result<()> {
+        let hosts = component
+            .get_metadata(crate::ALLOWED_REDIS_HOSTS_KEY)?
+            .unwrap_or_default();
+        data.allowed_hosts.extend(hosts);
+        Ok(())
     }
 }

--- a/crates/outbound-redis/src/host_component.rs
+++ b/crates/outbound-redis/src/host_component.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use spin_app::DynamicHostComponent;
 use spin_core::HostComponent;
 
@@ -27,9 +28,12 @@ impl DynamicHostComponent for OutboundRedisComponent {
         component: &spin_app::AppComponent,
     ) -> anyhow::Result<()> {
         let hosts = component
-            .get_metadata(crate::ALLOWED_REDIS_HOSTS_KEY)?
+            .get_metadata(crate::ALLOWED_HOSTS_KEY)?
             .unwrap_or_default();
-        data.allowed_hosts = hosts;
+        data.allowed_hosts = hosts
+            .map(|h| spin_outbound_networking::AllowedHosts::parse(&h[..]))
+            .transpose()
+            .context("`allowed_outbound_hosts` contained an invalid url")?;
         Ok(())
     }
 }

--- a/crates/outbound-redis/src/host_component.rs
+++ b/crates/outbound-redis/src/host_component.rs
@@ -29,7 +29,7 @@ impl DynamicHostComponent for OutboundRedisComponent {
         let hosts = component
             .get_metadata(crate::ALLOWED_REDIS_HOSTS_KEY)?
             .unwrap_or_default();
-        data.allowed_hosts.extend(hosts);
+        data.allowed_hosts = hosts;
         Ok(())
     }
 }

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -112,9 +112,12 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
 
             if !self.disable_default_host_components {
                 builder.link_import(|l, _| wasmtime_wasi_http::proxy::add_to_linker(l))?;
-                builder.add_host_component(outbound_redis::OutboundRedisComponent)?;
                 builder.add_host_component(outbound_pg::OutboundPg::default())?;
                 builder.add_host_component(outbound_mysql::OutboundMysql::default())?;
+                self.loader.add_dynamic_host_component(
+                    &mut builder,
+                    outbound_redis::OutboundRedisComponent,
+                )?;
                 self.loader.add_dynamic_host_component(
                     &mut builder,
                     runtime_config::llm::build_component(&runtime_config, init_data.llm.use_gpu)

--- a/examples/rust-outbound-redis/spin.toml
+++ b/examples/rust-outbound-redis/spin.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 environment = { REDIS_ADDRESS = "redis://127.0.0.1:6379", REDIS_CHANNEL = "messages" }
 id = "outbound-redis"
 source = "target/wasm32-wasi/release/rust_outbound_redis.wasm"
+allowed_redis_hosts = ["redis://127.0.0.1:6379"]
 [component.trigger]
 route = "/publish"
 [component.build]

--- a/examples/rust-outbound-redis/spin.toml
+++ b/examples/rust-outbound-redis/spin.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 environment = { REDIS_ADDRESS = "redis://127.0.0.1:6379", REDIS_CHANNEL = "messages" }
 id = "outbound-redis"
 source = "target/wasm32-wasi/release/rust_outbound_redis.wasm"
-allowed_redis_hosts = ["redis://127.0.0.1:6379"]
+allowed_outbound_hosts = ["127.0.0.1:6379"]
 [component.trigger]
 route = "/publish"
 [component.build]

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -2580,9 +2580,12 @@ version = "2.0.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
+ "spin-app",
  "spin-core",
+ "spin-locked-app",
  "spin-world",
  "table",
+ "terminal",
  "tokio",
  "tracing",
 ]

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -2583,6 +2583,7 @@ dependencies = [
  "spin-app",
  "spin-core",
  "spin-locked-app",
+ "spin-outbound-networking",
  "spin-world",
  "table",
  "terminal",
@@ -3750,6 +3751,7 @@ dependencies = [
  "spin-common",
  "spin-locked-app",
  "spin-manifest",
+ "spin-outbound-networking",
  "tempfile",
  "terminal",
  "thiserror",
@@ -3783,6 +3785,14 @@ dependencies = [
  "spin-serde",
  "thiserror",
  "toml 0.8.2",
+]
+
+[[package]]
+name = "spin-outbound-networking"
+version = "2.0.0-pre0"
+dependencies = [
+ "anyhow",
+ "url",
 ]
 
 [[package]]


### PR DESCRIPTION
~~This makes it required for users using the Redis v2 interface to add `allowed_redis_hosts` to their manifest specifying which hosts are allowed to be reached. This mirrors how key/value, llm, and sqlite all work.~~

~~Support is added in manifest v1 and v2 for the `allowed_redis_hosts`  key which defaults to the empty list. However, apps targeting the old Redis interface do not need to update their configs as only the new interface respects this configuration.~~ 

~~Next, we will move MySQL and PostgreSQL to do the same.~~

**Update**:

Introduce: `allowed_outbound_hosts` as a general way to control outbound networking. This is implemented for Redis for now, but will be introduced for MySQL, PostgreSQL, and http in future PRs. 