### PR TITLE
Refactor to keep variant descriptions together

### DIFF
--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -76,6 +76,15 @@ impl TemplateVariantInfo {
             Self::AddComponent { .. } => "component",
         }
     }
+
+    /// The noun that should be used for the variant in a prompt,
+    /// qualified with the appropriate a/an article for English
+    pub fn articled_noun(&self) -> &'static str {
+        match self {
+            Self::NewApplication => "an application",
+            Self::AddComponent { .. } => "a component",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -213,13 +213,10 @@ impl TemplateNewCommandCore {
             }
             // If -t is NOT provided and we have one positional arg then we have
             // to assume Spin 2 syntax. But if that arg matches a template then
-            // it could be Spin 1muscle memory.
+            // it could be Spin 1 muscle memory.
             (Some(name), None, None) => {
-                let creation_type = match variant {
-                    TemplateVariantInfo::NewApplication => "an app",
-                    TemplateVariantInfo::AddComponent { .. } => "a component",
-                };
                 if matches!(template_manager.get(name), Ok(Some(_))) {
+                    let creation_type = variant.articled_noun();
                     terminal::einfo!(
                         "This will create {creation_type} called {name}.",
                         "If you meant to use the {name} template, write '-t {name}'."


### PR DESCRIPTION
Extremely minor refactoring to keep the ever-escalating number of template variant "app or component" strings together (to help keep them consistent).  Low priority.