### PR TITLE
chore(templates/tests): bump spin fileserver component to v0.2.0

### DIFF
--- a/templates/static-fileserver/content/spin.toml
+++ b/templates/static-fileserver/content/spin.toml
@@ -11,5 +11,5 @@ route = "{{ http-path | http_wildcard }}"
 component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.2.0/spin_static_fs.wasm", digest = "sha256:1342e1b51f00ba3f9f5c96821f4ee8af75a8f49ca024a8bc892a3b74bbf53df2" }
 files = [{ source = "{{ files-path }}", destination = "/" }]

--- a/templates/static-fileserver/metadata/snippets/component.txt
+++ b/templates/static-fileserver/metadata/snippets/component.txt
@@ -3,5 +3,5 @@ route = "{{ http-path | http_wildcard }}"
 component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.2.0/spin_static_fs.wasm", digest = "sha256:1342e1b51f00ba3f9f5c96821f4ee8af75a8f49ca024a8bc892a3b74bbf53df2" }
 files = [{ source = "{{ files-path }}", destination = "/" }]

--- a/tests/testcases/assets-test/spin.toml
+++ b/tests/testcases/assets-test/spin.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 
 [[component]]
 id = "fs"
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.2.0/spin_static_fs.wasm", digest = "sha256:1342e1b51f00ba3f9f5c96821f4ee8af75a8f49ca024a8bc892a3b74bbf53df2" }
 files = [
     { source = "static/thisshouldbemounted", destination = "/thisshouldbemounted" },
 ]

--- a/tests/watch/static-fileserver/spin.toml
+++ b/tests/watch/static-fileserver/spin.toml
@@ -6,7 +6,7 @@ trigger = { type = "http" }
 version = "0.1.0"
 
 [[component]]
-source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.1.0/spin_static_fs.wasm", digest = "sha256:96c76d9af86420b39eb6cd7be5550e3cb5d4cc4de572ce0fd1f6a29471536cb4" }
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.2.0/spin_static_fs.wasm", digest = "sha256:1342e1b51f00ba3f9f5c96821f4ee8af75a8f49ca024a8bc892a3b74bbf53df2" }
 id = "static-fileserver"
 files = [ { source = "assets", destination = "/" } ]
 [component.trigger]


### PR DESCRIPTION
Ref https://github.com/fermyon/spin-fileserver/releases/tag/v0.2.0