### PR TITLE
rust/sdk: make exporting symbols opt-out

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -24,8 +24,10 @@ hyperium = { package = "http", version = "0.2", optional = true }
 bytes = { version = "1", optional = true }
 
 [features]
-default = ["export-sdk-language", "http", "json"]
+default = ["export-sdk-language", "export-sdk-version", "export-sdk-commit", "http", "json"]
 http = ["dep:hyperium", "dep:bytes"]
 export-sdk-language = []
+export-sdk-version = []
+export-sdk-commit = []
 json = ["dep:serde", "dep:serde_json"]
 experimental = []

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -35,6 +35,7 @@ pub mod wit {
 #[doc(hidden)]
 pub use wit::__link_section;
 
+#[cfg(feature = "export-sdk-version")]
 #[export_name = concat!("spin-sdk-version-", env!("SDK_VERSION"))]
 extern "C" fn __spin_sdk_version() {}
 
@@ -42,6 +43,7 @@ extern "C" fn __spin_sdk_version() {}
 #[export_name = "spin-sdk-language-rust"]
 extern "C" fn __spin_sdk_language() {}
 
+#[cfg(feature = "export-sdk-commit")]
 #[export_name = concat!("spin-sdk-commit-", env!("SDK_COMMIT"))]
 extern "C" fn __spin_sdk_hash() {}
 


### PR DESCRIPTION
Without it, there are linker errors when both a driver crate (e.g. libsql-client-rs) and a user app have spin-sdk as their dependency. That's because both contain global symbols (T in nm output) and the linker is not able to determine which one is to stay.

Before the patch:
```
[sarna@sarna-pc rust]$ cargo build
[sarna@sarna-pc rust]$ nm -a ../../target/debug/libspin_sdk.rlib | grep T\ spin-sdk-
0000000000000000 T spin-sdk-commit-8d4334eca6eb2b9cec0105612cc9a38402f839b4
0000000000000000 T spin-sdk-language-rust
0000000000000000 T spin-sdk-version-1-5
```

After:
```
[sarna@sarna-pc rust]$ cargo build --no-default-features -F http,json
[sarna@sarna-pc rust]$ nm -a ../../target/debug/libspin_sdk.rlib | grep T\ spin-sdk-
nm: lib.rmeta: no symbols
```

Refs https://github.com/libsql/libsql-client-rs/issues/51