### PR TITLE
add global value convertor for mysql and sqlite go sdk 

### DIFF
--- a/sdk/go/internal/db/driver.go
+++ b/sdk/go/internal/db/driver.go
@@ -4,8 +4,10 @@ import (
 	"database/sql/driver"
 )
 
-// GlobalValueConverter is a valueConverter instance.
-var GlobalValueConverter = &valueConverter{}
+// GlobalParameterConverter is a global valueConverter instance to convert parameters.
+var GlobalParameterConverter = &valueConverter{}
+
+var _ driver.ValueConverter = (*valueConverter)(nil)
 
 // valueConverter is a no-op value converter.
 type valueConverter struct{}

--- a/sdk/go/internal/db/driver.go
+++ b/sdk/go/internal/db/driver.go
@@ -4,7 +4,7 @@ import (
 	"database/sql/driver"
 )
 
-// globalValueConverter is a valueConverter instance.
+// GlobalValueConverter is a valueConverter instance.
 var GlobalValueConverter = &valueConverter{}
 
 // valueConverter is a no-op value converter.

--- a/sdk/go/internal/db/driver.go
+++ b/sdk/go/internal/db/driver.go
@@ -1,0 +1,15 @@
+package db
+
+import (
+	"database/sql/driver"
+)
+
+// globalValueConverter is a valueConverter instance.
+var GlobalValueConverter = &valueConverter{}
+
+// valueConverter is a no-op value converter.
+type valueConverter struct{}
+
+func (c *valueConverter) ConvertValue(v any) (driver.Value, error) {
+	return driver.Value(v), nil
+}

--- a/sdk/go/mysql/internals.go
+++ b/sdk/go/mysql/internals.go
@@ -216,6 +216,9 @@ func toOutboundMysqlParameterValue(x any) C.outbound_mysql_parameter_value_t {
 	case int64:
 		*(*C.int64_t)(unsafe.Pointer(&ret.val)) = int64(v)
 		ret.tag = paramValueInt64
+	case int:
+		*(*C.int64_t)(unsafe.Pointer(&ret.val)) = int64(v)
+		ret.tag = paramValueInt64
 	case uint8:
 		*(*C.uint8_t)(unsafe.Pointer(&ret.val)) = uint8(v)
 		ret.tag = paramValueUint8

--- a/sdk/go/mysql/mysql.go
+++ b/sdk/go/mysql/mysql.go
@@ -7,10 +7,9 @@ import (
 	"errors"
 	"io"
 	"reflect"
-)
 
-// globalValueConv a valueConv instance
-var globalValueConv = &valueConv{}
+	spindb "github.com/fermyon/spin/sdk/go/internal/db"
+)
 
 // Open returns a new connection to the database.
 func Open(address string) *sql.DB {
@@ -96,16 +95,9 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return &result{}, err
 }
 
-// ColumnConverter return globalValueConv to don't use driver.DefaultParameterConverter
+// ColumnConverter returns globalValueConverter to prevent using driver.DefaultParameterConverter.
 func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
-	return globalValueConv
-}
-
-// valueConv a convertor not convert value
-type valueConv struct{}
-
-func (c *valueConv) ConvertValue(v any) (driver.Value, error) {
-	return driver.Value(v), nil
+	return spindb.GlobalValueConverter
 }
 
 type result struct{}

--- a/sdk/go/mysql/mysql.go
+++ b/sdk/go/mysql/mysql.go
@@ -63,6 +63,7 @@ type stmt struct {
 }
 
 var _ driver.Stmt = (*stmt)(nil)
+var _ driver.ColumnConverter = (*stmt)(nil)
 
 // Close closes the statement.
 func (s *stmt) Close() error {

--- a/sdk/go/mysql/mysql.go
+++ b/sdk/go/mysql/mysql.go
@@ -9,6 +9,9 @@ import (
 	"reflect"
 )
 
+// globalValueConv a valueConv instance
+var globalValueConv = &valueConv{}
+
 // Open returns a new connection to the database.
 func Open(address string) *sql.DB {
 	return sql.OpenDB(&connector{address})
@@ -90,6 +93,18 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	}
 	err := execute(s.c.address, s.query, params)
 	return &result{}, err
+}
+
+// ColumnConverter return globalValueConv to don't use driver.DefaultParameterConverter
+func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
+	return globalValueConv
+}
+
+// valueConv a convertor not convert value
+type valueConv struct{}
+
+func (c *valueConv) ConvertValue(v any) (driver.Value, error) {
+	return driver.Value(v), nil
 }
 
 type result struct{}

--- a/sdk/go/mysql/mysql.go
+++ b/sdk/go/mysql/mysql.go
@@ -95,9 +95,9 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return &result{}, err
 }
 
-// ColumnConverter returns globalValueConverter to prevent using driver.DefaultParameterConverter.
+// ColumnConverter returns GlobalParameterConverter to prevent using driver.DefaultParameterConverter.
 func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
