### PR TITLE
trigger-http: Fix `base` routing without leading slash

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -93,10 +93,13 @@ impl TriggerExecutor for HttpTrigger {
     type RunConfig = CliArgs;
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
-        let base = engine
+        let mut base = engine
             .app()
             .require_metadata(spin_http::trigger::METADATA_KEY)?
             .base;
+        if !base.starts_with('/') {
+            base = format!("/{base}");
+        }
 
         let component_routes = engine
             .trigger_configs()


### PR DESCRIPTION
This seems to take care of the printed routes as well.

Fixes #1943 