### PR TITLE
Break `http` crate dependency on `wasmtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5758,6 +5758,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "spin-app",
+ "spin-locked-app",
  "spin-testing",
  "toml 0.8.2",
  "tracing",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -9,13 +9,18 @@ anyhow = "1.0"
 http = "0.2"
 hyper = { workspace = true }
 http-body-util = { workspace = true }
-wasmtime-wasi-http = { workspace = true }
+wasmtime-wasi-http = { workspace = true, optional = true }
 indexmap = "1"
 percent-encoding = "2"
 serde = { version = "1.0", features = ["derive"] }
 tracing = { workspace = true }
-spin-app = { path = "../app" }
+spin-app = { path = "../app", optional = true }
+spin-locked-app = { path = "../locked-app" }
 
 [dev-dependencies]
 spin-testing = { path = "../testing" }
 toml = "0.8.2"
+
+[features]
+default = ["runtime"]
+runtime = ["dep:spin-app", "dep:wasmtime-wasi-http"]

--- a/crates/http/src/app_info.rs
+++ b/crates/http/src/app_info.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "runtime")]
 use spin_app::{App, APP_NAME_KEY, APP_VERSION_KEY, OCI_IMAGE_DIGEST_KEY};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,6 +12,7 @@ pub struct AppInfo {
 }
 
 impl AppInfo {
+    #[cfg(feature = "runtime")]
     pub fn new(app: &App) -> Self {
         let name = app
             .get_metadata(APP_NAME_KEY)

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,13 +1,16 @@
+#[cfg(feature = "runtime")]
 pub use wasmtime_wasi_http::body::HyperIncomingBody as Body;
 
 pub mod app_info;
 pub mod config;
 pub mod routes;
 pub mod trigger;
+#[cfg(feature = "runtime")]
 pub mod wagi;
 
 pub const WELL_KNOWN_PREFIX: &str = "/.well-known/spin/";
 
+#[cfg(feature = "runtime")]
 pub mod body {
     use super::Body;
     use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};

--- a/crates/http/src/trigger.rs
+++ b/crates/http/src/trigger.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use spin_app::MetadataKey;
+use spin_locked_app::MetadataKey;
 
 /// Http trigger metadata key
 pub const METADATA_KEY: MetadataKey<Metadata> = MetadataKey::new("trigger");


### PR DESCRIPTION
I think this might be the last one folks... again I resorted to a feature but I can look at splitting out crates if people think that's better.