### PR TITLE
Improve the builtin Request/Response types

### DIFF
--- a/examples/variables-rust/src/lib.rs
+++ b/examples/variables-rust/src/lib.rs
@@ -6,7 +6,7 @@ use spin_sdk::{
 /// This endpoint returns the config value specified by key.
 #[http_component]
 fn get(req: Request) -> anyhow::Result<Response> {
-    if req.path_and_query.contains("dotenv") {
+    if req.path().contains("dotenv") {
         let val = variables::get("dotenv").expect("Failed to acquire dotenv from spin.toml");
         return Ok(Response::new(200, val));
     }

--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -112,7 +112,7 @@ pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             async fn handle_response<R: ::spin_sdk::http::IntoResponse>(response_out: ::spin_sdk::http::ResponseOutparam, resp: R) {
                 let mut response = ::spin_sdk::http::IntoResponse::into_response(resp);
-                let body = std::mem::take(&mut response.body);
+                let body = std::mem::take(response.body_mut());
                 let response = ::std::convert::Into::into(response);
                 if let Err(e) = ::spin_sdk::http::ResponseOutparam::set_with_body(response_out, response, body).await {
                     eprintln!("Could not set `ResponseOutparam`: {e}");

--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -289,7 +289,9 @@ impl HeaderValue {
     /// Construct a `HeaderValue` from a bag of bytes
     pub fn bytes(bytes: Vec<u8>) -> HeaderValue {
         HeaderValue {
-            inner: HeaderValueRep::Bytes(bytes),
+            inner: String::from_utf8(bytes)
+                .map(HeaderValueRep::String)
+                .unwrap_or_else(|e| HeaderValueRep::Bytes(e.into_bytes())),
         }
     }
 

--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -28,81 +28,9 @@ pub struct Request {
     body: Vec<u8>,
 }
 
-/// A header value.
-///
-/// Since header values do not have to be valid utf8, this allows for
-/// both utf8 strings and bags of bytes.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct HeaderValue {
-    inner: HeaderValueRep,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-enum HeaderValueRep {
-    /// Header value encoded as a utf8 string
-    String(String),
-    /// Header value as a bag of bytes
-    Bytes(Vec<u8>),
-}
-
-impl HeaderValue {
-    /// Construct a `HeaderValue` from a string
-    pub fn string(str: String) -> HeaderValue {
-        HeaderValue {
-            inner: HeaderValueRep::String(str),
-        }
-    }
-
-    /// Construct a `HeaderValue` from a bag of bytes
-    pub fn bytes(bytes: Vec<u8>) -> HeaderValue {
-        HeaderValue {
-            inner: HeaderValueRep::Bytes(bytes),
-        }
-    }
-
-    /// Get the `HeaderValue` as a utf8 encoded string
-    ///
-    /// Returns `None` if the value is a non utf8 encoded header value
-    pub fn as_str(&self) -> Option<&str> {
-        match &self.inner {
-            HeaderValueRep::String(s) => Some(s),
-            HeaderValueRep::Bytes(_) => None,
-        }
-    }
-
-    /// Get the `HeaderValue` as bytes
-    pub fn as_bytes(&self) -> &[u8] {
-        self.as_ref()
-    }
-
-    /// Turn the `HeaderValue` into a String (in a lossy way if the `HeaderValue` is a bag of bytes)
-    pub fn into_utf8_lossy(self) -> String {
-        match self.inner {
-            HeaderValueRep::String(s) => s,
-            HeaderValueRep::Bytes(b) => String::from_utf8_lossy(&b).into_owned(),
-        }
-    }
-
-    /// Turn the `HeaderValue` into bytes
-    pub fn into_bytes(self) -> Vec<u8> {
-        match self.inner {
-            HeaderValueRep::String(s) => s.into_bytes(),
-            HeaderValueRep::Bytes(b) => b,
-        }
-    }
-}
-
-impl AsRef<[u8]> for HeaderValue {
-    fn as_ref(&self) -> &[u8] {
-        match &self.inner {
-            HeaderValueRep::String(s) => s.as_bytes(),
-            HeaderValueRep::Bytes(b) => b,
-        }
-    }
-}
-
 impl Request {
-    fn new(method: Method, uri: impl Into<String>) -> Self {
+    /// Create a new request from a method and uri
+    pub fn new(method: Method, uri: impl Into<String>) -> Self {
         Self {
             method,
             uri: Self::parse_uri(uri.into()),
@@ -242,7 +170,7 @@ pub struct Response {
 }
 
 impl Response {
-    /// Create a new response from a status and optional headers and body
+    /// Create a new response from a status and body
     pub fn new(status: impl conversions::IntoStatusCode, body: impl conversions::IntoBody) -> Self {
         Self {
             status: status.into_status_code(),
@@ -330,6 +258,79 @@ impl ResponseBuilder {
     /// Build the `Response`
     pub fn build(&mut self) -> Response {
         std::mem::replace(&mut self.response, Response::new(200, Vec::new()))
+    }
+}
+
+/// A header value.
+///
+/// Since header values do not have to be valid utf8, this allows for
+/// both utf8 strings and bags of bytes.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct HeaderValue {
+    inner: HeaderValueRep,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum HeaderValueRep {
+    /// Header value encoded as a utf8 string
+    String(String),
+    /// Header value as a bag of bytes
+    Bytes(Vec<u8>),
+}
+
+impl HeaderValue {
+    /// Construct a `HeaderValue` from a string
+    pub fn string(str: String) -> HeaderValue {
+        HeaderValue {
+            inner: HeaderValueRep::String(str),
+        }
+    }
+
+    /// Construct a `HeaderValue` from a bag of bytes
+    pub fn bytes(bytes: Vec<u8>) -> HeaderValue {
+        HeaderValue {
+            inner: HeaderValueRep::Bytes(bytes),
+        }
+    }
+
+    /// Get the `HeaderValue` as a utf8 encoded string
+    ///
+    /// Returns `None` if the value is a non utf8 encoded header value
+    pub fn as_str(&self) -> Option<&str> {
+        match &self.inner {
+            HeaderValueRep::String(s) => Some(s),
+            HeaderValueRep::Bytes(_) => None,
+        }
+    }
+
+    /// Get the `HeaderValue` as bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    /// Turn the `HeaderValue` into a String (in a lossy way if the `HeaderValue` is a bag of bytes)
+    pub fn into_utf8_lossy(self) -> String {
+        match self.inner {
+            HeaderValueRep::String(s) => s,
+            HeaderValueRep::Bytes(b) => String::from_utf8_lossy(&b).into_owned(),
+        }
+    }
+
+    /// Turn the `HeaderValue` into bytes
+    pub fn into_bytes(self) -> Vec<u8> {
+        match self.inner {
+            HeaderValueRep::String(s) => s.into_bytes(),
+            HeaderValueRep::Bytes(b) => b,
+        }
+    }
+}
+
+impl AsRef<[u8]> for HeaderValue {
+    fn as_ref(&self) -> &[u8] {
+        match &self.inner {
+            HeaderValueRep::String(s) => s.as_bytes(),
+            HeaderValueRep::Bytes(b) => b,
+        }
     }
 }
 

--- a/sdk/rust/src/http/router.rs
+++ b/sdk/rust/src/http/router.rs
@@ -42,7 +42,7 @@ impl Router {
     pub fn handle<R: Into<Request>>(&self, request: R) -> Response {
         let request = request.into();
         let method = request.method.clone();
-        let path = &request.path_and_query;
+        let path = &request.path();
         let RouteMatch { params, handler } = self.find(path, method);
         handler(request, params)
     }
@@ -285,12 +285,7 @@ mod tests {
     use super::*;
 
     fn make_request(method: Method, path: &str) -> Request {
-        Request {
-            method,
-            path_and_query: path.into(),
-            headers: Vec::new(),
-            body: Default::default(),
-        }
+        Request::new(method, path)
     }
 
     fn echo_param(req: Request, params: Params) -> Response {


### PR DESCRIPTION
This is meant as an alternative to #1931. It improves the `Request`/`Response` types with an API that is useable, flexible, and powerful and hopefully enough to cover 80% of use cases. For more advanced use cases, we would recommend using a third party crate like `http`. 

Note: The one slightly awkward API choice is that `RequestBuilder::uri` is infallible so that even if the user passes a garbage URI it still "works" - they'll likely only see any error when the try to use the uri. I think this is the right balance of easy of use without sacrificing too much protection against misuse. 