-	return spindb.GlobalValueConverter
+	return spindb.GlobalParameterConverter
 }
 
 type result struct{}

--- a/sdk/go/pg/pg.go
+++ b/sdk/go/pg/pg.go
@@ -95,9 +95,9 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return &result{rowsAffected: int64(n)}, err
 }
 
-// ColumnConverter returns globalValueConverter to prevent using driver.DefaultParameterConverter.
+// ColumnConverter returns GlobalParameterConverter to prevent using driver.DefaultParameterConverter.
 func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
-	return spindb.GlobalValueConverter
+	return spindb.GlobalParameterConverter
 }
 
 type result struct {

--- a/sdk/go/pg/pg.go
+++ b/sdk/go/pg/pg.go
@@ -7,10 +7,9 @@ import (
 	"errors"
 	"io"
 	"reflect"
-)
 
-// globalValueConv a valueConv instance
-var globalValueConv = &valueConv{}
+	spindb "github.com/fermyon/spin/sdk/go/internal/db"
+)
 
 // Open returns a new connection to the database.
 func Open(address string) *sql.DB {
@@ -96,16 +95,9 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return &result{rowsAffected: int64(n)}, err
 }
 
-// ColumnConverter return globalValueConv to don't use driver.DefaultParameterConverter
+// ColumnConverter returns globalValueConverter to prevent using driver.DefaultParameterConverter.
 func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
-	return globalValueConv
-}
-
-// valueConv a convertor not convert value
-type valueConv struct{}
-
-func (c *valueConv) ConvertValue(v any) (driver.Value, error) {
-	return driver.Value(v), nil
+	return spindb.GlobalValueConverter
 }
 
 type result struct {

--- a/sdk/go/sqlite/sqlite.go
+++ b/sdk/go/sqlite/sqlite.go
@@ -8,6 +8,9 @@ import (
 	"io"
 )
 
+// globalValueConv a valueConv instance
+var globalValueConv = &valueConv{}
+
 // Open returns a new connection to the database.
 func Open(name string) *sql.DB {
 	return sql.OpenDB(&connector{name: name})
@@ -165,6 +168,18 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	}
 	_, err := s.c.execute(s.query, params)
 	return &result{}, err
+}
+
+// ColumnConverter return globalValueConv to don't use driver.DefaultParameterConverter
+func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
+	return globalValueConv
+}
+
+// valueConv a convertor not convert value
+type valueConv struct{}
+
+func (c *valueConv) ConvertValue(v any) (driver.Value, error) {
+	return driver.Value(v), nil
 }
 
 type result struct{}

--- a/sdk/go/sqlite/sqlite.go
+++ b/sdk/go/sqlite/sqlite.go
@@ -6,10 +6,9 @@ import (
 	"database/sql/driver"
 	"errors"
 	"io"
-)
 
-// globalValueConv a valueConv instance
-var globalValueConv = &valueConv{}
+	spindb "github.com/fermyon/spin/sdk/go/internal/db"
+)
 
 // Open returns a new connection to the database.
 func Open(name string) *sql.DB {
@@ -171,16 +170,9 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return &result{}, err
 }
 
-// ColumnConverter return globalValueConv to don't use driver.DefaultParameterConverter
+// ColumnConverter returns globalValueConverter to prevent using driver.DefaultParameterConverter.
 func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
-	return globalValueConv
-}
-
-// valueConv a convertor not convert value
-type valueConv struct{}
-
-func (c *valueConv) ConvertValue(v any) (driver.Value, error) {
-	return driver.Value(v), nil
+	return spindb.GlobalValueConverter
 }
 
 type result struct{}

--- a/sdk/go/sqlite/sqlite.go
+++ b/sdk/go/sqlite/sqlite.go
@@ -138,6 +138,7 @@ type stmt struct {
 }
 
 var _ driver.Stmt = (*stmt)(nil)
+var _ driver.ColumnConverter = (*stmt)(nil)
 
 // Close closes the statement.
 func (s *stmt) Close() error {

--- a/sdk/go/sqlite/sqlite.go
+++ b/sdk/go/sqlite/sqlite.go
@@ -170,9 +170,9 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return &result{}, err
 }
 
-// ColumnConverter returns globalValueConverter to prevent using driver.DefaultParameterConverter.
+// ColumnConverter returns GlobalParameterConverter to prevent using driver.DefaultParameterConverter.
 func (s *stmt) ColumnConverter(_ int) driver.ValueConverter {
-	return spindb.GlobalValueConverter
+	return spindb.GlobalParameterConverter
 }
 
 type result struct{}


### PR DESCRIPTION
If statement didn't implement ColumnConverter interface, go's db driver will use driver.DefaultParameterConverter to covert value, such as coverting int to int64. 
I think it's not expected.

May be share a ValueConverter which should be on a internal pkg?