### PR TITLE
fix `test_wasi_http_double_echo` regression

### DIFF
--- a/examples/wasi-http-rust-streaming-outgoing-body/spin.toml
+++ b/examples/wasi-http-rust-streaming-outgoing-body/spin.toml
@@ -12,7 +12,7 @@ component = "wasi-http-async"
 
 [component.wasi-http-async]
 source = "target/wasm32-wasi/release/wasi_http_rust_streaming_outgoing_body.wasm"
-allowed_outbound_hosts = ["https://*:*"]
+allowed_outbound_hosts = ["https://*:*", "http://*:*"]
 [component.wasi-http-async.build]
 command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]


### PR DESCRIPTION
The PR where I added that test conflicted subtly with Ryan's `allowed_outbound_hosts` PR.  This should fix it.