### PR TITLE
For postgres and mysql Connection::open- don't use v2 impl in v1

### DIFF
--- a/crates/outbound-pg/src/lib.rs
+++ b/crates/outbound-pg/src/lib.rs
@@ -21,6 +21,17 @@ pub struct OutboundPg {
 }
 
 impl OutboundPg {
+    async fn open_connection(&mut self, address: &str) -> Result<Resource<Connection>, v2::Error> {
+        self.connections
+            .push(
+                build_client(address)
+                    .await
+                    .map_err(|e| v2::Error::ConnectionFailed(format!("{e:?}")))?,
+            )
+            .map_err(|_| v2::Error::ConnectionFailed("too many connections".into()))
+            .map(Resource::new_own)
+    }
+
     async fn get_client(&mut self, connection: Resource<Connection>) -> Result<&Client, v2::Error> {
         self.connections
             .get(connection.rep())
@@ -95,17 +106,7 @@ impl v2::HostConnection for OutboundPg {
                 "address {address} is not permitted"
             ))));
         }
-        Ok(async {
-            self.connections
-                .push(
-                    build_client(&address)
-                        .await
-                        .map_err(|e| v2::Error::ConnectionFailed(format!("{e:?}")))?,
-                )
-                .map_err(|_| v2::Error::ConnectionFailed("too many connections".into()))
-                .map(Resource::new_own)
-        }
-        .await)
+        Ok(self.open_connection(&address).await)
     }
 
     async fn execute(
@@ -399,7 +400,7 @@ macro_rules! delegate {
                 "address {} is not permitted", $address
             ))));
         }
-        let connection = match <Self as v2::HostConnection>::open($self, $address).await? {
+        let connection = match $self.open_connection(&$address).await {
             Ok(c) => c,
             Err(e) => return Ok(Err(e.into())),
         };


### PR DESCRIPTION
This fixes an issue where users of the v1 interfaces were still being denied by default even when `allowed_outbound_hosts` was not present. 

This was because we were accidentally still using the v2 impl in v1 and the v2 impl has the deny-by-default semantics baked in. This changes refactors opening a connection so that v1 and v2 can decide differently when to deny a connection. 