### PR TITLE
chore(templates): Update TinyGo templates to v2

### DIFF
--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -1,7 +1,7 @@
 module github.com/{{project-name | snake_case}}
 
-go 1.17
+go 1.20
 
-require github.com/fermyon/spin/sdk/go main
+require github.com/fermyon/spin/sdk/go/v2 main
 
 require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/templates/http-go/content/main.go
+++ b/templates/http-go/content/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/http"
+	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
 )
 
 func init() {

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -1,5 +1,5 @@
 module github.com/{{project-name | snake_case}}
 
-go 1.17
+go 1.20
 
-require github.com/fermyon/spin/sdk/go main
+require github.com/fermyon/spin/sdk/go/v2 main

--- a/templates/redis-go/content/main.go
+++ b/templates/redis-go/content/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/fermyon/spin/sdk/go/redis"
+	"github.com/fermyon/spin/sdk/go/v2/redis"
 )
 
 func init() {


### PR DESCRIPTION
I tested running `go mod tidy` on these templates and everything worked as expected. I think we're okay to merge this before the 2.0 release.

Closes #1970