### PR TITLE
outbound-networking: More permissive allow-all

### DIFF
--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -120,7 +120,11 @@ pub(crate) fn convert_allowed_http_to_allowed_hosts(
         Vec::new()
     };
     match http_hosts {
-        AllowedHttpHosts::AllowAll => outbound_hosts.extend(["https://*:*".into()]),
+        AllowedHttpHosts::AllowAll => outbound_hosts.extend([
+            "http://*:*".into(),
+            "https://*:*".into(),
+            "http://self".into(),
+        ]),
         AllowedHttpHosts::AllowSpecific(specific) => {
             outbound_hosts.extend(specific.into_iter().map(|s| {
                 if s.domain == "self" {

--- a/crates/outbound-networking/src/lib.rs
+++ b/crates/outbound-networking/src/lib.rs
@@ -79,7 +79,7 @@ impl AllowedHostConfig {
     }
 
     fn allows_relative(&self, schemes: &[&str]) -> bool {
-        schemes.iter().any(|s| self.scheme.allows(s)) && self.host == HostConfig::ToSelf
+        schemes.iter().any(|s| self.scheme.allows(s)) && self.host.allows_relative()
     }
 }
 
@@ -158,6 +158,10 @@ impl HostConfig {
             HostConfig::List(l) => l.iter().any(|h| h.as_str() == host),
             HostConfig::ToSelf => false,
         }
+    }
+
+    fn allows_relative(&self) -> bool {
+        matches!(self, Self::Any | Self::ToSelf)
     }
 }
 


### PR DESCRIPTION
Two changes here that were regressions in LHC's understanding of allow-all:

- `insecure:allow-all` allows http and https
- `*:*` implies `self`

_Should backport for 2.0 if merged_