### PR TITLE
fix comment for disabling wasmtime pooling

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -64,7 +64,7 @@ where
     )]
     pub cache: Option<PathBuf>,
 
-    /// Enable Wasmtime's pooling instance allocator.
+    /// Disable Wasmtime's pooling instance allocator.
     #[clap(long = "disable-pooling")]
     pub disable_pooling: bool,
 


### PR DESCRIPTION
these comments show up in CLI output... this was rather confusing to read 😅 
```
-disable-pooling                                                                                  
            Enable Wasmtime's pooling instance allocator  
```