### PR TITLE
manifest: Improve error messages for invalid component IDs

### DIFF
--- a/crates/manifest/tests/ui/invalid/bad_kebab_component_ref.err
+++ b/crates/manifest/tests/ui/invalid/bad_kebab_component_ref.err
@@ -1,0 +1,6 @@
+TOML parse error at line 7, column 13
+  |
+7 | component = "1-2-3"
+  |             ^^^^^^^
+'-'-separated words must start with an ASCII letter; got '1'
+

--- a/crates/manifest/tests/ui/invalid/bad_kebab_component_ref.toml
+++ b/crates/manifest/tests/ui/invalid/bad_kebab_component_ref.toml
@@ -1,0 +1,7 @@
+spin_manifest_version = 2
+
+[application]
+name = "minimal-v2"
+
+[[trigger.fake]]
+component = "1-2-3"


### PR DESCRIPTION
The old error message was unhelpful: `data did not match any variant of untagged enum ComponentSpec`

This makes the variant deserialization explicit to give a better error on bad kebab name.

Fixes #1950