### PR TITLE
rust-sdk: Stub out un-disable-able 'http' feature

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -18,14 +18,17 @@ wit-bindgen = "0.13.0"
 routefinder = "0.5.3"
 once_cell = "1.18.0"
 futures = "0.3.28"
+bytes = "1"
+hyperium = { package = "http", version = "0.2" }
 serde_json = { version = "1.0.96", optional = true }
 serde = { version = "1.0.163", optional = true }
-hyperium = { package = "http", version = "0.2", optional = true }
-bytes = { version = "1", optional = true }
 
 [features]
-default = ["export-sdk-language", "http", "json"]
-http = ["dep:hyperium", "dep:bytes"]
+default = ["export-sdk-language", "json"]
+experimental = []
 export-sdk-language = []
 json = ["dep:serde", "dep:serde_json"]
-experimental = []
+# This was a default feature in the 2.0.0 release but couldn't be disabled
+# without breakage. Retained here for backward compat and future reuse.
+# TODO: Consider removing in a future release if it remains unused.
+http = []

--- a/sdk/rust/src/http/conversions.rs
+++ b/sdk/rust/src/http/conversions.rs
@@ -156,7 +156,6 @@ pub trait TryNonRequestFromRequest {
         Self: Sized;
 }
 
-#[cfg(feature = "http")]
 impl<B: TryFromBody> TryNonRequestFromRequest for hyperium::Request<B> {
     type Error = B::Error;
     fn try_from_request(req: Request) -> Result<Self, Self::Error> {
@@ -170,7 +169,6 @@ impl<B: TryFromBody> TryNonRequestFromRequest for hyperium::Request<B> {
     }
 }
 
-#[cfg(feature = "http")]
 impl From<super::Method> for hyperium::Method {
     fn from(method: super::Method) -> Self {
         match method {
@@ -216,7 +214,6 @@ impl IntoResponse for Response {
     }
 }
 
-#[cfg(feature = "http")]
 impl<B> IntoResponse for hyperium::Response<B>
 where
     B: IntoBody,
@@ -306,7 +303,6 @@ impl IntoStatusCode for u16 {
     }
 }
 
-#[cfg(feature = "http")]
 impl IntoStatusCode for hyperium::StatusCode {
     fn into_status_code(self) -> u16 {
         self.as_u16()
@@ -383,7 +379,6 @@ impl IntoBody for Vec<u8> {
     }
 }
 
-#[cfg(feature = "http")]
 impl IntoBody for bytes::Bytes {
     fn into_body(self) -> Vec<u8> {
         self.to_vec()
@@ -475,7 +470,6 @@ impl FromBody for () {
     fn from_body(_body: Vec<u8>) -> Self {}
 }
 
-#[cfg(feature = "http")]
 impl FromBody for bytes::Bytes {
     fn from_body(body: Vec<u8>) -> Self {
         Into::into(body)
@@ -564,7 +558,6 @@ impl TryIntoOutgoingRequest for RequestBuilder {
     }
 }
 
-#[cfg(feature = "http")]
 impl<B> TryIntoOutgoingRequest for hyperium::Request<B>
 where
     B: TryIntoBody,
@@ -627,7 +620,6 @@ impl TryFromIncomingResponse for Response {
     }
 }
 
-#[cfg(feature = "http")]
 #[async_trait]
 impl<B: TryFromBody> TryFromIncomingResponse for hyperium::Response<B> {
     type Error = B::Error;
@@ -658,7 +650,6 @@ impl TryIntoRequest for Request {
     }
 }
 
-#[cfg(feature = "http")]
 impl<B: TryIntoBody> TryIntoRequest for hyperium::Request<B> {
     type Error = B::Error;
     fn try_into_request(self) -> Result<Request, Self::Error> {


### PR DESCRIPTION
This feature could not be disabled without breaking compilation.

Fixes #2079 