### PR TITLE
Fix outbound http in the Rust SDK (take 2)

### DIFF
--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
@@ -7,7 +7,7 @@ use spin_sdk::{
 /// Send an HTTP request and return the response.
 #[http_component]
 async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
-    let mut res: http::Response<()> = spin_sdk::http::send(
+    let mut res: http::Response<String> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")
             .uri("/hello")

--- a/examples/http-rust-outbound-http/outbound-http/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http/src/lib.rs
@@ -7,7 +7,7 @@ use spin_sdk::{
 /// Send an HTTP request and return the response.
 #[http_component]
 async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
-    let mut res: http::Response<()> = spin_sdk::http::send(
+    let mut res: http::Response<String> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")
             .uri("https://random-data-api.fermyon.app/animals/json")

--- a/sdk/rust/readme.md
+++ b/sdk/rust/readme.md
@@ -41,7 +41,7 @@ server, modifies the result, then returns it:
 ```rust
 #[http_component]
 async fn hello_world(_req: Request) -> Result<Response> {
-    let mut res: http::Response<()> = spin_sdk::http::send(
+    let mut res: http::Response<String> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")
             .uri("https://fermyon.com")

--- a/sdk/rust/src/http/conversions.rs
+++ b/sdk/rust/src/http/conversions.rs
@@ -482,6 +482,28 @@ where
     }
 }
 
+impl TryFrom<Request> for OutgoingRequest {
+    type Error = std::convert::Infallible;
+
+    fn try_from(req: Request) -> Result<Self, Self::Error> {
+        let headers = req
+            .headers()
+            .map(|(k, v)| (k.to_owned(), v.as_bytes().to_owned()))
+            .collect::<Vec<_>>();
+        Ok(OutgoingRequest::new(
+            req.method(),
+            req.path_and_query(),
+            Some(if req.is_https() {
+                &super::Scheme::Https
+            } else {
+                &super::Scheme::Http
+            }),
+            req.authority(),
+            &Headers::new(&headers),
+        ))
+    }
+}
+
 #[cfg(feature = "http")]
 impl<B> TryFrom<hyperium::Request<B>> for OutgoingRequest
 where

--- a/sdk/rust/src/http/executor.rs
+++ b/sdk/rust/src/http/executor.rs
@@ -143,9 +143,8 @@ pub(crate) fn outgoing_body(body: OutgoingBody) -> impl Sink<Vec<u8>, Error = ty
 pub(crate) fn outgoing_request_send(
     request: OutgoingRequest,
 ) -> impl Future<Output = Result<IncomingResponse, types::Error>> {
+    let response = outgoing_handler::handle(request, None);
     future::poll_fn({
-        let response = outgoing_handler::handle(request, None);
-
         move |context| match &response {
             Ok(response) => {
                 if let Some(response) = response.get() {


### PR DESCRIPTION
This is a subset of the changes from #1902.

It keeps the API for `send` the same (with a slight change to the trait bounds). The internals are tweaked to fix outgoing requests which were not working when a body was sent.

There still seems to be some bugs in wasmtime-wasi-http that prevent true streaming of outbound request bodies. 

Also fixes https://github.com/fermyon/spin/issues/1954. @vdice, the issue was that the response had a non-zero content-length header but the body was actually empty. This was fixed by actually returning the body - [fixed here](https://github.com/fermyon/spin/compare/http-fix?expand=1#diff-060f2a7c3367a6ec24a7825ca6eac497707e2451843adf4b4c623b11ae783bf3L10).