### PR TITLE
rust: Add some convenience methods/impls to http types

### DIFF
--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.lock
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.lock
@@ -180,16 +180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,9 +225,7 @@ name = "outbound-http-to-same-app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "http",
  "spin-sdk",
- "url",
 ]
 
 [[package]]
@@ -453,40 +441,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -499,17 +457,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "url"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "version_check"

--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.toml
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.toml
@@ -7,11 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Useful crate to handle errors.
 anyhow = "1"
-# Crate to simplify working with bytes.
-http = "0.2"
-# The Spin SDK.
 spin-sdk = { path = "../../../sdk/rust" }
-url = "2"
+
 [workspace]

--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/src/lib.rs
@@ -1,21 +1,17 @@
 use anyhow::Result;
 use spin_sdk::{
-    http::{IntoResponse, Request},
+    http::{IntoResponse, Request, Response},
     http_component,
 };
 
 /// Send an HTTP request and return the response.
 #[http_component]
 async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
-    let mut res: http::Response<String> = spin_sdk::http::send(
-        http::Request::builder()
-            .method("GET")
-            .uri("/hello")
-            .body(())?,
-    )
-    .await?;
-    res.headers_mut()
-        .insert("spin-component", "rust-outbound-http".try_into()?);
-    println!("{:?}", res);
-    Ok(res)
+    let resp: Response = spin_sdk::http::send(Request::get("/hello")).await?;
+    let resp = resp
+        .into_builder()
+        .header("spin-component", "rust-outbound-http")
+        .build();
+    println!("{resp:?}");
+    Ok(resp)
 }

--- a/examples/http-rust-outbound-http/outbound-http/Cargo.lock
+++ b/examples/http-rust-outbound-http/outbound-http/Cargo.lock
@@ -178,7 +178,6 @@ name = "http-rust-outbound-http"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "http",
  "spin-sdk",
 ]
 

--- a/examples/http-rust-outbound-http/outbound-http/Cargo.toml
+++ b/examples/http-rust-outbound-http/outbound-http/Cargo.toml
@@ -7,11 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Useful crate to handle errors.
 anyhow = "1"
-# General-purpose crate with common HTTP types.
-http = "0.2"
-# The Spin SDK.
 spin-sdk = { path = "../../../sdk/rust" }
 
 [workspace]

--- a/examples/http-rust-outbound-http/outbound-http/src/lib.rs
+++ b/examples/http-rust-outbound-http/outbound-http/src/lib.rs
@@ -1,21 +1,20 @@
 use anyhow::Result;
 use spin_sdk::{
-    http::{IntoResponse, Request},
+    http::{IntoResponse, Request, Response},
     http_component,
 };
 
 /// Send an HTTP request and return the response.
 #[http_component]
 async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
-    let mut res: http::Response<String> = spin_sdk::http::send(
-        http::Request::builder()
-            .method("GET")
-            .uri("https://random-data-api.fermyon.app/animals/json")
-            .body(())?,
-    )
+    let resp: Response = spin_sdk::http::send(Request::get(
+        "https://random-data-api.fermyon.app/animals/json",
+    ))
     .await?;
-    res.headers_mut()
-        .insert("spin-component", "rust-outbound-http".try_into()?);
-    println!("{:?}", res);
-    Ok(res)
+    let resp = resp
+        .into_builder()
+        .header("spin-component", "rust-outbound-http")
+        .build();
+    println!("{resp:?}");
+    Ok(resp)
 }

--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -34,7 +34,7 @@ pub struct Request {
 }
 
 impl Request {
-    /// Create a new request from a method and uri
+    /// Creates a new request from a method and uri
     pub fn new(method: Method, uri: impl Into<String>) -> Self {
         Self {
             method,
@@ -42,6 +42,23 @@ impl Request {
             headers: HashMap::new(),
             body: Vec::new(),
         }
+    }
+
+    /// Creates a [`RequestBuilder`]
+    pub fn builder() -> RequestBuilder {
+        RequestBuilder::new(Method::Get, "/")
+    }
+
+    /// Creates a [`RequestBuilder`] to GET the given `uri`
+    pub fn get(uri: impl Into<String>) -> RequestBuilder {
+        RequestBuilder::new(Method::Get, uri)
+    }
+
+    /// Creates a [`RequestBuilder`] to POST the given `body` to `uri`
+    pub fn post(uri: impl Into<String>, body: impl conversions::IntoBody) -> RequestBuilder {
+        let mut builder = RequestBuilder::new(Method::Post, uri);
+        builder.body(body);
+        builder
     }
 
     /// The request method
@@ -93,11 +110,6 @@ impl Request {
     /// Consume this type and return its body
     pub fn into_body(self) -> Vec<u8> {
         self.body
-    }
-
-    /// Create a request builder
-    pub fn builder() -> RequestBuilder {
-        RequestBuilder::new(Method::Get, "/")
     }
 
     fn parse_uri(uri: String) -> (Option<hyperium::Uri>, String) {
@@ -244,8 +256,24 @@ impl Response {
         self.body
     }
 
+    /// Converts this response into a [`ResponseBuilder`]. This can be used to
+    /// update a response before passing it on.
+    pub fn into_builder(self) -> ResponseBuilder {
+        ResponseBuilder { response: self }
+    }
+
     fn builder() -> ResponseBuilder {
         ResponseBuilder::new(200)
+    }
+}
+
+impl std::fmt::Debug for Response {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Response")
+            .field("status", &self.status)
+            .field("headers", &self.headers)
+            .field("body.len()", &self.body.len())
+            .finish()
     }
 }
 

--- a/sdk/rust/src/http/conversions.rs
+++ b/sdk/rust/src/http/conversions.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 
 use crate::wit::wasi::io::streams;
 
-use super::{Headers, IncomingRequest, IncomingResponse, OutgoingRequest, OutgoingResponse};
+use super::{
+    Headers, IncomingRequest, IncomingResponse, OutgoingRequest, OutgoingResponse, RequestBuilder,
+};
 
 use super::{responses, NonUtf8BodyError, Request, Response};
 
@@ -525,6 +527,16 @@ impl TryIntoOutgoingRequest for Request {
             &Headers::new(&headers),
         );
         Ok((request, Some(self.into_body())))
+    }
+}
+
+impl TryIntoOutgoingRequest for RequestBuilder {
+    type Error = std::convert::Infallible;
+
+    fn try_into_outgoing_request(
+        mut self,
+    ) -> Result<(OutgoingRequest, Option<Vec<u8>>), Self::Error> {
+        self.build().try_into_outgoing_request()
     }
 }
 


### PR DESCRIPTION
This whole PR is summed up by this [`http-rust-outbound-http` example diff](https://github.com/fermyon/spin/pull/1977/files#diff-060f2a7c3367a6ec24a7825ca6eac497707e2451843adf4b4c623b11ae783bf3).

Draft until https://github.com/fermyon/spin/pull/1975 merges.

And update rust outbound http examples to use "simple" types.

- Add `Request::{get,post}` associated functions which cover the most common request types.
- `impl TryIntoOutgoingRequest for RequestBuilder` to skip a boilerplate `.build()`
- Add `Response::into_builder` to ease returning an updated response.
- `impl Debug for Response` to fix examples