### PR TITLE
Update wasmtime backport revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-entity",
 ]
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -1261,12 +1261,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "cranelift-control"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "arbitrary",
 ]
@@ -1274,7 +1274,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1294,12 +1294,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "cranelift-native"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -7190,7 +7190,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
@@ -7231,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "wasi-tokio"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -7371,7 +7371,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7410,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cfg-if",
 ]
@@ -7418,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7437,7 +7437,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7451,12 +7451,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cranelift-shared"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7495,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cc",
  "cfg-if",
@@ -7530,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "object 0.32.1",
  "once_cell",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7577,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cc",
@@ -7606,7 +7606,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -7618,7 +7618,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7663,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7685,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7701,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -7712,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wmemcheck"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "wast"
@@ -7853,7 +7853,7 @@ dependencies = [
 [[package]]
 name = "wiggle"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7867,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -7881,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7923,7 +7923,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "0.12.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8214,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.1"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,10 +117,10 @@ tracing = { version = "0.1", features = ["log"] }
 
 # Use forked wasmtime 14.0.4 with backported patches to fix a performance regression
 # TODO: Replace with wasmtime 15 release.
-wasi-common-preview1 = { git = "https://github.com/fermyon/wasmtime", rev = "69aa4526eab5fc71fbf0df5088b648c7a7db6c04", package = "wasi-common" }
-wasmtime = { git = "https://github.com/fermyon/wasmtime", rev = "69aa4526eab5fc71fbf0df5088b648c7a7db6c04" , features = ["component-model"] }
-wasmtime-wasi = { git = "https://github.com/fermyon/wasmtime", rev = "69aa4526eab5fc71fbf0df5088b648c7a7db6c04", features = ["tokio"] }
-wasmtime-wasi-http = { git = "https://github.com/fermyon/wasmtime", rev = "69aa4526eab5fc71fbf0df5088b648c7a7db6c04" }
+wasi-common-preview1 = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6", package = "wasi-common" }
+wasmtime = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6" , features = ["component-model"] }
+wasmtime-wasi = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6", features = ["tokio"] }
+wasmtime-wasi-http = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6" }
 
 spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "191789170abde10cd55590466c0660dd6c7d472a" }
 

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-entity",
 ]
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -637,12 +637,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "cranelift-control"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "arbitrary",
 ]
@@ -650,7 +650,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "serde",
  "serde_derive",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -670,12 +670,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "cranelift-native"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -4661,7 +4661,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4683,7 +4683,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "wasi-tokio"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cfg-if",
 ]
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -4908,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4922,12 +4922,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cranelift-shared"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -4988,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5001,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "object",
  "once_cell",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cc",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -5089,7 +5089,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5134,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5156,7 +5156,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "heck",
@@ -5183,7 +5183,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wmemcheck"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 
 [[package]]
 name = "wast"
@@ -5244,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "wiggle"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5258,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "heck",
@@ -5272,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5314,7 +5314,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "0.12.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5526,7 +5526,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.1"
-source = "git+https://github.com/fermyon/wasmtime?rev=69aa4526eab5fc71fbf0df5088b648c7a7db6c04#69aa4526eab5fc71fbf0df5088b648c7a7db6c04"
+source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
 dependencies = [
  "anyhow",
  "log",

--- a/examples/spin-timer/Cargo.toml
+++ b/examples/spin-timer/Cargo.toml
@@ -17,6 +17,6 @@ tokio-scoped = "0.2.0"
 
 # Use forked wasmtime 14.0.4 with backported patches to fix a performance regression
 # TODO: Replace with wasmtime 15 release.
-wasmtime = { git = "https://github.com/fermyon/wasmtime", rev = "69aa4526eab5fc71fbf0df5088b648c7a7db6c04" , features = ["component-model"] }
+wasmtime = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6" , features = ["component-model"] }
 
 [workspace]


### PR DESCRIPTION
This works around a regression in 2.0.0 SDK apps: https://github.com/fermyon/wasmtime/pull/3