### PR TITLE
update seemingly deprecated template flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ rustup target add wasm32-wasi
 First, run the `spin new` command to create a Spin application from a template.
 ```bash
 # Create a new Spin application named 'hello-rust' based on the Rust http template, accepting all defaults
-$ spin new --accept-defaults -t http-rust hello-rust
+$ spin new --accept-defaults http-rust hello-rust
 ```
 Running the `spin new` command created a `hello-rust` directory with all the necessary files for your application. Change to the `hello-rust` directory and build the application with `spin build`, then run it locally with `spin up`:
 


### PR DESCRIPTION
Hey team,

When kicking the tires, I noticed the readme has a `-t` flag, which I presume is for template. 
I have just downloaded `spin` today, so I don't suspect my binary is out of date, but it's possible.

Here's what I saw:
```sh
spin new --accept-defaults -t http-rust hello-rust
error: Found argument '-t' which wasn't expected, or isn't valid in this context

	If you tried to supply `-t` as a value rather than a flag, use `-- -t`

USAGE:
    spin new [OPTIONS] [ARGS]

For more information try --help
```

And here's what I found worked:

```sh
spin new --accept-defaults http-rust hello-rust
```

Updated the README accordingly