### PR TITLE
Add a Response::set_header method to the Rust SDK

### DIFF
--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -241,6 +241,16 @@ impl Response {
         self.headers.get(&name.to_lowercase())
     }
 
+    /// Set a response header
+    pub fn set_header(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        self.headers.insert(
+            name.into(),
+            HeaderValue {
+                inner: HeaderValueRep::String(value.into()),
+            },
+        );
+    }
+
     /// The response body
     pub fn body(&self) -> &[u8] {
         &self.body


### PR DESCRIPTION
This adds a `Response::set_header` method for upserting headers into responses. 

This method only accepts string header data and thus it's not possible to pass in non-utf8 data as a header. This is a deliberate tradeoff for simplicity sake (the same we've already made in the `ResponseBuilder`). For the rare use case that requires non-utf8 header data, we'll require users to use `ResponseBuilder::headers` or a third-party crate like `http`. 