### PR TITLE
When translating allowed_http_hosts allow both http and htttps

### DIFF
--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -126,15 +126,15 @@ pub(crate) fn convert_allowed_http_to_allowed_hosts(
             "http://self".into(),
         ]),
         AllowedHttpHosts::AllowSpecific(specific) => {
-            outbound_hosts.extend(specific.into_iter().map(|s| {
+            outbound_hosts.extend(specific.into_iter().flat_map(|s| {
                 if s.domain == "self" {
-                    "http://self".into()
+                    vec!["http://self".into()]
                 } else {
-                    let port = match s.port {
-                        Some(p) => p.to_string(),
-                        None => "443".to_string(),
-                    };
-                    format!("https://{}:{}", s.domain, port)
+                    let port = s.port.map(|p| format!(":{p}")).unwrap_or_default();
+                    vec![
+                        format!("http://{}{}", s.domain, port),
+                        format!("https://{}{}", s.domain, port),
+                    ]
                 }
             }))
         }

--- a/crates/manifest/tests/ui/v1/maximal.json
+++ b/crates/manifest/tests/ui/v1/maximal.json
@@ -66,7 +66,8 @@
       ],
       "allowed_outbound_hosts": [
         "https://fermyon.com:443",
-        "https://example.com:443"
+        "http://example.com",
+        "https://example.com"
       ],
       "key_value_stores": [
         "default"

--- a/crates/manifest/tests/ui/v1/maximal.toml.v2
+++ b/crates/manifest/tests/ui/v1/maximal.toml.v2
@@ -33,7 +33,7 @@ allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
 description = "My fine component"
 files = ["pattern/*", { source = "placement", destination = "/" }]
 exclude_files = ["**/secret"]
-allowed_outbound_hosts = ["https://fermyon.com:443", "https://example.com:443"]
+allowed_outbound_hosts = ["https://fermyon.com:443", "http://example.com", "https://example.com"]
 key_value_stores = ["default"]
 sqlite_databases = ["default"]
 ai_models = ["llama2-chat"]


### PR DESCRIPTION
`allowed_http_hosts` allowed both http and https so when translating to `allowed_outbound_hosts` we should respect that. 