### PR TITLE
[wasi-http handler] Handle error and send response if not yet sent

### DIFF
--- a/examples/wasi-http-streaming-file/src/lib.rs
+++ b/examples/wasi-http-streaming-file/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{fs::File, io::Read};
 
-use anyhow::Result;
 use futures::SinkExt;
 use spin_sdk::{
     http::{Headers, IncomingRequest, OutgoingResponse, ResponseOutparam},
@@ -10,11 +9,7 @@ use spin_sdk::{
 const CHUNK_SIZE: usize = 1024 * 1024; // 1 MB
 
 #[http_component]
-async fn handler(req: IncomingRequest, res: ResponseOutparam) {
-    stream_file(req, res).await.unwrap();
-}
-
-async fn stream_file(_req: IncomingRequest, res: ResponseOutparam) -> Result<()> {
+async fn handler(_req: IncomingRequest, res: ResponseOutparam) -> anyhow::Result<()> {
     let response = OutgoingResponse::new(
         200,
         &Headers::new(&[(


### PR DESCRIPTION
Allows http handlers to return `Result<_, impl IntoResponse>`. 

If the handler returns an `Err` and they've not yet set a response, we will set one for them. 

Some pros/cons of this:
* `ResponseOutparam::set` can now panic if it gets called twice (before we prevented this by taking `self` instead of `&self`). This necessary to dynamically decide if the handler will set the response or if the macro code will. 
* If a response has already been set but the handler then returns an error, all we can do is log. 
  * IMO this makes the 'streaming-outgoing-body' example worse as the user is lulled into thinking their errors will be handled but they won't be. They'll just be logged.
* If the user returns `Result<T, impl IntoResponse>` and they return a `Ok(T)` we currently just drop that value on the floor.
  * We could accept any type T that implements `IntoResponse` (returning it if the response hasn't yet been set), but then we would be forced to implement `IntoResponse` for `()` which is a big footgun that people always complain about in `axum`.

I'm personally unsure if I actually want to see this merged, but I thought I would open it up for comment from others.  