### PR TITLE
read incoming request bodies lazily

### DIFF
--- a/sdk/rust/macro/src/lib.rs
+++ b/sdk/rust/macro/src/lib.rs
@@ -106,7 +106,7 @@ pub fn http_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     let request: ::spin_sdk::http::IncomingRequest = ::std::convert::Into::into(request);
                     let response_out: ::spin_sdk::http::ResponseOutparam = ::std::convert::Into::into(response_out);
                     ::spin_sdk::http::run(async move {
-                        match ::spin_sdk::http::conversions::TryFromIncomingRequest::try_from_incoming_request(request).await {
+                        match ::spin_sdk::http::conversions::TryFromIncomingRequest::try_from_incoming_request(request) {
                             ::std::result::Result::Ok(req) => #handler,
                             ::std::result::Result::Err(e) => handle_response(response_out, e).await,
                         }

--- a/sdk/rust/src/http/router.rs
+++ b/sdk/rust/src/http/router.rs
@@ -1,4 +1,4 @@
-use super::conversions::{IntoResponse, TryFromRequest, TryIntoRequest};
+use super::conversions::{IntoRequest, IntoResponse, TryFromRequest};
 use super::{responses, Method, Request, Response};
 use routefinder::{Captures, Router as MethodRouter};
 use std::{collections::HashMap, fmt::Display};
@@ -41,13 +41,9 @@ impl Router {
     /// Dispatches a request to the appropriate handler along with the URI parameters.
     pub fn handle<R>(&self, request: R) -> Response
     where
-        R: TryIntoRequest,
-        R::Error: IntoResponse,
+        R: IntoRequest,
     {
-        let request = match R::try_into_request(request) {
-            Ok(r) => r,
-            Err(e) => return e.into_response(),
-        };
+        let request = R::into_request(request);
         let method = request.method.clone();
         let path = &request.path();
         let RouteMatch { params, handler } = self.find(path, method);


### PR DESCRIPTION
This currently entails terrible code duplication, even more terrible error handling, and miscellaneous crimes of various severity.

The main goal for the time being is to have something to benchmark against.  We can clean up (some of? all of?) the crimes prior to merging if the benchmarks look good.