### PR TITLE
fix(tests/integration): update plugin output assertion

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -592,10 +592,9 @@ route = "/..."
         let output = run(execute_args, None, Some(env_map.clone()))?;
 
         // Verify plugin successfully wrote to output file
-        assert_eq!(
-            std::str::from_utf8(&output.stdout)?.trim(),
-            "This is an example Spin plugin!"
-        );
+        assert!(std::str::from_utf8(&output.stdout)?
+            .trim()
+            .contains("This is an example Spin plugin!"));
 
         // Upgrade plugin to newer version
         *plugin_manifest_json.get_mut("version").unwrap() = serde_json::json!("0.2.1");


### PR DESCRIPTION
I  was unable to successfully run the integration tests on my machine (Mac Apple Silicon; same with @adamreese I believe), seeing the following:
```
failures:

---- integration_tests::test_spin_plugin_install_command stdout ----
STDOUT:
Plugin 'example' was installed successfully!

Description:
	A description of the plugin.

STDERR:
Warning: You're using a pre-release version of Spin (2.0.0-pre0). This plugin might not be compatible (supported: >=0.5). Continuing anyway.

STDOUT:
This is an example Spin plugin!

STDERR:
Warning: You're using a pre-release version of Spin (2.0.0-pre0). This plugin might not be compatible (supported: >=0.5). Continuing anyway.

thread 'integration_tests::test_spin_plugin_install_command' panicked at tests/integration.rs:595:9:
assertion `left == right` failed
  left: "\u{1b}(B\u{1b}[m\u{1b}(B\u{1b}[mThis is an example Spin plugin!"
 right: "This is an example Spin plugin!"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    integration_tests::test_spin_plugin_install_command
```

This proposes tweaking the assertion to use contains instead.