### PR TITLE
Add manifest field for plugin settings

### DIFF
--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -21,6 +21,7 @@ pub fn v1_to_v2_app(manifest: v1::AppManifestV1) -> Result<v2::AppManifest, Erro
         description: manifest.description,
         authors: manifest.authors,
         trigger_global_configs,
+        tool: Default::default(),
     };
 
     let app_variables = manifest
@@ -82,6 +83,7 @@ pub fn v1_to_v2_app(manifest: v1::AppManifestV1) -> Result<v2::AppManifest, Erro
                 sqlite_databases,
                 ai_models,
                 build: component.build,
+                tool: Default::default(),
                 allowed_outbound_hosts,
                 allowed_http_hosts: Vec::new(),
             },

--- a/crates/manifest/tests/ui/maximal.json
+++ b/crates/manifest/tests/ui/maximal.json
@@ -12,6 +12,11 @@
       "fake": {
         "global_option": true
       }
+    },
+    "tool": {
+      "lint": {
+        "lint_level": "savage"
+      }
     }
   },
   "variables": {
@@ -77,6 +82,11 @@
         "watch": [
           "src/**/*.rs"
         ]
+      },
+      "tool": {
+        "clean": {
+          "command": "cargo clean"
+        }
       }
     }
   }

--- a/crates/manifest/tests/ui/maximal.toml
+++ b/crates/manifest/tests/ui/maximal.toml
@@ -9,6 +9,9 @@ authors = ["alice@example.com", "bob@example.com"]
 [application.trigger.fake]
 global_option = true
 
+[application.tool.lint]
+lint_level = "savage"
+
 [variables]
 var_one = { default = "Default" }
 var_TWO = { required = true, secret = true }
@@ -38,3 +41,6 @@ ai_models = ["llama2-chat"]
 command = "cargo build"
 workdir = "my-component"
 watch = ["src/**/*.rs"]
+
+[component.maximal-component.tool.clean]
+command = "cargo clean"


### PR DESCRIPTION
Fixes #1768.

This adds a `tool` table at `[application]` and `[component.*]` levels.  Plugins or other tools can define their own keys.  The value of each entry is itself a table, so that each tool can structure its settings separately.  The expected use is as shown in the `maximal.toml` test:

```toml
[application.tool.lint]
lint_level = "savage"

[component.maximal-component.tool.clean]
command = "cargo clean"
```

Spin completely ignores the contents of the field.  Per discussion in #1768, it is currently not even propagated to the lockfile, although we could easily do this if the need arises.
