### PR TITLE
[1.5.x] rust/sdk: make exporting symbols opt-out

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -21,7 +21,9 @@ serde_json = {version = "1.0.96", optional = true}
 serde = {version = "1.0.163", optional = true}
 
 [features]
-default = ["export-sdk-language"]
+default = ["export-sdk-language", "export-sdk-version", "export-sdk-commit"]
 export-sdk-language = []
+export-sdk-version = []
+export-sdk-commit = []
 json = ["dep:serde", "dep:serde_json"]
 experimental = []

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -39,6 +39,7 @@ pub mod wit {
 #[doc(hidden)]
 pub use wit::__link_section;
 
+#[cfg(feature = "export-sdk-version")]
 #[export_name = concat!("spin-sdk-version-", env!("SDK_VERSION"))]
 extern "C" fn __spin_sdk_version() {}
 
@@ -46,6 +47,7 @@ extern "C" fn __spin_sdk_version() {}
 #[export_name = "spin-sdk-language-rust"]
 extern "C" fn __spin_sdk_language() {}
 
+#[cfg(feature = "export-sdk-commit")]
 #[export_name = concat!("spin-sdk-commit-", env!("SDK_COMMIT"))]
 extern "C" fn __spin_sdk_hash() {}
 


### PR DESCRIPTION
This PR is rebased on top of v1.5 branch, since that's the one I get when I install `spin` from the webpage. Not sure what's your backporting policy, so feel free to nuke this PR if it doesn't adhere to the rules (:

Without the patch, there are linker errors when both a driver crate (e.g. libsql-client-rs) and a user app have spin-sdk as their dependency. That's because both contain global symbols (T in nm output) and the linker is not able to determine which one is to stay.

Before the patch:
```
[sarna@sarna-pc rust]$ cargo build
[sarna@sarna-pc rust]$ nm -a ../../target/debug/libspin_sdk.rlib | grep T\ spin-sdk-
0000000000000000 T spin-sdk-commit-8d4334eca6eb2b9cec0105612cc9a38402f839b4
0000000000000000 T spin-sdk-language-rust
0000000000000000 T spin-sdk-version-1-5
```

After:
```
[sarna@sarna-pc rust]$ cargo build --no-default-features
[sarna@sarna-pc rust]$ nm -a ../../target/debug/libspin_sdk.rlib | grep T\ spin-sdk-
nm: lib.rmeta: no symbols
```

Refs https://github.com/libsql/libsql-client-rs/issues/51