### PR TITLE
Improve the OutParam API for wasi-http

### DIFF
--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -121,8 +121,7 @@ pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             impl From<self::wasi::http::types::IncomingRequest> for ::spin_sdk::http::IncomingRequest {
                 fn from(req: self::wasi::http::types::IncomingRequest) -> Self {
-                    let req = ::std::mem::ManuallyDrop::new(req);
-                    unsafe { Self::from_handle(req.handle()) }
+                    unsafe { Self::from_handle(req.into_handle()) }
                 }
             }
 
@@ -134,8 +133,7 @@ pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             impl From<self::wasi::http::types::ResponseOutparam> for ::spin_sdk::http::ResponseOutparam {
                 fn from(resp: self::wasi::http::types::ResponseOutparam) -> Self {
-                    let resp = ::std::mem::ManuallyDrop::new(resp);
-                    unsafe { Self::from_handle(resp.handle()) }
+                    unsafe { Self::from_handle(resp.into_handle()) }
                 }
             }
         }

--- a/sdk/rust/src/http/conversions.rs
+++ b/sdk/rust/src/http/conversions.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 
-use super::{
-    Fields, Headers, IncomingRequest, IncomingResponse, OutgoingRequest, OutgoingResponse,
-};
+use super::{Headers, IncomingRequest, IncomingResponse, OutgoingRequest, OutgoingResponse};
 
 use super::{responses, NonUtf8BodyError, Request, Response};
 
@@ -466,7 +464,7 @@ where
                 })
                 .as_ref(),
             req.uri().authority().map(|a| a.as_str()),
-            &Fields::new(&headers),
+            &Headers::new(&headers),
         ))
     }
 }


### PR DESCRIPTION
This API is a bit awkward but this makes it slightly better by allowing method call syntax. I'm not sure I fully understand why the wit-bindgen generated version does allow for method call syntax. 