### PR TITLE
Fix broken template

### DIFF
--- a/templates/http-rust/content/src/lib.rs
+++ b/templates/http-rust/content/src/lib.rs
@@ -1,10 +1,10 @@
-use spin_sdk::http::{IntoResponse, Request};
+use spin_sdk::http::{HeaderValue, IntoResponse, Request};
 use spin_sdk::http_component;
 
 /// A simple Spin HTTP component.
 #[http_component]
 fn handle_{{project-name | snake_case}}(req: Request) -> anyhow::Result<impl IntoResponse> {
-    println!("{:?}", req.headers);
+    println!("Handling request to {:?}", req.header("spin-full-url"));
     Ok(http::Response::builder()
         .status(200)
         .header("content-type", "text/plain")


### PR DESCRIPTION
The `http-rust` template appears to have been broken by #1939. This PR updates the templates to use the new headers API.