### PR TITLE
ci(release): only config aws creds + upload to s3 if main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,11 @@ jobs:
           prerelease: ${{ steps.release-version.outputs.prerelease == 'true' }}
 
       - name: Configure AWS Credentials
-        if: runner.os == 'linux' && matrix.config.arch == 'amd64' && github.repository_owner == 'fermyon'
+        if: |
+          runner.os == 'linux' &&
+          matrix.config.arch == 'amd64' &&
+          github.repository_owner == 'fermyon' &&
+          github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.SPIN_RELEASE_ARTIFACTS_REPO }}
@@ -200,7 +204,11 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Copy Binary to S3 - ${{ env.RELEASE_VERSION }}
-        if: runner.os == 'linux' && matrix.config.arch == 'amd64' && github.repository_owner == 'fermyon'
+        if: |
+          runner.os == 'linux' &&
+          matrix.config.arch == 'amd64' &&
+          github.repository_owner == 'fermyon' &&
+          github.ref == 'refs/heads/main'
         run: |
           aws s3 cp _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz s3://${{ secrets.SPIN_RELEASE_ARTIFACTS_REPO }}/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz --acl public-read
 


### PR DESCRIPTION
This job failed for a recent push to the [v2.0 branch](https://github.com/fermyon/spin/tree/v2.0): https://github.com/fermyon/spin/actions/runs/6714173936/job/18246992840.

We're anticipating it may fail in the same way for the 2.0.0(-rc.1) release; hence creating this PR to unblock.  Can/should certainly revisit if we'd like s3 uploads from either/both v* branches and/or v* tags. cc @rajatjindal 