### PR TITLE
Add `dotted_pascal_case` template filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ update-cargo-locks:
 test-unit:
 	RUST_LOG=$(LOG_LEVEL) cargo test --all --no-fail-fast -- --skip integration_tests --skip spinup_tests --skip cloud_tests --nocapture
 
+.PHONY: test-crate
+test-crate:
+	RUST_LOG=$(LOG_LEVEL) cargo test -p $(crate) --no-fail-fast -- --skip integration_tests --skip spinup_tests --skip cloud_tests --nocapture
+
 .PHONY: test-integration
 test-integration: test-kv test-sqlite
 	RUST_LOG=$(LOG_LEVEL) cargo test --test integration --no-fail-fast -- --skip spinup_tests --skip cloud_tests --nocapture


### PR DESCRIPTION
This filter was originally implemented as a custom filter for the C# template.  In order to bring back C# templates, we will need it in Spin templates core instead.

This PR includes an unrelated change to the makefile to allow me to run `make crate-blah-blah-blah test-crate` instead of copying and editing the `test-unit` script every dratted time.  I can move that to a separate PR if it's controversial.
