### PR TITLE
replace `MyStd{in|out}Stream` with shareable streams

### DIFF
--- a/crates/core/src/io.rs
+++ b/crates/core/src/io.rs
@@ -1,6 +1,7 @@
 use wasmtime_wasi::preview2::{pipe::MemoryOutputPipe, HostOutputStream};
 
 /// An in-memory stdio output buffer.
+#[derive(Clone)]
 pub struct OutputBuffer(MemoryOutputPipe);
 
 impl OutputBuffer {


### PR DESCRIPTION
`MyStd{in|out}Stream` were written based on the assumption that `Std{in|out}Stream::stream` would only ever be called once.  Turns out that's not true for guest components which are composed of multiple subcomponents, since each subcomponent will potentially want its own handle, so they need to be shareable.  The easiest way to do that is provide cloneable implementations of `Host{In|Out}putStream` which operate synchronously.

Note that this amounts to doing synchronous I/O in an asynchronous context, which we'd normally prefer to avoid, but the properly asynchronous implementations `Host{In|Out}putStream` based on `AsyncRead`/`AsyncWrite` are quite hairy and probably not worth it for "normal" stdio streams in Spin.  If this does prove to be a performance bottleneck, though, we can certainly revisit it.