### PR TITLE
Update to Wasmtime 15.0.0, support multiple WASI snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
 name = "async-channel"
@@ -863,7 +863,7 @@ checksum = "6ffc30dee200c20b4dcb80572226f42658e1d9c4b668656d7cc59c33d50e396e"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "smallvec",
 ]
 
@@ -879,7 +879,7 @@ dependencies = [
  "io-lifetimes 2.0.2",
  "ipnet",
  "maybe-owned",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
  "winx",
 ]
@@ -903,7 +903,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes 2.0.2",
- "rustix 0.38.13",
+ "rustix 0.38.25",
 ]
 
 [[package]]
@@ -914,7 +914,7 @@ checksum = "f8f52b3c8f4abfe3252fd0a071f3004aaa3b18936ec97bdbd8763ce03aff6247"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "winx",
 ]
 
@@ -1224,16 +1224,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eb38f2af690b5a4411d9a8782b6d77dabff3ca939e0518453ab9f9a4392d41"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39526c036b92912417e8931f52c1e235796688068d3efdbbd8b164f299d19156"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1252,29 +1254,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb0deedc9fccf2db53a5a3c9c9d0163e44143b0d004dca9bf6ab6a0024cd79a"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea2d1b274e45aa8e61e9103efa1ba82d4b5a19d12bd1fd10744c3b7380ba3ff"
 
 [[package]]
 name = "cranelift-control"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea5977559a71e63db79a263f0e81a89b996e8a38212c4281e37dd1dbaa8b65c"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f871ada808b58158d84dfc43a6a2e2d2756baaf4ed1c51fd969ca8330e6ca5c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1282,8 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e6890f587ef59824b3debe577e68fdf9b307b3808c54b8d93a18fd0b70941b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1293,13 +1300,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d5fc6d5d3b52d1917002b17a8ecce448c2621b5bf394bb4e77e2f676893537"
 
 [[package]]
 name = "cranelift-native"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e10c2e7faa65d4ae7de9a83b44f2c31aca7dc638e17d0a79572fdf8103d720b"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1308,8 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2755807efc7ec80d1cc0b6815e70f10cedf968889f0469091dbff9c5c0741c48"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1317,7 +1327,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-types",
 ]
 
@@ -1967,7 +1977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -2030,7 +2040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd738b84894214045e8414eaded76359b4a5773f0a0a56b16575110739cdcf39"
 dependencies = [
  "io-lifetimes 2.0.2",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -3046,9 +3056,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "ittapi"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a5c0b993601cad796222ea076565c5d9f337d35592f8622c753724f06d7271"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -3057,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7b5e473765060536a660eed127f758cf1a810c73e49063264959c60d1727d9"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]
@@ -3234,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libflate"
@@ -3337,9 +3347,9 @@ checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "liquid"
@@ -5133,15 +5143,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.0",
  "errno 0.3.1",
  "itoa",
  "libc",
- "linux-raw-sys 0.4.7",
+ "linux-raw-sys 0.4.11",
  "once_cell",
  "windows-sys 0.48.0",
 ]
@@ -5751,10 +5761,10 @@ version = "0.1.0"
 source = "git+https://github.com/fermyon/spin-componentize?rev=191789170abde10cd55590466c0660dd6c7d472a#191789170abde10cd55590466c0660dd6c7d472a"
 dependencies = [
  "anyhow",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.12.1",
 ]
 
 [[package]]
@@ -6251,6 +6261,7 @@ dependencies = [
  "tracing",
  "url",
  "wasmtime",
+ "wasmtime-wasi",
  "wasmtime-wasi-http",
 ]
 
@@ -6453,7 +6464,7 @@ dependencies = [
  "cap-std",
  "fd-lock 4.0.0",
  "io-lifetimes 2.0.2",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
  "winx",
 ]
@@ -6481,9 +6492,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "temp-dir"
@@ -6500,7 +6511,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -7249,8 +7260,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3542b8d238a3de6c9986218af842f1e8f950ca7c4707aee9d0dd83002577a759"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7262,7 +7274,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes 2.0.2",
  "once_cell",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -7271,8 +7283,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a362c9dbdc5eb0809ce9db09e7b76805fea3ddaf2b8ff41a0e5c805935736205"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
@@ -7280,7 +7293,7 @@ dependencies = [
  "cap-std",
  "io-extras",
  "log",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -7290,14 +7303,15 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385503c0e4502dc5cbd7fdfe25f2d87a5dd19dd1cdd7e3bc5184146713bba554"
 dependencies = [
  "anyhow",
  "cap-std",
  "io-extras",
  "io-lifetimes 2.0.2",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "tokio",
  "wasi-cap-std-sync",
  "wasi-common",
@@ -7380,6 +7394,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b09bc5df933a3dabbdb72ae4b6b71be8ae07f58774d5aa41bd20adcd41a235a"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7391,8 +7423,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
 ]
 
 [[package]]
@@ -7419,19 +7451,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.2.70"
+name = "wasmparser"
+version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74458a9bc5cc9c7108abfa0fe4dc88d5abf1f3baf194df3264985f17d559b5e"
+checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
+dependencies = [
+ "indexmap 2.0.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.118.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebbb91574de0011ded32b14db12777e7dd5e9ea2f9d7317a1ab51a9495c75924"
+dependencies = [
+ "indexmap 2.0.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a7a046e6636d25c06a5df00bdc34e02f9e6e0e8a356d738299b961a6126114"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.118.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4b1702ef55144d6f594085f4989dc71fb71a791be1c8354ecc8e489b81199b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7452,8 +7505,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.36.2",
+ "wasmparser 0.116.1",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -7469,23 +7522,25 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c981d0e87bb3e98e08e76644e7ae5dfdef7f1d4105145853f3d677bb4535d65f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7ba8adaa84fdb9dd659275edcf7fc5282c44b9c9f829986c71d44fd52ea80a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
  "bincode",
  "directories-next",
  "log",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "serde",
  "serde_derive",
  "sha2",
@@ -7496,8 +7551,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91dcbbd0e1f094351d1ae0e53463c63ba53ec8f8e0e21d17567c1979a8c3758"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7505,18 +7561,20 @@ dependencies = [
  "syn 2.0.29",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.13.0",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e85f1319a7ed36aa59446ab7e967d0c2fb0cd179bf56913633190b44572023e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1453665878e16245b9a25405e550c4a36c6731c6e34ea804edc002a38c3e6741"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7531,7 +7589,7 @@ dependencies = [
  "object 0.32.1",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
@@ -7539,8 +7597,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dface3d9b72b4670781ff72675eabb291e2836b5dded6bb312b577d2bb561f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7554,8 +7613,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0116108e7d231cce15fe7dd642c66c3abb14dbcf169b0130e11f223ce8d1ad7"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -7567,8 +7627,8 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.36.2",
+ "wasmparser 0.116.1",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -7576,12 +7636,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a5896355c37bf0f9feb4f1299142ef4bed8c92576aa3a41d150fed0cafa056"
 dependencies = [
+ "anyhow",
  "cc",
  "cfg-if",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.48.0",
@@ -7589,8 +7651,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32b210767452f6b20157bb7c7d98295b92cc47aaad2a8aa31652f4469813a5d"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -7602,7 +7665,7 @@ dependencies = [
  "log",
  "object 0.32.1",
  "rustc-demangle",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "serde",
  "serde_derive",
  "target-lexicon",
@@ -7615,19 +7678,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffd2785a16c55ac77565613ebda625f5850d4014af0499df750e8de97c04547"
 dependencies = [
  "object 0.32.1",
  "once_cell",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73ad1395eda136baec5ece7e079e0536a82ef73488e345456cc9b89858ad0ec"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7636,8 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b50f7f3c1a8dabb2607f32a81242917bd77cee75f3dec66e04b02ccbb8ba07"
 dependencies = [
  "anyhow",
  "cc",
@@ -7651,9 +7717,9 @@ dependencies = [
  "memoffset 0.9.0",
  "paste",
  "rand 0.8.5",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "sptr",
- "wasm-encoder",
+ "wasm-encoder 0.36.2",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -7665,20 +7731,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447973db3dc5c24db14130ab0922795c58790aec296d198ad9d253b82ec67471"
 dependencies = [
  "cranelift-entity",
  "serde",
  "serde_derive",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a347bb8ecf12275fb180afb1b1c85c9e186553c43109737bffed4f54c2aa365"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7687,8 +7755,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f94342fc932695027cdfa0500a62a680879bdad495b36490887b1564124e53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7706,7 +7775,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "rustix 0.38.13",
+ "rustix 0.38.25",
  "system-interface",
  "thiserror",
  "tokio",
@@ -7722,8 +7791,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531b30bd168aa46cca77a678daaab99ed9bda5e70750aa6f638f3b05188d2047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7744,15 +7814,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8c602f026526d754c33b750f67d754234c6ec29595865916693c3306ca6a3b"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli 0.28.0",
  "object 0.32.1",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -7760,19 +7831,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41786c7bbbf250c0e685b291323b50c6bb65f0505a2c0b4f0b598c740f13f185"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.0.0",
- "wit-parser",
+ "wit-parser 0.13.0",
 ]
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47907bdd67500c66fa308acbce7387c7bfb63b5505ef81be7fc897709afcca60"
 
 [[package]]
 name = "wast"
@@ -7785,23 +7858,23 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "66.0.2"
+version = "69.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cb43b0ac6dd156f2c375735ccfd72b012a7c0a6e6d09503499b8d3cb6e6072"
+checksum = "efa51b5ad1391943d1bfad537e50f28fe938199ee76b115be6bae83802cd5185"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.38.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.77"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e367582095d2903caeeea9acbb140e1db9c7677001efa4347c3687fd34fe7072"
+checksum = "74a4c2488d058326466e086a43f5d4ea448241a8d0975e3eb0642c0828be1eb3"
 dependencies = [
- "wast 66.0.2",
+ "wast 69.0.0",
 ]
 
 [[package]]
@@ -7912,8 +7985,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b5a36af7e0a7d68fd6c080e78803b34c3105caa3f743dff2fc8db2fac4ab71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7926,8 +8000,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f5a763e4801e83c438e7fa6abdd5c38d735194c2a94e2f2ccdcc66456cefee"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -7940,8 +8015,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58262f5ac3a8ea686d4b940aa9f976f26c7e4e980aa8ac378f29274cb8638e33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7982,8 +8058,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.12.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9057ea325cac1ec02b28418da975a9f3a3634611812dc6150401347f1774844e"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7991,7 +8068,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-environ",
 ]
 
@@ -8204,7 +8281,7 @@ checksum = "565b945ae074886071eccf9cdaf8ccd7b959c2b0d624095bea5fe62003e8b3e0"
 dependencies = [
  "anyhow",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.12.1",
 ]
 
 [[package]]
@@ -8248,10 +8325,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.35.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.115.0",
+ "wit-parser 0.12.1",
 ]
 
 [[package]]
@@ -8272,9 +8349,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.0.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+]
+
+[[package]]
 name = "witx"
 version = "0.9.1"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
 dependencies = [
  "anyhow",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,16 +118,10 @@ hyper = { version = "=1.0.0-rc.3", features = ["full"] }
 reqwest = { version = "0.11", features = ["stream"] }
 tracing = { version = "0.1", features = ["log"] }
 
-# Use forked wasmtime 14.0.4 with backported patches to fix a performance regression
-# TODO: Replace with wasmtime 15 release.
-wasi-common-preview1 = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6", package = "wasi-common" }
-wasmtime = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6", features = [
-  "component-model",
-] }
-wasmtime-wasi = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6", features = [
-  "tokio",
-] }
-wasmtime-wasi-http = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6" }
+wasi-common-preview1 = { version = "15.0.0", package = "wasi-common" }
+wasmtime = { version = "15.0.0" , features = ["component-model"] }
+wasmtime-wasi = { version = "15.0.0", features = ["tokio"] }
+wasmtime-wasi-http = "15.0.0"
 
 spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "191789170abde10cd55590466c0660dd6c7d472a" }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@ mod io;
 mod limits;
 mod preview1;
 mod store;
+pub mod wasi_2023_10_18;
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
@@ -266,6 +267,7 @@ impl<T: Send + Sync + OutboundWasiHttpHandler> EngineBuilder<T> {
         let engine = wasmtime::Engine::new(&config.inner)?;
         let linker: Linker<T> = Linker::new(&engine);
         let mut module_linker = ModuleLinker::new(&engine);
+
         wasmtime_wasi::tokio::add_to_linker(&mut module_linker, |data| match &mut data.wasi {
             Wasi::Preview1(ctx) => ctx,
             Wasi::Preview2 { .. } => panic!("using WASI Preview 2 functions with Preview 1 store"),

--- a/crates/core/src/wasi_2023_10_18.rs
+++ b/crates/core/src/wasi_2023_10_18.rs
@@ -1,0 +1,2440 @@
+#![doc(hidden)] // internal implementation detail used in tests and spin-trigger
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::mem;
+use wasmtime::component::{Linker, Resource};
+use wasmtime_wasi::preview2::{TrappableError, WasiView};
+use wasmtime_wasi_http::WasiHttpView;
+
+mod latest {
+    pub use wasmtime_wasi::preview2::bindings::wasi::*;
+    pub mod http {
+        pub use wasmtime_wasi_http::bindings::wasi::http::*;
+    }
+}
+
+wasmtime::component::bindgen!({
+    path: "../../wit",
+    interfaces: r#"
+        include wasi:http/proxy@0.2.0-rc-2023-10-18;
+
+        // NB: this is handling the historical behavior where Spin supported
+        // more than "just" this snaphsot of the proxy world but additionally
+        // other CLI-related interfaces.
+        include wasi:cli/reactor@0.2.0-rc-2023-10-18;
+    "#,
+    async: {
+        only_imports: [
+            "[method]descriptor.access-at",
+            "[method]descriptor.advise",
+            "[method]descriptor.change-directory-permissions-at",
+            "[method]descriptor.change-file-permissions-at",
+            "[method]descriptor.create-directory-at",
+            "[method]descriptor.get-flags",
+            "[method]descriptor.get-type",
+            "[method]descriptor.is-same-object",
+            "[method]descriptor.link-at",
+            "[method]descriptor.lock-exclusive",
+            "[method]descriptor.lock-shared",
+            "[method]descriptor.metadata-hash",
+            "[method]descriptor.metadata-hash-at",
+            "[method]descriptor.open-at",
+            "[method]descriptor.read",
+            "[method]descriptor.read-directory",
+            "[method]descriptor.readlink-at",
+            "[method]descriptor.remove-directory-at",
+            "[method]descriptor.rename-at",
+            "[method]descriptor.set-size",
+            "[method]descriptor.set-times",
+            "[method]descriptor.set-times-at",
+            "[method]descriptor.stat",
+            "[method]descriptor.stat-at",
+            "[method]descriptor.symlink-at",
+            "[method]descriptor.sync",
+            "[method]descriptor.sync-data",
+            "[method]descriptor.try-lock-exclusive",
+            "[method]descriptor.try-lock-shared",
+            "[method]descriptor.unlink-file-at",
+            "[method]descriptor.unlock",
+            "[method]descriptor.write",
+            "[method]input-stream.read",
+            "[method]input-stream.blocking-read",
+            "[method]input-stream.blocking-skip",
+            "[method]input-stream.skip",
+            "[method]output-stream.forward",
+            "[method]output-stream.splice",
+            "[method]output-stream.blocking-splice",
+            "[method]output-stream.blocking-flush",
+            "[method]output-stream.blocking-write",
+            "[method]output-stream.blocking-write-and-flush",
+            "[method]output-stream.blocking-write-zeroes-and-flush",
+            "[method]directory-entry-stream.read-directory-entry",
+            "poll-list",
+            "poll-one",
+        ],
+    },
+    with: {
+        "wasi:io/poll/pollable": latest::io::poll::Pollable,
+        "wasi:io/streams/input-stream": latest::io::streams::InputStream,
+        "wasi:io/streams/output-stream": latest::io::streams::OutputStream,
+        "wasi:io/streams/error": latest::io::streams::Error,
+        "wasi:filesystem/types/directory-entry-stream": latest::filesystem::types::DirectoryEntryStream,
+        "wasi:filesystem/types/descriptor": latest::filesystem::types::Descriptor,
+        "wasi:cli/terminal-input/terminal-input": latest::cli::terminal_input::TerminalInput,
+        "wasi:cli/terminal-output/terminal-output": latest::cli::terminal_output::TerminalOutput,
+        "wasi:sockets/tcp/tcp-socket": latest::sockets::tcp::TcpSocket,
+        "wasi:sockets/udp/udp-socket": UdpSocket,
+        "wasi:sockets/network/network": latest::sockets::network::Network,
+        "wasi:sockets/ip-name-lookup/resolve-address-stream": latest::sockets::ip_name_lookup::ResolveAddressStream,
+        "wasi:http/types/incoming-response": latest::http::types::IncomingResponse,
+        "wasi:http/types/incoming-request": latest::http::types::IncomingRequest,
+        "wasi:http/types/incoming-body": latest::http::types::IncomingBody,
+        "wasi:http/types/outgoing-response": latest::http::types::OutgoingResponse,
+        "wasi:http/types/outgoing-request": latest::http::types::OutgoingRequest,
+        "wasi:http/types/outgoing-body": latest::http::types::OutgoingBody,
+        "wasi:http/types/fields": latest::http::types::Fields,
+        "wasi:http/types/response-outparam": latest::http::types::ResponseOutparam,
+        "wasi:http/types/future-incoming-response": latest::http::types::FutureIncomingResponse,
+        "wasi:http/types/future-trailers": latest::http::types::FutureTrailers,
+    },
+});
+
+use wasi::cli::terminal_input::TerminalInput;
+use wasi::cli::terminal_output::TerminalOutput;
+use wasi::clocks::monotonic_clock::Instant;
+use wasi::clocks::wall_clock::Datetime;
+use wasi::filesystem::types::{
+    AccessType, Advice, Descriptor, DescriptorFlags, DescriptorStat, DescriptorType,
+    DirectoryEntry, DirectoryEntryStream, Error, ErrorCode as FsErrorCode, Filesize,
+    MetadataHashValue, Modes, NewTimestamp, OpenFlags, PathFlags,
+};
+use wasi::http::types::{
+    Error as HttpError, Fields, FutureIncomingResponse, FutureTrailers, Headers, IncomingBody,
+    IncomingRequest, IncomingResponse, Method, OutgoingBody, OutgoingRequest, OutgoingResponse,
+    RequestOptions, ResponseOutparam, Scheme, StatusCode, Trailers,
+};
+use wasi::io::poll::Pollable;
+use wasi::io::streams::{InputStream, OutputStream, StreamError};
+use wasi::sockets::ip_name_lookup::{IpAddress, ResolveAddressStream};
+use wasi::sockets::network::{Ipv4SocketAddress, Ipv6SocketAddress};
+use wasi::sockets::tcp::{
+    ErrorCode as SocketErrorCode, IpAddressFamily, IpSocketAddress, Network, ShutdownType,
+    TcpSocket,
+};
+use wasi::sockets::udp::Datagram;
+
+pub fn add_to_linker<T>(linker: &mut Linker<T>) -> Result<()>
+where
+    T: WasiView + WasiHttpView,
+{
+    // interfaces from the "command" world
+    wasi::clocks::monotonic_clock::add_to_linker(linker, |t| t)?;
+    wasi::clocks::wall_clock::add_to_linker(linker, |t| t)?;
+    wasi::filesystem::types::add_to_linker(linker, |t| t)?;
+    wasi::filesystem::preopens::add_to_linker(linker, |t| t)?;
+    wasi::io::poll::add_to_linker(linker, |t| t)?;
+    wasi::io::streams::add_to_linker(linker, |t| t)?;
+    wasi::random::random::add_to_linker(linker, |t| t)?;
+    wasi::cli::exit::add_to_linker(linker, |t| t)?;
+    wasi::cli::environment::add_to_linker(linker, |t| t)?;
+    wasi::cli::stdin::add_to_linker(linker, |t| t)?;
+    wasi::cli::stdout::add_to_linker(linker, |t| t)?;
+    wasi::cli::stderr::add_to_linker(linker, |t| t)?;
+    wasi::cli::terminal_input::add_to_linker(linker, |t| t)?;
+    wasi::cli::terminal_output::add_to_linker(linker, |t| t)?;
+    wasi::cli::terminal_stdin::add_to_linker(linker, |t| t)?;
+    wasi::cli::terminal_stdout::add_to_linker(linker, |t| t)?;
+    wasi::cli::terminal_stderr::add_to_linker(linker, |t| t)?;
+    wasi::sockets::tcp::add_to_linker(linker, |t| t)?;
+    wasi::sockets::tcp_create_socket::add_to_linker(linker, |t| t)?;
+    wasi::sockets::udp::add_to_linker(linker, |t| t)?;
+    wasi::sockets::udp_create_socket::add_to_linker(linker, |t| t)?;
+    wasi::sockets::instance_network::add_to_linker(linker, |t| t)?;
+    wasi::sockets::network::add_to_linker(linker, |t| t)?;
+    wasi::sockets::ip_name_lookup::add_to_linker(linker, |t| t)?;
+
+    wasi::http::types::add_to_linker(linker, |t| t)?;
+    wasi::http::outgoing_handler::add_to_linker(linker, |t| t)?;
+    Ok(())
+}
+
+impl<T> wasi::clocks::monotonic_clock::Host for T
+where
+    T: WasiView,
+{
+    fn now(&mut self) -> wasmtime::Result<Instant> {
+        <T as latest::clocks::monotonic_clock::Host>::now(self)
+    }
+
+    fn resolution(&mut self) -> wasmtime::Result<Instant> {
+        <T as latest::clocks::monotonic_clock::Host>::resolution(self)
+    }
+
+    fn subscribe(&mut self, when: Instant, absolute: bool) -> wasmtime::Result<Resource<Pollable>> {
+        if absolute {
+            <T as latest::clocks::monotonic_clock::Host>::subscribe_instant(self, when)
+        } else {
+            <T as latest::clocks::monotonic_clock::Host>::subscribe_duration(self, when)
+        }
+    }
+}
+
+impl<T> wasi::clocks::wall_clock::Host for T
+where
+    T: WasiView,
+{
+    fn now(&mut self) -> wasmtime::Result<Datetime> {
+        Ok(<T as latest::clocks::wall_clock::Host>::now(self)?.into())
+    }
+
+    fn resolution(&mut self) -> wasmtime::Result<Datetime> {
+        Ok(<T as latest::clocks::wall_clock::Host>::resolution(self)?.into())
+    }
+}
+
+impl<T> wasi::filesystem::types::Host for T
+where
+    T: WasiView,
+{
+    fn filesystem_error_code(
+        &mut self,
+        err: Resource<Error>,
+    ) -> wasmtime::Result<Option<FsErrorCode>> {
+        Ok(
+            <T as latest::filesystem::types::Host>::filesystem_error_code(self, err)?
+                .map(|e| e.into()),
+        )
+    }
+}
+
+#[async_trait]
+impl<T> wasi::filesystem::types::HostDescriptor for T
+where
+    T: WasiView,
+{
+    fn read_via_stream(
+        &mut self,
+        self_: Resource<Descriptor>,
+        offset: Filesize,
+    ) -> wasmtime::Result<Result<Resource<InputStream>, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::read_via_stream(self, self_, offset),
+        )
+    }
+
+    fn write_via_stream(
+        &mut self,
+        self_: Resource<Descriptor>,
+        offset: Filesize,
+    ) -> wasmtime::Result<Result<Resource<OutputStream>, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::write_via_stream(self, self_, offset),
+        )
+    }
+
+    fn append_via_stream(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<Resource<OutputStream>, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::append_via_stream(self, self_),
+        )
+    }
+
+    async fn advise(
+        &mut self,
+        self_: Resource<Descriptor>,
+        offset: Filesize,
+        length: Filesize,
+        advice: Advice,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::advise(
+                self,
+                self_,
+                offset,
+                length,
+                advice.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn sync_data(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::sync_data(self, self_).await,
+        )
+    }
+
+    async fn get_flags(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<DescriptorFlags, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::get_flags(self, self_).await,
+        )
+    }
+
+    async fn get_type(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<DescriptorType, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::get_type(self, self_).await,
+        )
+    }
+
+    async fn set_size(
+        &mut self,
+        self_: Resource<Descriptor>,
+        size: Filesize,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::set_size(self, self_, size).await,
+        )
+    }
+
+    async fn set_times(
+        &mut self,
+        self_: Resource<Descriptor>,
+        data_access_timestamp: NewTimestamp,
+        data_modification_timestamp: NewTimestamp,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::set_times(
+                self,
+                self_,
+                data_access_timestamp.into(),
+                data_modification_timestamp.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn read(
+        &mut self,
+        self_: Resource<Descriptor>,
+        length: Filesize,
+        offset: Filesize,
+    ) -> wasmtime::Result<Result<(Vec<u8>, bool), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::read(self, self_, length, offset)
+                .await,
+        )
+    }
+
+    async fn write(
+        &mut self,
+        self_: Resource<Descriptor>,
+        buffer: Vec<u8>,
+        offset: Filesize,
+    ) -> wasmtime::Result<Result<Filesize, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::write(self, self_, buffer, offset)
+                .await,
+        )
+    }
+
+    async fn read_directory(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<Resource<DirectoryEntryStream>, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::read_directory(self, self_).await,
+        )
+    }
+
+    async fn sync(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(<T as latest::filesystem::types::HostDescriptor>::sync(self, self_).await)
+    }
+
+    async fn create_directory_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::create_directory_at(
+                self, self_, path,
+            )
+            .await,
+        )
+    }
+
+    async fn stat(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<DescriptorStat, FsErrorCode>> {
+        convert_result(<T as latest::filesystem::types::HostDescriptor>::stat(self, self_).await)
+    }
+
+    async fn stat_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+    ) -> wasmtime::Result<Result<DescriptorStat, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::stat_at(
+                self,
+                self_,
+                path_flags.into(),
+                path,
+            )
+            .await,
+        )
+    }
+
+    async fn set_times_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+        data_access_timestamp: NewTimestamp,
+        data_modification_timestamp: NewTimestamp,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::set_times_at(
+                self,
+                self_,
+                path_flags.into(),
+                path,
+                data_access_timestamp.into(),
+                data_modification_timestamp.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn link_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        old_path_flags: PathFlags,
+        old_path: String,
+        new_descriptor: Resource<Descriptor>,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::link_at(
+                self,
+                self_,
+                old_path_flags.into(),
+                old_path,
+                new_descriptor,
+                new_path,
+            )
+            .await,
+        )
+    }
+
+    async fn open_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+        open_flags: OpenFlags,
+        flags: DescriptorFlags,
+        _modes: Modes,
+    ) -> wasmtime::Result<Result<Resource<Descriptor>, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::open_at(
+                self,
+                self_,
+                path_flags.into(),
+                path,
+                open_flags.into(),
+                flags.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn readlink_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<String, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::readlink_at(self, self_, path).await,
+        )
+    }
+
+    async fn remove_directory_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::remove_directory_at(
+                self, self_, path,
+            )
+            .await,
+        )
+    }
+
+    async fn rename_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        old_path: String,
+        new_descriptor: Resource<Descriptor>,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::rename_at(
+                self,
+                self_,
+                old_path,
+                new_descriptor,
+                new_path,
+            )
+            .await,
+        )
+    }
+
+    async fn symlink_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        old_path: String,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::symlink_at(
+                self, self_, old_path, new_path,
+            )
+            .await,
+        )
+    }
+
+    async fn access_at(
+        &mut self,
+        _self_: Resource<Descriptor>,
+        _path_flags: PathFlags,
+        _path: String,
+        _type_: AccessType,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!("access-at API is no longer supported in the latest snapshot")
+    }
+
+    async fn unlink_file_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::unlink_file_at(self, self_, path)
+                .await,
+        )
+    }
+
+    async fn change_file_permissions_at(
+        &mut self,
+        _self_: Resource<Descriptor>,
+        _path_flags: PathFlags,
+        _path: String,
+        _modes: Modes,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!(
+            "change-file-permissions-at API is no longer supported in the latest snapshot"
+        )
+    }
+
+    async fn change_directory_permissions_at(
+        &mut self,
+        _self_: Resource<Descriptor>,
+        _path_flags: PathFlags,
+        _path: String,
+        _modes: Modes,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!(
+            "change-directory-permissions-at API is no longer supported in the latest snapshot"
+        )
+    }
+
+    async fn lock_shared(
+        &mut self,
+        _self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!("lock-shared API is no longer supported in the latest snapshot")
+    }
+
+    async fn lock_exclusive(
+        &mut self,
+        _self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!("lock-exclusive API is no longer supported in the latest snapshot")
+    }
+
+    async fn try_lock_shared(
+        &mut self,
+        _self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!("try-lock-shared API is no longer supported in the latest snapshot")
+    }
+
+    async fn try_lock_exclusive(
+        &mut self,
+        _self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!("try-lock-exclusive API is no longer supported in the latest snapshot")
+    }
+
+    async fn unlock(
+        &mut self,
+        _self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<(), FsErrorCode>> {
+        anyhow::bail!("unlock API is no longer supported in the latest snapshot")
+    }
+
+    async fn is_same_object(
+        &mut self,
+        self_: Resource<Descriptor>,
+        other: Resource<Descriptor>,
+    ) -> wasmtime::Result<bool> {
+        <T as latest::filesystem::types::HostDescriptor>::is_same_object(self, self_, other).await
+    }
+
+    async fn metadata_hash(
+        &mut self,
+        self_: Resource<Descriptor>,
+    ) -> wasmtime::Result<Result<MetadataHashValue, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::metadata_hash(self, self_).await,
+        )
+    }
+
+    async fn metadata_hash_at(
+        &mut self,
+        self_: Resource<Descriptor>,
+        path_flags: PathFlags,
+        path: String,
+    ) -> wasmtime::Result<Result<MetadataHashValue, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDescriptor>::metadata_hash_at(
+                self,
+                self_,
+                path_flags.into(),
+                path,
+            )
+            .await,
+        )
+    }
+
+    fn drop(&mut self, rep: Resource<Descriptor>) -> wasmtime::Result<()> {
+        <T as latest::filesystem::types::HostDescriptor>::drop(self, rep)
+    }
+}
+
+#[async_trait]
+impl<T> wasi::filesystem::types::HostDirectoryEntryStream for T
+where
+    T: WasiView,
+{
+    async fn read_directory_entry(
+        &mut self,
+        self_: Resource<DirectoryEntryStream>,
+    ) -> wasmtime::Result<Result<Option<DirectoryEntry>, FsErrorCode>> {
+        convert_result(
+            <T as latest::filesystem::types::HostDirectoryEntryStream>::read_directory_entry(
+                self, self_,
+            )
+            .await
+            .map(|e| e.map(DirectoryEntry::from)),
+        )
+    }
+
+    fn drop(&mut self, rep: Resource<DirectoryEntryStream>) -> wasmtime::Result<()> {
+        <T as latest::filesystem::types::HostDirectoryEntryStream>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::filesystem::preopens::Host for T
+where
+    T: WasiView,
+{
+    fn get_directories(&mut self) -> wasmtime::Result<Vec<(Resource<Descriptor>, String)>> {
+        <T as latest::filesystem::preopens::Host>::get_directories(self)
+    }
+}
+
+#[async_trait]
+impl<T> wasi::io::poll::Host for T
+where
+    T: WasiView,
+{
+    async fn poll_list(&mut self, list: Vec<Resource<Pollable>>) -> wasmtime::Result<Vec<u32>> {
+        <T as latest::io::poll::Host>::poll(self, list).await
+    }
+
+    async fn poll_one(&mut self, rep: Resource<Pollable>) -> wasmtime::Result<()> {
+        <T as latest::io::poll::HostPollable>::block(self, rep).await
+    }
+}
+
+impl<T> wasi::io::poll::HostPollable for T
+where
+    T: WasiView,
+{
+    fn drop(&mut self, rep: Resource<Pollable>) -> wasmtime::Result<()> {
+        <T as latest::io::poll::HostPollable>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::io::streams::Host for T where T: WasiView {}
+
+impl<T> wasi::io::streams::HostError for T
+where
+    T: WasiView,
+{
+    fn to_debug_string(&mut self, self_: Resource<Error>) -> wasmtime::Result<String> {
+        <T as latest::io::error::HostError>::to_debug_string(self, self_)
+    }
+
+    fn drop(&mut self, rep: Resource<Error>) -> wasmtime::Result<()> {
+        <T as latest::io::error::HostError>::drop(self, rep)
+    }
+}
+
+#[async_trait]
+impl<T> wasi::io::streams::HostInputStream for T
+where
+    T: WasiView,
+{
+    async fn read(
+        &mut self,
+        self_: Resource<InputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<Vec<u8>, StreamError>> {
+        let result = <T as latest::io::streams::HostInputStream>::read(self, self_, len).await;
+        convert_stream_result(self, result)
+    }
+
+    async fn blocking_read(
+        &mut self,
+        self_: Resource<InputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<Vec<u8>, StreamError>> {
+        let result =
+            <T as latest::io::streams::HostInputStream>::blocking_read(self, self_, len).await;
+        convert_stream_result(self, result)
+    }
+
+    async fn skip(
+        &mut self,
+        self_: Resource<InputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<u64, StreamError>> {
+        let result = <T as latest::io::streams::HostInputStream>::skip(self, self_, len).await;
+        convert_stream_result(self, result)
+    }
+
+    async fn blocking_skip(
+        &mut self,
+        self_: Resource<InputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<u64, StreamError>> {
+        let result =
+            <T as latest::io::streams::HostInputStream>::blocking_skip(self, self_, len).await;
+        convert_stream_result(self, result)
+    }
+
+    fn subscribe(&mut self, self_: Resource<InputStream>) -> wasmtime::Result<Resource<Pollable>> {
+        <T as latest::io::streams::HostInputStream>::subscribe(self, self_)
+    }
+
+    fn drop(&mut self, rep: Resource<InputStream>) -> wasmtime::Result<()> {
+        <T as latest::io::streams::HostInputStream>::drop(self, rep)
+    }
+}
+
+#[async_trait]
+impl<T> wasi::io::streams::HostOutputStream for T
+where
+    T: WasiView,
+{
+    fn check_write(
+        &mut self,
+        self_: Resource<OutputStream>,
+    ) -> wasmtime::Result<Result<u64, StreamError>> {
+        let result = <T as latest::io::streams::HostOutputStream>::check_write(self, self_);
+        convert_stream_result(self, result)
+    }
+
+    fn write(
+        &mut self,
+        self_: Resource<OutputStream>,
+        contents: Vec<u8>,
+    ) -> wasmtime::Result<Result<(), StreamError>> {
+        let result = <T as latest::io::streams::HostOutputStream>::write(self, self_, contents);
+        convert_stream_result(self, result)
+    }
+
+    async fn blocking_write_and_flush(
+        &mut self,
+        self_: Resource<OutputStream>,
+        contents: Vec<u8>,
+    ) -> wasmtime::Result<Result<(), StreamError>> {
+        let result = <T as latest::io::streams::HostOutputStream>::blocking_write_and_flush(
+            self, self_, contents,
+        )
+        .await;
+        convert_stream_result(self, result)
+    }
+
+    fn flush(
+        &mut self,
+        self_: Resource<OutputStream>,
+    ) -> wasmtime::Result<Result<(), StreamError>> {
+        let result = <T as latest::io::streams::HostOutputStream>::flush(self, self_);
+        convert_stream_result(self, result)
+    }
+
+    async fn blocking_flush(
+        &mut self,
+        self_: Resource<OutputStream>,
+    ) -> wasmtime::Result<Result<(), StreamError>> {
+        let result =
+            <T as latest::io::streams::HostOutputStream>::blocking_flush(self, self_).await;
+        convert_stream_result(self, result)
+    }
+
+    fn subscribe(&mut self, self_: Resource<OutputStream>) -> wasmtime::Result<Resource<Pollable>> {
+        <T as latest::io::streams::HostOutputStream>::subscribe(self, self_)
+    }
+
+    fn write_zeroes(
+        &mut self,
+        self_: Resource<OutputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<(), StreamError>> {
+        let result = <T as latest::io::streams::HostOutputStream>::write_zeroes(self, self_, len);
+        convert_stream_result(self, result)
+    }
+
+    async fn blocking_write_zeroes_and_flush(
+        &mut self,
+        self_: Resource<OutputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<(), StreamError>> {
+        let result = <T as latest::io::streams::HostOutputStream>::blocking_write_zeroes_and_flush(
+            self, self_, len,
+        )
+        .await;
+        convert_stream_result(self, result)
+    }
+
+    async fn splice(
+        &mut self,
+        self_: Resource<OutputStream>,
+        src: Resource<InputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<u64, StreamError>> {
+        let result =
+            <T as latest::io::streams::HostOutputStream>::splice(self, self_, src, len).await;
+        convert_stream_result(self, result)
+    }
+
+    async fn blocking_splice(
+        &mut self,
+        self_: Resource<OutputStream>,
+        src: Resource<InputStream>,
+        len: u64,
+    ) -> wasmtime::Result<Result<u64, StreamError>> {
+        let result =
+            <T as latest::io::streams::HostOutputStream>::blocking_splice(self, self_, src, len)
+                .await;
+        convert_stream_result(self, result)
+    }
+
+    async fn forward(
+        &mut self,
+        _self_: Resource<OutputStream>,
+        _src: Resource<InputStream>,
+    ) -> wasmtime::Result<Result<u64, StreamError>> {
+        anyhow::bail!("forward API no longer supported")
+    }
+
+    fn drop(&mut self, rep: Resource<OutputStream>) -> wasmtime::Result<()> {
+        <T as latest::io::streams::HostOutputStream>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::random::random::Host for T
+where
+    T: WasiView,
+{
+    fn get_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
+        <T as latest::random::random::Host>::get_random_bytes(self, len)
+    }
+
+    fn get_random_u64(&mut self) -> wasmtime::Result<u64> {
+        <T as latest::random::random::Host>::get_random_u64(self)
+    }
+}
+
+impl<T> wasi::cli::exit::Host for T
+where
+    T: WasiView,
+{
+    fn exit(&mut self, status: Result<(), ()>) -> wasmtime::Result<()> {
+        <T as latest::cli::exit::Host>::exit(self, status)
+    }
+}
+
+impl<T> wasi::cli::environment::Host for T
+where
+    T: WasiView,
+{
+    fn get_environment(&mut self) -> wasmtime::Result<Vec<(String, String)>> {
+        <T as latest::cli::environment::Host>::get_environment(self)
+    }
+
+    fn get_arguments(&mut self) -> wasmtime::Result<Vec<String>> {
+        <T as latest::cli::environment::Host>::get_arguments(self)
+    }
+
+    fn initial_cwd(&mut self) -> wasmtime::Result<Option<String>> {
+        <T as latest::cli::environment::Host>::initial_cwd(self)
+    }
+}
+
+impl<T> wasi::cli::stdin::Host for T
+where
+    T: WasiView,
+{
+    fn get_stdin(&mut self) -> wasmtime::Result<Resource<InputStream>> {
+        <T as latest::cli::stdin::Host>::get_stdin(self)
+    }
+}
+
+impl<T> wasi::cli::stdout::Host for T
+where
+    T: WasiView,
+{
+    fn get_stdout(&mut self) -> wasmtime::Result<Resource<OutputStream>> {
+        <T as latest::cli::stdout::Host>::get_stdout(self)
+    }
+}
+
+impl<T> wasi::cli::stderr::Host for T
+where
+    T: WasiView,
+{
+    fn get_stderr(&mut self) -> wasmtime::Result<Resource<OutputStream>> {
+        <T as latest::cli::stderr::Host>::get_stderr(self)
+    }
+}
+
+impl<T> wasi::cli::terminal_stdin::Host for T
+where
+    T: WasiView,
+{
+    fn get_terminal_stdin(&mut self) -> wasmtime::Result<Option<Resource<TerminalInput>>> {
+        <T as latest::cli::terminal_stdin::Host>::get_terminal_stdin(self)
+    }
+}
+
+impl<T> wasi::cli::terminal_stdout::Host for T
+where
+    T: WasiView,
+{
+    fn get_terminal_stdout(&mut self) -> wasmtime::Result<Option<Resource<TerminalOutput>>> {
+        <T as latest::cli::terminal_stdout::Host>::get_terminal_stdout(self)
+    }
+}
+
+impl<T> wasi::cli::terminal_stderr::Host for T
+where
+    T: WasiView,
+{
+    fn get_terminal_stderr(&mut self) -> wasmtime::Result<Option<Resource<TerminalOutput>>> {
+        <T as latest::cli::terminal_stderr::Host>::get_terminal_stderr(self)
+    }
+}
+
+impl<T> wasi::cli::terminal_input::Host for T where T: WasiView {}
+
+impl<T> wasi::cli::terminal_input::HostTerminalInput for T
+where
+    T: WasiView,
+{
+    fn drop(&mut self, rep: Resource<TerminalInput>) -> wasmtime::Result<()> {
+        <T as latest::cli::terminal_input::HostTerminalInput>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::cli::terminal_output::Host for T where T: WasiView {}
+
+impl<T> wasi::cli::terminal_output::HostTerminalOutput for T
+where
+    T: WasiView,
+{
+    fn drop(&mut self, rep: Resource<TerminalOutput>) -> wasmtime::Result<()> {
+        <T as latest::cli::terminal_output::HostTerminalOutput>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::sockets::tcp::Host for T where T: WasiView {}
+
+impl<T> wasi::sockets::tcp::HostTcpSocket for T
+where
+    T: WasiView,
+{
+    fn start_bind(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        network: Resource<Network>,
+        local_address: IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::start_bind(
+            self,
+            self_,
+            network,
+            local_address.into(),
+        ))
+    }
+
+    fn finish_bind(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::finish_bind(
+            self, self_,
+        ))
+    }
+
+    fn start_connect(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        network: Resource<Network>,
+        remote_address: IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::start_connect(
+            self,
+            self_,
+            network,
+            remote_address.into(),
+        ))
+    }
+
+    fn finish_connect(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<(Resource<InputStream>, Resource<OutputStream>), SocketErrorCode>>
+    {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::finish_connect(
+            self, self_,
+        ))
+    }
+
+    fn start_listen(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::start_listen(
+            self, self_,
+        ))
+    }
+
+    fn finish_listen(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::finish_listen(
+            self, self_,
+        ))
+    }
+
+    fn accept(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<
+        Result<
+            (
+                Resource<TcpSocket>,
+                Resource<InputStream>,
+                Resource<OutputStream>,
+            ),
+            SocketErrorCode,
+        >,
+    > {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::accept(
+            self, self_,
+        ))
+    }
+
+    fn local_address(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<IpSocketAddress, SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::local_address(
+            self, self_,
+        ))
+    }
+
+    fn remote_address(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<IpSocketAddress, SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::remote_address(
+            self, self_,
+        ))
+    }
+
+    fn address_family(&mut self, self_: Resource<TcpSocket>) -> wasmtime::Result<IpAddressFamily> {
+        <T as latest::sockets::tcp::HostTcpSocket>::address_family(self, self_).map(|e| e.into())
+    }
+
+    fn ipv6_only(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<bool, SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::ipv6_only(
+            self, self_,
+        ))
+    }
+
+    fn set_ipv6_only(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        value: bool,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::set_ipv6_only(
+            self, self_, value,
+        ))
+    }
+
+    fn set_listen_backlog_size(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(
+            <T as latest::sockets::tcp::HostTcpSocket>::set_listen_backlog_size(self, self_, value),
+        )
+    }
+
+    fn keep_alive(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<bool, SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::keep_alive_enabled(self, self_))
+    }
+
+    fn set_keep_alive(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        value: bool,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(
+            <T as latest::sockets::tcp::HostTcpSocket>::set_keep_alive_enabled(self, self_, value),
+        )
+    }
+
+    fn no_delay(
+        &mut self,
+        _self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<bool, SocketErrorCode>> {
+        anyhow::bail!("no-delay API no longer supported")
+    }
+
+    fn set_no_delay(
+        &mut self,
+        _self_: Resource<TcpSocket>,
+        _value: bool,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        anyhow::bail!("set-no-delay API no longer supported")
+    }
+
+    fn unicast_hop_limit(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<u8, SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::hop_limit(
+            self, self_,
+        ))
+    }
+
+    fn set_unicast_hop_limit(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        value: u8,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::set_hop_limit(
+            self, self_, value,
+        ))
+    }
+
+    fn receive_buffer_size(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<u64, SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::receive_buffer_size(self, self_))
+    }
+
+    fn set_receive_buffer_size(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(
+            <T as latest::sockets::tcp::HostTcpSocket>::set_receive_buffer_size(self, self_, value),
+        )
+    }
+
+    fn send_buffer_size(
+        &mut self,
+        self_: Resource<TcpSocket>,
+    ) -> wasmtime::Result<Result<u64, SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::send_buffer_size(self, self_))
+    }
+
+    fn set_send_buffer_size(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(
+            <T as latest::sockets::tcp::HostTcpSocket>::set_send_buffer_size(self, self_, value),
+        )
+    }
+
+    fn subscribe(&mut self, self_: Resource<TcpSocket>) -> wasmtime::Result<Resource<Pollable>> {
+        <T as latest::sockets::tcp::HostTcpSocket>::subscribe(self, self_)
+    }
+
+    fn shutdown(
+        &mut self,
+        self_: Resource<TcpSocket>,
+        shutdown_type: ShutdownType,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        convert_result(<T as latest::sockets::tcp::HostTcpSocket>::shutdown(
+            self,
+            self_,
+            shutdown_type.into(),
+        ))
+    }
+
+    fn drop(&mut self, rep: Resource<TcpSocket>) -> wasmtime::Result<()> {
+        <T as latest::sockets::tcp::HostTcpSocket>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::sockets::tcp_create_socket::Host for T
+where
+    T: WasiView,
+{
+    fn create_tcp_socket(
+        &mut self,
+        address_family: IpAddressFamily,
+    ) -> wasmtime::Result<Result<Resource<TcpSocket>, SocketErrorCode>> {
+        convert_result(
+            <T as latest::sockets::tcp_create_socket::Host>::create_tcp_socket(
+                self,
+                address_family.into(),
+            ),
+        )
+    }
+}
+
+impl<T> wasi::sockets::udp::Host for T where T: WasiView {}
+
+/// Between the snapshot of WASI that this file is implementing and the current
+/// implementation of WASI UDP sockets were redesigned slightly to deal with
+/// a different way of managing incoming and outgoing datagrams. This means
+/// that this snapshot's `{start,finish}_connect`, `send`, and `receive`
+/// methods are no longer natively implemented, so they're polyfilled by this
+/// implementation.
+pub enum UdpSocket {
+    Initial(Resource<latest::sockets::udp::UdpSocket>),
+    Connecting(Resource<latest::sockets::udp::UdpSocket>, IpSocketAddress),
+    Connected {
+        socket: Resource<latest::sockets::udp::UdpSocket>,
+        incoming: Resource<latest::sockets::udp::IncomingDatagramStream>,
+        outgoing: Resource<latest::sockets::udp::OutgoingDatagramStream>,
+    },
+    Dummy,
+}
+
+impl UdpSocket {
+    fn finish_connect<T: WasiView>(
+        table: &mut T,
+        socket: &Resource<UdpSocket>,
+        explicit: bool,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let state = table.table_mut().get_mut(socket)?;
+        let (new_socket, addr) = match mem::replace(state, UdpSocket::Dummy) {
+            // Implicit finishes will call `stream` for sockets in the initial
+            // state.
+            UdpSocket::Initial(socket) if !explicit => (socket, None),
+            // Implicit finishes won't try to reconnect a socket.
+            UdpSocket::Connected { .. } if !explicit => return Ok(Ok(())),
+            // Only explicit finishes can transition from the `Connecting` state.
+            UdpSocket::Connecting(socket, addr) if explicit => (socket, Some(addr)),
+            _ => return Ok(Err(SocketErrorCode::ConcurrencyConflict)),
+        };
+        let borrow = Resource::new_borrow(new_socket.rep());
+        let result = convert_result(<T as latest::sockets::udp::HostUdpSocket>::stream(
+            table,
+            borrow,
+            addr.map(|a| a.into()),
+        ))?;
+        let (incoming, outgoing) = match result {
+            Ok(pair) => pair,
+            Err(e) => return Ok(Err(e)),
+        };
+        *table.table_mut().get_mut(socket)? = UdpSocket::Connected {
+            socket: new_socket,
+            incoming,
+            outgoing,
+        };
+        Ok(Ok(()))
+    }
+
+    fn inner(&self) -> wasmtime::Result<Resource<latest::sockets::udp::UdpSocket>> {
+        let r = match self {
+            UdpSocket::Initial(r) => r,
+            UdpSocket::Connecting(r, _) => r,
+            UdpSocket::Connected { socket, .. } => socket,
+            UdpSocket::Dummy => anyhow::bail!("invalid udp socket state"),
+        };
+        Ok(Resource::new_borrow(r.rep()))
+    }
+}
+
+impl<T> wasi::sockets::udp::HostUdpSocket for T
+where
+    T: WasiView,
+{
+    fn start_bind(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        network: Resource<Network>,
+        local_address: IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::start_bind(
+            self,
+            socket,
+            network,
+            local_address.into(),
+        ))
+    }
+
+    fn finish_bind(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::finish_bind(
+            self, socket,
+        ))
+    }
+
+    fn start_connect(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        _network: Resource<Network>,
+        remote_address: IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let socket = self.table_mut().get_mut(&self_)?;
+        let (new_state, result) = match mem::replace(socket, UdpSocket::Dummy) {
+            UdpSocket::Initial(socket) => (UdpSocket::Connecting(socket, remote_address), Ok(())),
+            other => (other, Err(SocketErrorCode::ConcurrencyConflict)),
+        };
+        *socket = new_state;
+        Ok(result)
+    }
+
+    fn finish_connect(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        UdpSocket::finish_connect(self, &self_, true)
+    }
+
+    fn receive(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        max_results: u64,
+    ) -> wasmtime::Result<Result<Vec<Datagram>, SocketErrorCode>> {
+        // If the socket is in the `initial` state then complete the connect,
+        // otherwise verify we're connected.
+        if let Err(e) = UdpSocket::finish_connect(self, &self_, true)? {
+            return Ok(Err(e));
+        }
+
+        // Use our connected state to acquire the `incoming-datagram-stream`
+        // resource, then receive some datagrams.
+        let incoming = match self.table().get(&self_)? {
+            UdpSocket::Connected { incoming, .. } => Resource::new_borrow(incoming.rep()),
+            _ => return Ok(Err(SocketErrorCode::ConcurrencyConflict)),
+        };
+        let result: Result<Vec<_>, _> = convert_result(
+            <T as latest::sockets::udp::HostIncomingDatagramStream>::receive(
+                self,
+                incoming,
+                max_results,
+            ),
+        )?;
+        match result {
+            Ok(datagrams) => Ok(Ok(datagrams
+                .into_iter()
+                .map(|datagram| datagram.into())
+                .collect())),
+            Err(e) => Ok(Err(e)),
+        }
+    }
+
+    fn send(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        mut datagrams: Vec<Datagram>,
+    ) -> wasmtime::Result<Result<u64, SocketErrorCode>> {
+        // If the socket is in the `initial` state then complete the connect,
+        // otherwise verify we're connected.
+        if let Err(e) = UdpSocket::finish_connect(self, &self_, true)? {
+            return Ok(Err(e));
+        }
+
+        // Use our connected state to acquire the `outgoing-datagram-stream`
+        // resource.
+        let outgoing = match self.table().get(&self_)? {
+            UdpSocket::Connected { outgoing, .. } => Resource::new_borrow(outgoing.rep()),
+            _ => return Ok(Err(SocketErrorCode::ConcurrencyConflict)),
+        };
+
+        // Acquire a sending permit for some datagrams, truncating our list to
+        // that size if we have one.
+        let outgoing2 = Resource::new_borrow(outgoing.rep());
+        match convert_result(
+            <T as latest::sockets::udp::HostOutgoingDatagramStream>::check_send(self, outgoing2),
+        )? {
+            Ok(n) => {
+                if datagrams.len() as u64 > n {
+                    datagrams.truncate(n as usize);
+                }
+            }
+            Err(e) => return Ok(Err(e)),
+        }
+
+        // Send off the datagrams.
+        convert_result(
+            <T as latest::sockets::udp::HostOutgoingDatagramStream>::send(
+                self,
+                outgoing,
+                datagrams
+                    .into_iter()
+                    .map(|d| latest::sockets::udp::OutgoingDatagram {
+                        data: d.data,
+                        remote_address: Some(d.remote_address.into()),
+                    })
+                    .collect(),
+            ),
+        )
+    }
+
+    fn local_address(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<IpSocketAddress, SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::local_address(
+            self, socket,
+        ))
+    }
+
+    fn remote_address(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<IpSocketAddress, SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::remote_address(
+            self, socket,
+        ))
+    }
+
+    fn address_family(&mut self, self_: Resource<UdpSocket>) -> wasmtime::Result<IpAddressFamily> {
+        let socket = self.table().get(&self_)?.inner()?;
+        <T as latest::sockets::udp::HostUdpSocket>::address_family(self, socket).map(|e| e.into())
+    }
+
+    fn ipv6_only(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<bool, SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::ipv6_only(
+            self, socket,
+        ))
+    }
+
+    fn set_ipv6_only(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        value: bool,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::set_ipv6_only(
+            self, socket, value,
+        ))
+    }
+
+    fn unicast_hop_limit(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<u8, SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::unicast_hop_limit(self, socket))
+    }
+
+    fn set_unicast_hop_limit(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        value: u8,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(
+            <T as latest::sockets::udp::HostUdpSocket>::set_unicast_hop_limit(self, socket, value),
+        )
+    }
+
+    fn receive_buffer_size(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<u64, SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(
+            <T as latest::sockets::udp::HostUdpSocket>::receive_buffer_size(self, socket),
+        )
+    }
+
+    fn set_receive_buffer_size(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(
+            <T as latest::sockets::udp::HostUdpSocket>::set_receive_buffer_size(
+                self, socket, value,
+            ),
+        )
+    }
+
+    fn send_buffer_size(
+        &mut self,
+        self_: Resource<UdpSocket>,
+    ) -> wasmtime::Result<Result<u64, SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(<T as latest::sockets::udp::HostUdpSocket>::send_buffer_size(self, socket))
+    }
+
+    fn set_send_buffer_size(
+        &mut self,
+        self_: Resource<UdpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        convert_result(
+            <T as latest::sockets::udp::HostUdpSocket>::set_send_buffer_size(self, socket, value),
+        )
+    }
+
+    fn subscribe(&mut self, self_: Resource<UdpSocket>) -> wasmtime::Result<Resource<Pollable>> {
+        let socket = self.table().get(&self_)?.inner()?;
+        <T as latest::sockets::udp::HostUdpSocket>::subscribe(self, socket)
+    }
+
+    fn drop(&mut self, rep: Resource<UdpSocket>) -> wasmtime::Result<()> {
+        let me = self.table_mut().delete(rep)?;
+        let socket = match me {
+            UdpSocket::Initial(s) => s,
+            UdpSocket::Connecting(s, _) => s,
+            UdpSocket::Connected {
+                socket,
+                incoming,
+                outgoing,
+            } => {
+                <T as latest::sockets::udp::HostIncomingDatagramStream>::drop(self, incoming)?;
+                <T as latest::sockets::udp::HostOutgoingDatagramStream>::drop(self, outgoing)?;
+                socket
+            }
+            UdpSocket::Dummy => return Ok(()),
+        };
+        <T as latest::sockets::udp::HostUdpSocket>::drop(self, socket)
+    }
+}
+
+impl<T> wasi::sockets::udp_create_socket::Host for T
+where
+    T: WasiView,
+{
+    fn create_udp_socket(
+        &mut self,
+        address_family: IpAddressFamily,
+    ) -> wasmtime::Result<Result<Resource<UdpSocket>, SocketErrorCode>> {
+        let result = convert_result(
+            <T as latest::sockets::udp_create_socket::Host>::create_udp_socket(
+                self,
+                address_family.into(),
+            ),
+        )?;
+        let socket = match result {
+            Ok(socket) => socket,
+            Err(e) => return Ok(Err(e)),
+        };
+        let socket = self.table_mut().push(UdpSocket::Initial(socket))?;
+        Ok(Ok(socket))
+    }
+}
+
+impl<T> wasi::sockets::instance_network::Host for T
+where
+    T: WasiView,
+{
+    fn instance_network(&mut self) -> wasmtime::Result<Resource<Network>> {
+        <T as latest::sockets::instance_network::Host>::instance_network(self)
+    }
+}
+
+impl<T> wasi::sockets::network::Host for T where T: WasiView {}
+
+impl<T> wasi::sockets::network::HostNetwork for T
+where
+    T: WasiView,
+{
+    fn drop(&mut self, rep: Resource<Network>) -> wasmtime::Result<()> {
+        <T as latest::sockets::network::HostNetwork>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::sockets::ip_name_lookup::Host for T
+where
+    T: WasiView,
+{
+    fn resolve_addresses(
+        &mut self,
+        network: Resource<Network>,
+        name: String,
+        _address_family: Option<IpAddressFamily>,
+        _include_unavailable: bool,
+    ) -> wasmtime::Result<Result<Resource<ResolveAddressStream>, SocketErrorCode>> {
+        convert_result(
+            <T as latest::sockets::ip_name_lookup::Host>::resolve_addresses(self, network, name),
+        )
+    }
+}
+
+impl<T> wasi::sockets::ip_name_lookup::HostResolveAddressStream for T
+where
+    T: WasiView,
+{
+    fn resolve_next_address(
+        &mut self,
+        self_: Resource<ResolveAddressStream>,
+    ) -> wasmtime::Result<Result<Option<IpAddress>, SocketErrorCode>> {
+        convert_result(
+            <T as latest::sockets::ip_name_lookup::HostResolveAddressStream>::resolve_next_address(
+                self, self_,
+            )
+            .map(|e| e.map(|e| e.into())),
+        )
+    }
+
+    fn subscribe(
+        &mut self,
+        self_: Resource<ResolveAddressStream>,
+    ) -> wasmtime::Result<Resource<Pollable>> {
+        <T as latest::sockets::ip_name_lookup::HostResolveAddressStream>::subscribe(self, self_)
+    }
+
+    fn drop(&mut self, rep: Resource<ResolveAddressStream>) -> wasmtime::Result<()> {
+        <T as latest::sockets::ip_name_lookup::HostResolveAddressStream>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::Host for T where T: WasiHttpView {}
+
+impl<T> wasi::http::types::HostFields for T
+where
+    T: WasiHttpView,
+{
+    fn new(
+        &mut self,
+        entries: Vec<(String, Vec<u8>)>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<Fields>> {
+        match <T as latest::http::types::HostFields>::from_list(self, entries)? {
+            Ok(fields) => Ok(fields),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn get(
+        &mut self,
+        self_: wasmtime::component::Resource<Fields>,
+        name: String,
+    ) -> wasmtime::Result<Vec<Vec<u8>>> {
+        <T as latest::http::types::HostFields>::get(self, self_, name)
+    }
+
+    fn set(
+        &mut self,
+        self_: wasmtime::component::Resource<Fields>,
+        name: String,
+        value: Vec<Vec<u8>>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostFields>::set(self, self_, name, value)??;
+        Ok(())
+    }
+
+    fn delete(
+        &mut self,
+        self_: wasmtime::component::Resource<Fields>,
+        name: String,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostFields>::delete(self, self_, name)??;
+        Ok(())
+    }
+
+    fn append(
+        &mut self,
+        self_: wasmtime::component::Resource<Fields>,
+        name: String,
+        value: Vec<u8>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostFields>::append(self, self_, name, value)??;
+        Ok(())
+    }
+
+    fn entries(
+        &mut self,
+        self_: wasmtime::component::Resource<Fields>,
+    ) -> wasmtime::Result<Vec<(String, Vec<u8>)>> {
+        <T as latest::http::types::HostFields>::entries(self, self_)
+    }
+
+    fn clone(
+        &mut self,
+        self_: wasmtime::component::Resource<Fields>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<Fields>> {
+        <T as latest::http::types::HostFields>::clone(self, self_)
+    }
+
+    fn drop(&mut self, rep: wasmtime::component::Resource<Fields>) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostFields>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostIncomingRequest for T
+where
+    T: WasiHttpView,
+{
+    fn method(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingRequest>,
+    ) -> wasmtime::Result<Method> {
+        <T as latest::http::types::HostIncomingRequest>::method(self, self_).map(|e| e.into())
+    }
+
+    fn path_with_query(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingRequest>,
+    ) -> wasmtime::Result<Option<String>> {
+        <T as latest::http::types::HostIncomingRequest>::path_with_query(self, self_)
+    }
+
+    fn scheme(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingRequest>,
+    ) -> wasmtime::Result<Option<Scheme>> {
+        <T as latest::http::types::HostIncomingRequest>::scheme(self, self_)
+            .map(|e| e.map(|e| e.into()))
+    }
+
+    fn authority(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingRequest>,
+    ) -> wasmtime::Result<Option<String>> {
+        <T as latest::http::types::HostIncomingRequest>::authority(self, self_)
+    }
+
+    fn headers(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingRequest>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<Headers>> {
+        <T as latest::http::types::HostIncomingRequest>::headers(self, self_)
+    }
+
+    fn consume(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingRequest>,
+    ) -> wasmtime::Result<Result<wasmtime::component::Resource<IncomingBody>, ()>> {
+        <T as latest::http::types::HostIncomingRequest>::consume(self, self_)
+    }
+
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<IncomingRequest>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostIncomingRequest>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostIncomingResponse for T
+where
+    T: WasiHttpView,
+{
+    fn status(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingResponse>,
+    ) -> wasmtime::Result<StatusCode> {
+        <T as latest::http::types::HostIncomingResponse>::status(self, self_)
+    }
+
+    fn headers(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingResponse>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<Headers>> {
+        <T as latest::http::types::HostIncomingResponse>::headers(self, self_)
+    }
+
+    fn consume(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingResponse>,
+    ) -> wasmtime::Result<Result<wasmtime::component::Resource<IncomingBody>, ()>> {
+        <T as latest::http::types::HostIncomingResponse>::consume(self, self_)
+    }
+
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<IncomingResponse>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostIncomingResponse>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostIncomingBody for T
+where
+    T: WasiHttpView,
+{
+    fn stream(
+        &mut self,
+        self_: wasmtime::component::Resource<IncomingBody>,
+    ) -> wasmtime::Result<Result<wasmtime::component::Resource<InputStream>, ()>> {
+        <T as latest::http::types::HostIncomingBody>::stream(self, self_)
+    }
+
+    fn finish(
+        &mut self,
+        this: wasmtime::component::Resource<IncomingBody>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<FutureTrailers>> {
+        <T as latest::http::types::HostIncomingBody>::finish(self, this)
+    }
+
+    fn drop(&mut self, rep: wasmtime::component::Resource<IncomingBody>) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostIncomingBody>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostOutgoingRequest for T
+where
+    T: WasiHttpView,
+{
+    fn new(
+        &mut self,
+        method: Method,
+        path_with_query: Option<String>,
+        scheme: Option<Scheme>,
+        authority: Option<String>,
+        headers: wasmtime::component::Resource<Headers>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<OutgoingRequest>> {
+        let headers = <T as latest::http::types::HostFields>::clone(self, headers)?;
+        let request = <T as latest::http::types::HostOutgoingRequest>::new(self, headers)?;
+        let borrow = || Resource::new_borrow(request.rep());
+
+        if let Err(()) = <T as latest::http::types::HostOutgoingRequest>::set_method(
+            self,
+            borrow(),
+            method.into(),
+        )? {
+            <T as latest::http::types::HostOutgoingRequest>::drop(self, request)?;
+            anyhow::bail!("invalid method supplied");
+        }
+
+        if let Err(()) = <T as latest::http::types::HostOutgoingRequest>::set_path_with_query(
+            self,
+            borrow(),
+            path_with_query,
+        )? {
+            <T as latest::http::types::HostOutgoingRequest>::drop(self, request)?;
+            anyhow::bail!("invalid path-with-query supplied");
+        }
+
+        // Historical WASI would fill in an empty authority with a port which
+        // got just enough working to get things through. Current WASI requires
+        // the authority, though, so perform the translation manually here.
+        let authority = authority.unwrap_or_else(|| match &scheme {
+            Some(Scheme::Http) | Some(Scheme::Other(_)) => ":80".to_string(),
+            Some(Scheme::Https) | None => ":443".to_string(),
+        });
+        if let Err(()) = <T as latest::http::types::HostOutgoingRequest>::set_scheme(
+            self,
+            borrow(),
+            scheme.map(|s| s.into()),
+        )? {
+            <T as latest::http::types::HostOutgoingRequest>::drop(self, request)?;
+            anyhow::bail!("invalid scheme supplied");
+        }
+
+        if let Err(()) = <T as latest::http::types::HostOutgoingRequest>::set_authority(
+            self,
+            borrow(),
+            Some(authority),
+        )? {
+            <T as latest::http::types::HostOutgoingRequest>::drop(self, request)?;
+            anyhow::bail!("invalid authority supplied");
+        }
+
+        Ok(request)
+    }
+
+    fn write(
+        &mut self,
+        self_: wasmtime::component::Resource<OutgoingRequest>,
+    ) -> wasmtime::Result<Result<wasmtime::component::Resource<OutgoingBody>, ()>> {
+        <T as latest::http::types::HostOutgoingRequest>::body(self, self_)
+    }
+
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<OutgoingRequest>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostOutgoingRequest>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostOutgoingResponse for T
+where
+    T: WasiHttpView,
+{
+    fn new(
+        &mut self,
+        status_code: StatusCode,
+        headers: wasmtime::component::Resource<Headers>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<OutgoingResponse>> {
+        let headers = <T as latest::http::types::HostFields>::clone(self, headers)?;
+        let response = <T as latest::http::types::HostOutgoingResponse>::new(self, headers)?;
+        let borrow = || Resource::new_borrow(response.rep());
+
+        if let Err(()) = <T as latest::http::types::HostOutgoingResponse>::set_status_code(
+            self,
+            borrow(),
+            status_code,
+        )? {
+            <T as latest::http::types::HostOutgoingResponse>::drop(self, response)?;
+            anyhow::bail!("invalid status code supplied");
+        }
+
+        Ok(response)
+    }
+
+    fn write(
+        &mut self,
+        self_: wasmtime::component::Resource<OutgoingResponse>,
+    ) -> wasmtime::Result<Result<wasmtime::component::Resource<OutgoingBody>, ()>> {
+        <T as latest::http::types::HostOutgoingResponse>::body(self, self_)
+    }
+
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<OutgoingResponse>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostOutgoingResponse>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostOutgoingBody for T
+where
+    T: WasiHttpView,
+{
+    fn write(
+        &mut self,
+        self_: wasmtime::component::Resource<OutgoingBody>,
+    ) -> wasmtime::Result<Result<wasmtime::component::Resource<OutputStream>, ()>> {
+        <T as latest::http::types::HostOutgoingBody>::write(self, self_)
+    }
+
+    fn finish(
+        &mut self,
+        this: wasmtime::component::Resource<OutgoingBody>,
+        trailers: Option<wasmtime::component::Resource<Trailers>>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostOutgoingBody>::finish(self, this, trailers)??;
+        Ok(())
+    }
+
+    fn drop(&mut self, rep: wasmtime::component::Resource<OutgoingBody>) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostOutgoingBody>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostResponseOutparam for T
+where
+    T: WasiHttpView,
+{
+    fn set(
+        &mut self,
+        param: wasmtime::component::Resource<ResponseOutparam>,
+        response: Result<wasmtime::component::Resource<OutgoingResponse>, HttpError>,
+    ) -> wasmtime::Result<()> {
+        let response = response.map_err(|err| {
+            // TODO: probably need to figure out a better mapping between
+            // errors, but that seems like it would require string matching,
+            // which also seems not great.
+            let msg = match err {
+                HttpError::InvalidUrl(s) => format!("invalid url: {s}"),
+                HttpError::TimeoutError(s) => format!("timeout: {s}"),
+                HttpError::ProtocolError(s) => format!("protocol error: {s}"),
+                HttpError::UnexpectedError(s) => format!("unexpected error: {s}"),
+            };
+            latest::http::types::ErrorCode::InternalError(Some(msg))
+        });
+        <T as latest::http::types::HostResponseOutparam>::set(self, param, response)
+    }
+
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<ResponseOutparam>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostResponseOutparam>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostFutureTrailers for T
+where
+    T: WasiHttpView,
+{
+    fn subscribe(
+        &mut self,
+        self_: wasmtime::component::Resource<FutureTrailers>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<Pollable>> {
+        <T as latest::http::types::HostFutureTrailers>::subscribe(self, self_)
+    }
+
+    fn get(
+        &mut self,
+        self_: wasmtime::component::Resource<FutureTrailers>,
+    ) -> wasmtime::Result<Option<Result<wasmtime::component::Resource<Trailers>, HttpError>>> {
+        match <T as latest::http::types::HostFutureTrailers>::get(self, self_)? {
+            Some(Ok(Some(trailers))) => Ok(Some(Ok(trailers))),
+            // Return an empty trailers if no trailers popped out since this
+            // version of WASI couldn't represent the lack of trailers.
+            Some(Ok(None)) => Ok(Some(Ok(<T as latest::http::types::HostFields>::new(self)?))),
+            Some(Err(e)) => Ok(Some(Err(e.into()))),
+            None => Ok(None),
+        }
+    }
+
+    fn drop(&mut self, rep: wasmtime::component::Resource<FutureTrailers>) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostFutureTrailers>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::types::HostFutureIncomingResponse for T
+where
+    T: WasiHttpView,
+{
+    fn get(
+        &mut self,
+        self_: wasmtime::component::Resource<FutureIncomingResponse>,
+    ) -> wasmtime::Result<
+        Option<Result<Result<wasmtime::component::Resource<IncomingResponse>, HttpError>, ()>>,
+    > {
+        match <T as latest::http::types::HostFutureIncomingResponse>::get(self, self_)? {
+            None => Ok(None),
+            Some(Ok(Ok(response))) => Ok(Some(Ok(Ok(response)))),
+            Some(Ok(Err(e))) => Ok(Some(Ok(Err(e.into())))),
+            Some(Err(())) => Ok(Some(Err(()))),
+        }
+    }
+
+    fn subscribe(
+        &mut self,
+        self_: wasmtime::component::Resource<FutureIncomingResponse>,
+    ) -> wasmtime::Result<wasmtime::component::Resource<Pollable>> {
+        <T as latest::http::types::HostFutureIncomingResponse>::subscribe(self, self_)
+    }
+
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<FutureIncomingResponse>,
+    ) -> wasmtime::Result<()> {
+        <T as latest::http::types::HostFutureIncomingResponse>::drop(self, rep)
+    }
+}
+
+impl<T> wasi::http::outgoing_handler::Host for T
+where
+    T: WasiHttpView,
+{
+    fn handle(
+        &mut self,
+        request: wasmtime::component::Resource<OutgoingRequest>,
+        options: Option<RequestOptions>,
+    ) -> wasmtime::Result<Result<wasmtime::component::Resource<FutureIncomingResponse>, HttpError>>
+    {
+        let options = match options {
+            Some(RequestOptions {
+                connect_timeout_ms,
+                first_byte_timeout_ms,
+                between_bytes_timeout_ms,
+            }) => {
+                let options = <T as latest::http::types::HostRequestOptions>::new(self)?;
+                let borrow = || Resource::new_borrow(request.rep());
+
+                if let Some(ms) = connect_timeout_ms {
+                    if let Err(()) =
+                        <T as latest::http::types::HostRequestOptions>::set_connect_timeout_ms(
+                            self,
+                            borrow(),
+                            Some(ms.into()),
+                        )?
+                    {
+                        <T as latest::http::types::HostRequestOptions>::drop(self, options)?;
+                        anyhow::bail!("invalid connect timeout supplied");
+                    }
+                }
+
+                if let Some(ms) = first_byte_timeout_ms {
+                    if let Err(()) =
+                        <T as latest::http::types::HostRequestOptions>::set_first_byte_timeout_ms(
+                            self,
+                            borrow(),
+                            Some(ms.into()),
+                        )?
+                    {
+                        <T as latest::http::types::HostRequestOptions>::drop(self, options)?;
+                        anyhow::bail!("invalid first byte timeout supplied");
+                    }
+                }
+
+                if let Some(ms) = between_bytes_timeout_ms {
+                    if let Err(()) =
+                        <T as latest::http::types::HostRequestOptions>::set_between_bytes_timeout_ms(
+                            self,
+                            borrow(),
+                            Some(ms.into()),
+                        )?
+                    {
+                        <T as latest::http::types::HostRequestOptions>::drop(self, options)?;
+                        anyhow::bail!("invalid between bytes timeout supplied");
+                    }
+                }
+
+                Some(options)
+            }
+            None => None,
+        };
+        match <T as latest::http::outgoing_handler::Host>::handle(self, request, options)? {
+            Ok(resp) => Ok(Ok(resp)),
+            Err(e) => Ok(Err(e.into())),
+        }
+    }
+}
+
+fn convert_result<T, T2, E, E2>(
+    result: Result<T, TrappableError<E>>,
+) -> wasmtime::Result<Result<T2, E2>>
+where
+    T2: From<T>,
+    E: std::error::Error + Send + Sync + 'static,
+    E2: From<E>,
+{
+    match result {
+        Ok(e) => Ok(Ok(e.into())),
+        Err(e) => Ok(Err(e.downcast()?.into())),
+    }
+}
+
+fn convert_stream_result<T, T2>(
+    view: &mut dyn WasiView,
+    result: Result<T, wasmtime_wasi::preview2::StreamError>,
+) -> wasmtime::Result<Result<T2, StreamError>>
+where
+    T2: From<T>,
+{
+    match result {
+        Ok(e) => Ok(Ok(e.into())),
+        Err(wasmtime_wasi::preview2::StreamError::Closed) => Ok(Err(StreamError::Closed)),
+        Err(wasmtime_wasi::preview2::StreamError::LastOperationFailed(e)) => {
+            let e = view.table_mut().push(e)?;
+            Ok(Err(StreamError::LastOperationFailed(e)))
+        }
+        Err(wasmtime_wasi::preview2::StreamError::Trap(e)) => Err(e),
+    }
+}
+
+macro_rules! convert {
+    () => {};
+    ($kind:ident $from:path [<=>] $to:path { $($body:tt)* } $($rest:tt)*) => {
+        convert!($kind $from => $to { $($body)* });
+        convert!($kind $to => $from { $($body)* });
+
+        convert!($($rest)*);
+    };
+    (struct $from:ty => $to:path { $($field:ident,)* } $($rest:tt)*) => {
+        impl From<$from> for $to {
+            fn from(e: $from) -> $to {
+                $to {
+                    $( $field: e.$field.into(), )*
+                }
+            }
+        }
+
+        convert!($($rest)*);
+    };
+    (enum $from:path => $to:path { $($variant:ident $(($e:ident))?,)* } $($rest:tt)*) => {
+        impl From<$from> for $to {
+            fn from(e: $from) -> $to {
+                use $from as A;
+                use $to as B;
+                match e {
+                    $(
+                        A::$variant $(($e))? => B::$variant $(($e.into()))?,
+                    )*
+                }
+            }
+        }
+
+        convert!($($rest)*);
+    };
+    (flags $from:path => $to:path { $($flag:ident,)* } $($rest:tt)*) => {
+        impl From<$from> for $to {
+            fn from(e: $from) -> $to {
+                use $from as A;
+                use $to as B;
+                let mut out = B::empty();
+                $(
+                    if e.contains(A::$flag) {
+                        out |= B::$flag;
+                    }
+                )*
+                out
+            }
+        }
+
+        convert!($($rest)*);
+    };
+}
+
+convert! {
+    struct latest::clocks::wall_clock::Datetime [<=>] Datetime {
+        seconds,
+        nanoseconds,
+    }
+
+    enum latest::filesystem::types::ErrorCode => FsErrorCode {
+        Access,
+        WouldBlock,
+        Already,
+        BadDescriptor,
+        Busy,
+        Deadlock,
+        Quota,
+        Exist,
+        FileTooLarge,
+        IllegalByteSequence,
+        InProgress,
+        Interrupted,
+        Invalid,
+        Io,
+        IsDirectory,
+        Loop,
+        TooManyLinks,
+        MessageSize,
+        NameTooLong,
+        NoDevice,
+        NoEntry,
+        NoLock,
+        InsufficientMemory,
+        InsufficientSpace,
+        NotDirectory,
+        NotEmpty,
+        NotRecoverable,
+        Unsupported,
+        NoTty,
+        NoSuchDevice,
+        Overflow,
+        NotPermitted,
+        Pipe,
+        ReadOnly,
+        InvalidSeek,
+        TextFileBusy,
+        CrossDevice,
+    }
+
+    enum Advice => latest::filesystem::types::Advice {
+        Normal,
+        Sequential,
+        Random,
+        WillNeed,
+        DontNeed,
+        NoReuse,
+    }
+
+    flags DescriptorFlags [<=>] latest::filesystem::types::DescriptorFlags {
+        READ,
+        WRITE,
+        FILE_INTEGRITY_SYNC,
+        DATA_INTEGRITY_SYNC,
+        REQUESTED_WRITE_SYNC,
+        MUTATE_DIRECTORY,
+    }
+
+    enum DescriptorType [<=>] latest::filesystem::types::DescriptorType {
+        Unknown,
+        BlockDevice,
+        CharacterDevice,
+        Directory,
+        Fifo,
+        SymbolicLink,
+        RegularFile,
+        Socket,
+    }
+
+    enum NewTimestamp => latest::filesystem::types::NewTimestamp {
+        NoChange,
+        Now,
+        Timestamp(e),
+    }
+
+    flags PathFlags => latest::filesystem::types::PathFlags {
+        SYMLINK_FOLLOW,
+    }
+
+    flags OpenFlags => latest::filesystem::types::OpenFlags {
+        CREATE,
+        DIRECTORY,
+        EXCLUSIVE,
+        TRUNCATE,
+    }
+
+    struct latest::filesystem::types::MetadataHashValue => MetadataHashValue {
+        lower,
+        upper,
+    }
+
+    struct latest::filesystem::types::DirectoryEntry => DirectoryEntry {
+        type_,
+        name,
+    }
+
+    enum latest::sockets::network::ErrorCode => SocketErrorCode {
+        Unknown,
+        AccessDenied,
+        NotSupported,
+        InvalidArgument,
+        OutOfMemory,
+        Timeout,
+        ConcurrencyConflict,
+        NotInProgress,
+        WouldBlock,
+        InvalidState,
+        NewSocketLimit,
+        AddressNotBindable,
+        AddressInUse,
+        RemoteUnreachable,
+        ConnectionRefused,
+        ConnectionReset,
+        ConnectionAborted,
+        DatagramTooLarge,
+        NameUnresolvable,
+        TemporaryResolverFailure,
+        PermanentResolverFailure,
+    }
+
+    enum latest::sockets::network::IpAddress [<=>] IpAddress {
+        Ipv4(e),
+        Ipv6(e),
+    }
+
+    enum latest::sockets::network::IpSocketAddress [<=>] IpSocketAddress {
+        Ipv4(e),
+        Ipv6(e),
+    }
+
+    struct latest::sockets::network::Ipv4SocketAddress [<=>] Ipv4SocketAddress {
+        port,
+        address,
+    }
+
+    struct latest::sockets::network::Ipv6SocketAddress [<=>] Ipv6SocketAddress {
+        port,
+        flow_info,
+        scope_id,
+        address,
+    }
+
+    enum latest::sockets::network::IpAddressFamily [<=>] IpAddressFamily {
+        Ipv4,
+        Ipv6,
+    }
+
+    enum ShutdownType => latest::sockets::tcp::ShutdownType {
+        Receive,
+        Send,
+        Both,
+    }
+
+    struct latest::sockets::udp::IncomingDatagram => Datagram {
+        data,
+        remote_address,
+    }
+
+    enum latest::http::types::Method [<=>] Method {
+        Get,
+        Head,
+        Post,
+        Put,
+        Delete,
+        Connect,
+        Options,
+        Trace,
+        Patch,
+        Other(e),
+    }
+
+    enum latest::http::types::Scheme [<=>] Scheme {
+        Http,
+        Https,
+        Other(e),
+    }
+}
+
+impl From<latest::filesystem::types::DescriptorStat> for DescriptorStat {
+    fn from(e: latest::filesystem::types::DescriptorStat) -> DescriptorStat {
+        DescriptorStat {
+            type_: e.type_.into(),
+            link_count: e.link_count,
+            size: e.size,
+            data_access_timestamp: e.data_access_timestamp.map(|e| e.into()),
+            data_modification_timestamp: e.data_modification_timestamp.map(|e| e.into()),
+            status_change_timestamp: e.status_change_timestamp.map(|e| e.into()),
+        }
+    }
+}
+
+impl From<latest::http::types::ErrorCode> for HttpError {
+    fn from(e: latest::http::types::ErrorCode) -> HttpError {
+        // TODO: should probably categorize this better given the typed info
+        // we have in `e`.
+        HttpError::UnexpectedError(e.to_string())
+    }
+}

--- a/crates/core/tests/core-wasi-test/wit/multiplier.wit
+++ b/crates/core/tests/core-wasi-test/wit/multiplier.wit
@@ -1,7 +1,7 @@
-package test:test
+package test:test;
 
 world multiplier {
   import imports: interface {
-     multiply: func(n: s32) -> s32
+     multiply: func(n: s32) -> s32;
   }
 }

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -181,6 +181,9 @@ fn test_engine() -> Engine<()> {
     builder
         .link_import(|l, _| wasmtime_wasi::preview2::command::add_to_linker(l))
         .unwrap();
+    builder
+        .link_import(|l, _| spin_core::wasi_2023_10_18::add_to_linker(l))
+        .unwrap();
     builder.build()
 }
 

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use clap::Args;
 use http::{uri::Scheme, StatusCode, Uri};
@@ -301,8 +301,10 @@ impl HttpTrigger {
                         async move {
                             self_
                                 .handle(
-                                    request
-                                        .map(|body: Incoming| body.map_err(|e| anyhow!(e)).boxed()),
+                                    request.map(|body: Incoming| {
+                                        body.map_err(wasmtime_wasi_http::hyper_response_error)
+                                            .boxed()
+                                    }),
                                     Scheme::HTTP,
                                     addr,
                                 )

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -48,6 +48,7 @@ url = "2"
 spin-componentize = { workspace = true }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 
 [dev-dependencies]

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -111,7 +111,12 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
             let mut builder = Engine::builder(&self.config)?;
 
             if !self.disable_default_host_components {
+                // Wasmtime 15: WASI@0.2.0-rc-2023-11-10
                 builder.link_import(|l, _| wasmtime_wasi_http::proxy::add_to_linker(l))?;
+
+                // Wasmtime 14: WASI@0.2.0-rc-2023-10-18
+                builder.link_import(|l, _| spin_core::wasi_2023_10_18::add_to_linker(l))?;
+
                 self.loader.add_dynamic_host_component(
                     &mut builder,
                     outbound_redis::OutboundRedisComponent,

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -2,10 +2,10 @@
 
 wasmtime::component::bindgen!({
     inline: r#"
-    package fermyon:runtime
+    package fermyon:runtime;
     world host {
-        include fermyon:spin/host
-        include fermyon:spin/platform@2.0.0
+        include fermyon:spin/host;
+        include fermyon:spin/platform@2.0.0;
     }
     "#,
     path: "../../wit",

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "6ffc30dee200c20b4dcb80572226f42658e1d9c4b668656d7cc59c33d50e396e"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "smallvec",
 ]
 
@@ -390,7 +390,7 @@ dependencies = [
  "io-lifetimes 2.0.2",
  "ipnet",
  "maybe-owned",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
  "winx",
 ]
@@ -414,7 +414,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes 2.0.2",
- "rustix 0.38.19",
+ "rustix 0.38.25",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ checksum = "f8f52b3c8f4abfe3252fd0a071f3004aaa3b18936ec97bdbd8763ce03aff6247"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "winx",
 ]
 
@@ -600,16 +600,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eb38f2af690b5a4411d9a8782b6d77dabff3ca939e0518453ab9f9a4392d41"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39526c036b92912417e8931f52c1e235796688068d3efdbbd8b164f299d19156"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -628,29 +630,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb0deedc9fccf2db53a5a3c9c9d0163e44143b0d004dca9bf6ab6a0024cd79a"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea2d1b274e45aa8e61e9103efa1ba82d4b5a19d12bd1fd10744c3b7380ba3ff"
 
 [[package]]
 name = "cranelift-control"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea5977559a71e63db79a263f0e81a89b996e8a38212c4281e37dd1dbaa8b65c"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f871ada808b58158d84dfc43a6a2e2d2756baaf4ed1c51fd969ca8330e6ca5c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -658,8 +664,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e6890f587ef59824b3debe577e68fdf9b307b3808c54b8d93a18fd0b70941b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -669,13 +676,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d5fc6d5d3b52d1917002b17a8ecce448c2621b5bf394bb4e77e2f676893537"
 
 [[package]]
 name = "cranelift-native"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e10c2e7faa65d4ae7de9a83b44f2c31aca7dc638e17d0a79572fdf8103d720b"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -684,8 +693,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.101.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2755807efc7ec80d1cc0b6815e70f10cedf968889f0469091dbff9c5c0741c48"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -693,7 +703,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-types",
 ]
 
@@ -1095,7 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -1164,7 +1174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd738b84894214045e8414eaded76359b4a5773f0a0a56b16575110739cdcf39"
 dependencies = [
  "io-lifetimes 2.0.2",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -1791,9 +1801,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "ittapi"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e0d0b7b3b53d92a7e8b80ede3400112a6b8b4c98d1f5b8b16bb787c780582c"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -1802,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8763c96e54e6d6a0dccc2990d8b5e33e3313aaeae6185921a3f4c1614a77c"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]
@@ -1920,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -1973,9 +1983,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "llm"
@@ -2162,7 +2172,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.19",
+ "rustix 0.38.25",
 ]
 
 [[package]]
@@ -3253,15 +3263,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.19"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "itoa",
  "libc",
- "linux-raw-sys 0.4.10",
+ "linux-raw-sys 0.4.11",
  "once_cell",
  "windows-sys 0.48.0",
 ]
@@ -3619,10 +3629,10 @@ version = "0.1.0"
 source = "git+https://github.com/fermyon/spin-componentize?rev=191789170abde10cd55590466c0660dd6c7d472a#191789170abde10cd55590466c0660dd6c7d472a"
 dependencies = [
  "anyhow",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.12.1",
 ]
 
 [[package]]
@@ -3892,6 +3902,7 @@ dependencies = [
  "tracing",
  "url",
  "wasmtime",
+ "wasmtime-wasi",
  "wasmtime-wasi-http",
 ]
 
@@ -4076,7 +4087,7 @@ dependencies = [
  "cap-std",
  "fd-lock",
  "io-lifetimes 2.0.2",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
  "winx",
 ]
@@ -4104,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tempfile"
@@ -4117,7 +4128,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall 0.3.5",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -4667,8 +4678,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3542b8d238a3de6c9986218af842f1e8f950ca7c4707aee9d0dd83002577a759"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4680,7 +4692,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes 2.0.2",
  "once_cell",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -4689,8 +4701,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a362c9dbdc5eb0809ce9db09e7b76805fea3ddaf2b8ff41a0e5c805935736205"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4698,7 +4711,7 @@ dependencies = [
  "cap-std",
  "io-extras",
  "log",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -4708,14 +4721,15 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385503c0e4502dc5cbd7fdfe25f2d87a5dd19dd1cdd7e3bc5184146713bba554"
 dependencies = [
  "anyhow",
  "cap-std",
  "io-extras",
  "io-lifetimes 2.0.2",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "tokio",
  "wasi-cap-std-sync",
  "wasi-common",
@@ -4798,6 +4812,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b09bc5df933a3dabbdb72ae4b6b71be8ae07f58774d5aa41bd20adcd41a235a"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4809,8 +4841,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
 ]
 
 [[package]]
@@ -4837,19 +4869,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.2.70"
+name = "wasmparser"
+version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74458a9bc5cc9c7108abfa0fe4dc88d5abf1f3baf194df3264985f17d559b5e"
+checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
+dependencies = [
+ "indexmap 2.0.2",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.118.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebbb91574de0011ded32b14db12777e7dd5e9ea2f9d7317a1ab51a9495c75924"
+dependencies = [
+ "indexmap 2.0.2",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a7a046e6636d25c06a5df00bdc34e02f9e6e0e8a356d738299b961a6126114"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.118.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4b1702ef55144d6f594085f4989dc71fb71a791be1c8354ecc8e489b81199b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4870,8 +4923,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.36.2",
+ "wasmparser 0.116.1",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -4887,23 +4940,25 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c981d0e87bb3e98e08e76644e7ae5dfdef7f1d4105145853f3d677bb4535d65f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7ba8adaa84fdb9dd659275edcf7fc5282c44b9c9f829986c71d44fd52ea80a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
  "bincode",
  "directories-next",
  "log",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "serde",
  "serde_derive",
  "sha2",
@@ -4914,8 +4969,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91dcbbd0e1f094351d1ae0e53463c63ba53ec8f8e0e21d17567c1979a8c3758"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4923,18 +4979,20 @@ dependencies = [
  "syn 2.0.38",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.13.0",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e85f1319a7ed36aa59446ab7e967d0c2fb0cd179bf56913633190b44572023e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1453665878e16245b9a25405e550c4a36c6731c6e34ea804edc002a38c3e6741"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4949,7 +5007,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
@@ -4957,8 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dface3d9b72b4670781ff72675eabb291e2836b5dded6bb312b577d2bb561f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4972,8 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0116108e7d231cce15fe7dd642c66c3abb14dbcf169b0130e11f223ce8d1ad7"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -4985,8 +5045,8 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.36.2",
+ "wasmparser 0.116.1",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -4994,12 +5054,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a5896355c37bf0f9feb4f1299142ef4bed8c92576aa3a41d150fed0cafa056"
 dependencies = [
+ "anyhow",
  "cc",
  "cfg-if",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.48.0",
@@ -5007,8 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32b210767452f6b20157bb7c7d98295b92cc47aaad2a8aa31652f4469813a5d"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5020,7 +5083,7 @@ dependencies = [
  "log",
  "object",
  "rustc-demangle",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "serde",
  "serde_derive",
  "target-lexicon",
@@ -5033,19 +5096,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffd2785a16c55ac77565613ebda625f5850d4014af0499df750e8de97c04547"
 dependencies = [
  "object",
  "once_cell",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73ad1395eda136baec5ece7e079e0536a82ef73488e345456cc9b89858ad0ec"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5054,8 +5119,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b50f7f3c1a8dabb2607f32a81242917bd77cee75f3dec66e04b02ccbb8ba07"
 dependencies = [
  "anyhow",
  "cc",
@@ -5069,9 +5135,9 @@ dependencies = [
  "memoffset",
  "paste",
  "rand 0.8.5",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "sptr",
- "wasm-encoder",
+ "wasm-encoder 0.36.2",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -5083,20 +5149,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447973db3dc5c24db14130ab0922795c58790aec296d198ad9d253b82ec67471"
 dependencies = [
  "cranelift-entity",
  "serde",
  "serde_derive",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a347bb8ecf12275fb180afb1b1c85c9e186553c43109737bffed4f54c2aa365"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5105,8 +5173,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f94342fc932695027cdfa0500a62a680879bdad495b36490887b1564124e53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5124,7 +5193,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "rustix 0.38.19",
+ "rustix 0.38.25",
  "system-interface",
  "thiserror",
  "tokio",
@@ -5140,8 +5209,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531b30bd168aa46cca77a678daaab99ed9bda5e70750aa6f638f3b05188d2047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5162,15 +5232,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8c602f026526d754c33b750f67d754234c6ec29595865916693c3306ca6a3b"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -5178,19 +5249,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41786c7bbbf250c0e685b291323b50c6bb65f0505a2c0b4f0b598c740f13f185"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.0.2",
- "wit-parser",
+ "wit-parser 0.13.0",
 ]
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47907bdd67500c66fa308acbce7387c7bfb63b5505ef81be7fc897709afcca60"
 
 [[package]]
 name = "wast"
@@ -5203,23 +5276,23 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "66.0.2"
+version = "69.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cb43b0ac6dd156f2c375735ccfd72b012a7c0a6e6d09503499b8d3cb6e6072"
+checksum = "efa51b5ad1391943d1bfad537e50f28fe938199ee76b115be6bae83802cd5185"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.38.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.77"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e367582095d2903caeeea9acbb140e1db9c7677001efa4347c3687fd34fe7072"
+checksum = "74a4c2488d058326466e086a43f5d4ea448241a8d0975e3eb0642c0828be1eb3"
 dependencies = [
- "wast 66.0.2",
+ "wast 69.0.0",
 ]
 
 [[package]]
@@ -5250,8 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b5a36af7e0a7d68fd6c080e78803b34c3105caa3f743dff2fc8db2fac4ab71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5264,8 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f5a763e4801e83c438e7fa6abdd5c38d735194c2a94e2f2ccdcc66456cefee"
 dependencies = [
  "anyhow",
  "heck",
@@ -5278,8 +5353,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "14.0.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58262f5ac3a8ea686d4b940aa9f976f26c7e4e980aa8ac378f29274cb8638e33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5320,8 +5396,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.12.4"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9057ea325cac1ec02b28418da975a9f3a3634611812dc6150401347f1774844e"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5329,7 +5406,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.116.1",
  "wasmtime-environ",
 ]
 
@@ -5522,10 +5599,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.35.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.115.0",
+ "wit-parser 0.12.1",
 ]
 
 [[package]]
@@ -5546,9 +5623,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.0.2",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+]
+
+[[package]]
 name = "witx"
 version = "0.9.1"
-source = "git+https://github.com/fermyon/wasmtime?rev=a2fa8fe7de1e918eae06d78de53451832ba380b6#a2fa8fe7de1e918eae06d78de53451832ba380b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
 dependencies = [
  "anyhow",
  "log",

--- a/examples/spin-timer/Cargo.toml
+++ b/examples/spin-timer/Cargo.toml
@@ -14,9 +14,6 @@ spin-core = { path = "../../crates/core" }
 spin-trigger = { path = "../../crates/trigger" }
 tokio = { version = "1.11", features = ["full"] }
 tokio-scoped = "0.2.0"
-
-# Use forked wasmtime 14.0.4 with backported patches to fix a performance regression
-# TODO: Replace with wasmtime 15 release.
-wasmtime = { git = "https://github.com/fermyon/wasmtime", rev = "a2fa8fe7de1e918eae06d78de53451832ba380b6" , features = ["component-model"] }
+wasmtime = { version = "15.0.0", features = ["component-model"] }
 
 [workspace]

--- a/examples/spin-timer/deps/spin/variables.wit
+++ b/examples/spin-timer/deps/spin/variables.wit
@@ -1,10 +1,10 @@
-package fermyon:spin@2.0.0
+package fermyon:spin@2.0.0;
 
 interface variables {
     /// Get an application variable value for the current component.
     ///
     /// The name must match one defined in in the component manifest.
-    get: func(name: string) -> result<string, error>
+    get: func(name: string) -> result<string, error>;
 
     /// The set of errors which may be raised by functions in this interface.
     variant error {

--- a/examples/spin-timer/spin-timer.wit
+++ b/examples/spin-timer/spin-timer.wit
@@ -1,6 +1,6 @@
-package fermyon:example
+package fermyon:example;
 
 world spin-timer {
-  import fermyon:spin/variables@2.0.0
-  export handle-timer-request: func()
+  import fermyon:spin/variables@2.0.0;
+  export handle-timer-request: func();
 }

--- a/wit/deps/cli/command.wit
+++ b/wit/deps/cli/command.wit
@@ -1,0 +1,7 @@
+package wasi:cli@0.2.0-rc-2023-10-18;
+
+world command {
+  include reactor;
+
+  export run;
+}

--- a/wit/deps/cli/environment.wit
+++ b/wit/deps/cli/environment.wit
@@ -1,0 +1,18 @@
+interface environment {
+  /// Get the POSIX-style environment variables.
+  ///
+  /// Each environment variable is provided as a pair of string variable names
+  /// and string value.
+  ///
+  /// Morally, these are a value import, but until value imports are available
+  /// in the component model, this import function should return the same
+  /// values each time it is called.
+  get-environment: func() -> list<tuple<string, string>>;
+
+  /// Get the POSIX-style arguments to the program.
+  get-arguments: func() -> list<string>;
+
+  /// Return a path that programs should use as their initial current working
+  /// directory, interpreting `.` as shorthand for this.
+  initial-cwd: func() -> option<string>;
+}

--- a/wit/deps/cli/exit.wit
+++ b/wit/deps/cli/exit.wit
@@ -1,0 +1,4 @@
+interface exit {
+  /// Exit the current instance and any linked instances.
+  exit: func(status: result);
+}

--- a/wit/deps/cli/reactor.wit
+++ b/wit/deps/cli/reactor.wit
@@ -1,0 +1,32 @@
+package wasi:cli@0.2.0-rc-2023-10-18;
+
+world reactor {
+  import wasi:clocks/wall-clock@0.2.0-rc-2023-10-18;
+  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-10-18;
+  import wasi:clocks/timezone@0.2.0-rc-2023-10-18;
+  import wasi:filesystem/types@0.2.0-rc-2023-10-18;
+  import wasi:filesystem/preopens@0.2.0-rc-2023-10-18;
+  import wasi:sockets/instance-network@0.2.0-rc-2023-10-18;
+  import wasi:sockets/ip-name-lookup@0.2.0-rc-2023-10-18;
+  import wasi:sockets/network@0.2.0-rc-2023-10-18;
+  import wasi:sockets/tcp-create-socket@0.2.0-rc-2023-10-18;
+  import wasi:sockets/tcp@0.2.0-rc-2023-10-18;
+  import wasi:sockets/udp-create-socket@0.2.0-rc-2023-10-18;
+  import wasi:sockets/udp@0.2.0-rc-2023-10-18;
+  import wasi:random/random@0.2.0-rc-2023-10-18;
+  import wasi:random/insecure@0.2.0-rc-2023-10-18;
+  import wasi:random/insecure-seed@0.2.0-rc-2023-10-18;
+  import wasi:io/poll@0.2.0-rc-2023-10-18;
+  import wasi:io/streams@0.2.0-rc-2023-10-18;
+
+  import environment;
+  import exit;
+  import stdin;
+  import stdout;
+  import stderr;
+  import terminal-input;
+  import terminal-output;
+  import terminal-stdin;
+  import terminal-stdout;
+  import terminal-stderr;
+}

--- a/wit/deps/cli/run.wit
+++ b/wit/deps/cli/run.wit
@@ -1,0 +1,4 @@
+interface run {
+  /// Run the program.
+  run: func() -> result;
+}

--- a/wit/deps/cli/stdio.wit
+++ b/wit/deps/cli/stdio.wit
@@ -1,0 +1,17 @@
+interface stdin {
+  use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream};
+
+  get-stdin: func() -> input-stream;
+}
+
+interface stdout {
+  use wasi:io/streams@0.2.0-rc-2023-10-18.{output-stream};
+
+  get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+  use wasi:io/streams@0.2.0-rc-2023-10-18.{output-stream};
+
+  get-stderr: func() -> output-stream;
+}

--- a/wit/deps/cli/terminal.wit
+++ b/wit/deps/cli/terminal.wit
@@ -1,0 +1,47 @@
+interface terminal-input {
+    /// The input side of a terminal.
+    resource terminal-input;
+
+    // In the future, this may include functions for disabling echoing,
+    // disabling input buffering so that keyboard events are sent through
+    // immediately, querying supported features, and so on.
+}
+
+interface terminal-output {
+    /// The output side of a terminal.
+    resource terminal-output;
+
+    // In the future, this may include functions for querying the terminal
+    // size, being notified of terminal size changes, querying supported
+    // features, and so on.
+}
+
+/// An interface providing an optional `terminal-input` for stdin as a
+/// link-time authority.
+interface terminal-stdin {
+    use terminal-input.{terminal-input};
+
+    /// If stdin is connected to a terminal, return a `terminal-input` handle
+    /// allowing further interaction with it.
+    get-terminal-stdin: func() -> option<terminal-input>;
+}
+
+/// An interface providing an optional `terminal-output` for stdout as a
+/// link-time authority.
+interface terminal-stdout {
+    use terminal-output.{terminal-output};
+
+    /// If stdout is connected to a terminal, return a `terminal-output` handle
+    /// allowing further interaction with it.
+    get-terminal-stdout: func() -> option<terminal-output>;
+}
+
+/// An interface providing an optional `terminal-output` for stderr as a
+/// link-time authority.
+interface terminal-stderr {
+    use terminal-output.{terminal-output};
+
+    /// If stderr is connected to a terminal, return a `terminal-output` handle
+    /// allowing further interaction with it.
+    get-terminal-stderr: func() -> option<terminal-output>;
+}

--- a/wit/deps/clocks/monotonic-clock.wit
+++ b/wit/deps/clocks/monotonic-clock.wit
@@ -1,0 +1,32 @@
+/// WASI Monotonic Clock is a clock API intended to let users measure elapsed
+/// time.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A monotonic clock is a clock which has an unspecified initial value, and
+/// successive reads of the clock will produce non-decreasing values.
+///
+/// It is intended for measuring elapsed time.
+interface monotonic-clock {
+    use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+
+    /// A timestamp in nanoseconds.
+    type instant = u64;
+
+    /// Read the current value of the clock.
+    ///
+    /// The clock is monotonic, therefore calling this function repeatedly will
+    /// produce a sequence of non-decreasing values.
+    now: func() -> instant;
+
+    /// Query the resolution of the clock.
+    resolution: func() -> instant;
+
+    /// Create a `pollable` which will resolve once the specified time has been
+    /// reached.
+    subscribe: func(
+        when: instant,
+        absolute: bool
+    ) -> pollable;
+}

--- a/wit/deps/clocks/timezone.wit
+++ b/wit/deps/clocks/timezone.wit
@@ -1,0 +1,48 @@
+interface timezone {
+    use wall-clock.{datetime};
+
+    /// Return information needed to display the given `datetime`. This includes
+    /// the UTC offset, the time zone name, and a flag indicating whether
+    /// daylight saving time is active.
+    ///
+    /// If the timezone cannot be determined for the given `datetime`, return a
+    /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
+    /// saving time.
+    display: func(when: datetime) -> timezone-display;
+
+    /// The same as `display`, but only return the UTC offset.
+    utc-offset: func(when: datetime) -> s32;
+
+    /// Information useful for displaying the timezone of a specific `datetime`.
+    ///
+    /// This information may vary within a single `timezone` to reflect daylight
+    /// saving time adjustments.
+    record timezone-display {
+        /// The number of seconds difference between UTC time and the local
+        /// time of the timezone.
+        ///
+        /// The returned value will always be less than 86400 which is the
+        /// number of seconds in a day (24*60*60).
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should return 0.
+        utc-offset: s32,
+
+        /// The abbreviated name of the timezone to display to a user. The name
+        /// `UTC` indicates Coordinated Universal Time. Otherwise, this should
+        /// reference local standards for the name of the time zone.
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should be the string `UTC`.
+        ///
+        /// In time zones that do not have an applicable name, a formatted
+        /// representation of the UTC offset may be returned, such as `-04:00`.
+        name: string,
+
+        /// Whether daylight saving time is active.
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should return false.
+        in-daylight-saving-time: bool,
+    }
+}

--- a/wit/deps/clocks/wall-clock.wit
+++ b/wit/deps/clocks/wall-clock.wit
@@ -1,0 +1,41 @@
+/// WASI Wall Clock is a clock API intended to let users query the current
+/// time. The name "wall" makes an analogy to a "clock on the wall", which
+/// is not necessarily monotonic as it may be reset.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A wall clock is a clock which measures the date and time according to
+/// some external reference.
+///
+/// External references may be reset, so this clock is not necessarily
+/// monotonic, making it unsuitable for measuring elapsed time.
+///
+/// It is intended for reporting the current date and time for humans.
+interface wall-clock {
+    /// A time and date in seconds plus nanoseconds.
+    record datetime {
+        seconds: u64,
+        nanoseconds: u32,
+    }
+
+    /// Read the current value of the clock.
+    ///
+    /// This clock is not monotonic, therefore calling this function repeatedly
+    /// will not necessarily produce a sequence of non-decreasing values.
+    ///
+    /// The returned timestamps represent the number of seconds since
+    /// 1970-01-01T00:00:00Z, also known as [POSIX's Seconds Since the Epoch],
+    /// also known as [Unix Time].
+    ///
+    /// The nanoseconds field of the output is always less than 1000000000.
+    ///
+    /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
+    /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
+    now: func() -> datetime;
+
+    /// Query the resolution of the clock.
+    ///
+    /// The nanoseconds field of the output is always less than 1000000000.
+    resolution: func() -> datetime;
+}

--- a/wit/deps/clocks/world.wit
+++ b/wit/deps/clocks/world.wit
@@ -1,0 +1,7 @@
+package wasi:clocks@0.2.0-rc-2023-10-18;
+
+world imports {
+    import monotonic-clock;
+    import wall-clock;
+    import timezone;
+}

--- a/wit/deps/filesystem/preopens.wit
+++ b/wit/deps/filesystem/preopens.wit
@@ -1,0 +1,6 @@
+interface preopens {
+    use types.{descriptor};
+
+    /// Return the set of preopened directories, and their path.
+    get-directories: func() -> list<tuple<descriptor, string>>;
+}

--- a/wit/deps/filesystem/types.wit
+++ b/wit/deps/filesystem/types.wit
@@ -1,0 +1,810 @@
+/// WASI filesystem is a filesystem API primarily intended to let users run WASI
+/// programs that access their files on their existing filesystems, without
+/// significant overhead.
+///
+/// It is intended to be roughly portable between Unix-family platforms and
+/// Windows, though it does not hide many of the major differences.
+///
+/// Paths are passed as interface-type `string`s, meaning they must consist of
+/// a sequence of Unicode Scalar Values (USVs). Some filesystems may contain
+/// paths which are not accessible by this API.
+///
+/// The directory separator in WASI is always the forward-slash (`/`).
+///
+/// All paths in WASI are relative paths, and are interpreted relative to a
+/// `descriptor` referring to a base directory. If a `path` argument to any WASI
+/// function starts with `/`, or if any step of resolving a `path`, including
+/// `..` and symbolic link steps, reaches a directory outside of the base
+/// directory, or reaches a symlink to an absolute or rooted path in the
+/// underlying filesystem, the function fails with `error-code::not-permitted`.
+///
+/// For more information about WASI path resolution and sandboxing, see
+/// [WASI filesystem path resolution].
+///
+/// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
+interface types {
+    use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock@0.2.0-rc-2023-10-18.{datetime};
+
+    /// File size or length of a region within a file.
+    type filesize = u64;
+
+    /// The type of a filesystem object referenced by a descriptor.
+    ///
+    /// Note: This was called `filetype` in earlier versions of WASI.
+    enum descriptor-type {
+        /// The type of the descriptor or file is unknown or is different from
+        /// any of the other types specified.
+        unknown,
+        /// The descriptor refers to a block device inode.
+        block-device,
+        /// The descriptor refers to a character device inode.
+        character-device,
+        /// The descriptor refers to a directory inode.
+        directory,
+        /// The descriptor refers to a named pipe.
+        fifo,
+        /// The file refers to a symbolic link inode.
+        symbolic-link,
+        /// The descriptor refers to a regular file inode.
+        regular-file,
+        /// The descriptor refers to a socket.
+        socket,
+    }
+
+    /// Descriptor flags.
+    ///
+    /// Note: This was called `fdflags` in earlier versions of WASI.
+    flags descriptor-flags {
+        /// Read mode: Data can be read.
+        read,
+        /// Write mode: Data can be written to.
+        write,
+        /// Request that writes be performed according to synchronized I/O file
+        /// integrity completion. The data stored in the file and the file's
+        /// metadata are synchronized. This is similar to `O_SYNC` in POSIX.
+        ///
+        /// The precise semantics of this operation have not yet been defined for
+        /// WASI. At this time, it should be interpreted as a request, and not a
+        /// requirement.
+        file-integrity-sync,
+        /// Request that writes be performed according to synchronized I/O data
+        /// integrity completion. Only the data stored in the file is
+        /// synchronized. This is similar to `O_DSYNC` in POSIX.
+        ///
+        /// The precise semantics of this operation have not yet been defined for
+        /// WASI. At this time, it should be interpreted as a request, and not a
+        /// requirement.
+        data-integrity-sync,
+        /// Requests that reads be performed at the same level of integrety
+        /// requested for writes. This is similar to `O_RSYNC` in POSIX.
+        ///
+        /// The precise semantics of this operation have not yet been defined for
+        /// WASI. At this time, it should be interpreted as a request, and not a
+        /// requirement.
+        requested-write-sync,
+        /// Mutating directories mode: Directory contents may be mutated.
+        ///
+        /// When this flag is unset on a descriptor, operations using the
+        /// descriptor which would create, rename, delete, modify the data or
+        /// metadata of filesystem objects, or obtain another handle which
+        /// would permit any of those, shall fail with `error-code::read-only` if
+        /// they would otherwise succeed.
+        ///
+        /// This may only be set on directories.
+        mutate-directory,
+    }
+
+    /// File attributes.
+    ///
+    /// Note: This was called `filestat` in earlier versions of WASI.
+    record descriptor-stat {
+        /// File type.
+        %type: descriptor-type,
+        /// Number of hard links to the file.
+        link-count: link-count,
+        /// For regular files, the file size in bytes. For symbolic links, the
+        /// length in bytes of the pathname contained in the symbolic link.
+        size: filesize,
+        /// Last data access timestamp.
+        ///
+        /// If the `option` is none, the platform doesn't maintain an access
+        /// timestamp for this file.
+        data-access-timestamp: option<datetime>,
+        /// Last data modification timestamp.
+        ///
+        /// If the `option` is none, the platform doesn't maintain a
+        /// modification timestamp for this file.
+        data-modification-timestamp: option<datetime>,
+        /// Last file status-change timestamp.
+        ///
+        /// If the `option` is none, the platform doesn't maintain a
+        /// status-change timestamp for this file.
+        status-change-timestamp: option<datetime>,
+    }
+
+    /// Flags determining the method of how paths are resolved.
+    flags path-flags {
+        /// As long as the resolved path corresponds to a symbolic link, it is
+        /// expanded.
+        symlink-follow,
+    }
+
+    /// Open flags used by `open-at`.
+    flags open-flags {
+        /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
+        create,
+        /// Fail if not a directory, similar to `O_DIRECTORY` in POSIX.
+        directory,
+        /// Fail if file already exists, similar to `O_EXCL` in POSIX.
+        exclusive,
+        /// Truncate file to size 0, similar to `O_TRUNC` in POSIX.
+        truncate,
+    }
+
+    /// Permissions mode used by `open-at`, `change-file-permissions-at`, and
+    /// similar.
+    flags modes {
+        /// True if the resource is considered readable by the containing
+        /// filesystem.
+        readable,
+        /// True if the resource is considered writable by the containing
+        /// filesystem.
+        writable,
+        /// True if the resource is considered executable by the containing
+        /// filesystem. This does not apply to directories.
+        executable,
+    }
+
+    /// Access type used by `access-at`.
+    variant access-type {
+        /// Test for readability, writeability, or executability.
+        access(modes),
+
+        /// Test whether the path exists.
+        exists,
+    }
+
+    /// Number of hard links to an inode.
+    type link-count = u64;
+
+    /// When setting a timestamp, this gives the value to set it to.
+    variant new-timestamp {
+        /// Leave the timestamp set to its previous value.
+        no-change,
+        /// Set the timestamp to the current time of the system clock associated
+        /// with the filesystem.
+        now,
+        /// Set the timestamp to the given value.
+        timestamp(datetime),
+    }
+
+    /// A directory entry.
+    record directory-entry {
+        /// The type of the file referred to by this directory entry.
+        %type: descriptor-type,
+
+        /// The name of the object.
+        name: string,
+    }
+
+    /// Error codes returned by functions, similar to `errno` in POSIX.
+    /// Not all of these error codes are returned by the functions provided by this
+    /// API; some are used in higher-level library layers, and others are provided
+    /// merely for alignment with POSIX.
+    enum error-code {
+        /// Permission denied, similar to `EACCES` in POSIX.
+        access,
+        /// Resource unavailable, or operation would block, similar to `EAGAIN` and `EWOULDBLOCK` in POSIX.
+        would-block,
+        /// Connection already in progress, similar to `EALREADY` in POSIX.
+        already,
+        /// Bad descriptor, similar to `EBADF` in POSIX.
+        bad-descriptor,
+        /// Device or resource busy, similar to `EBUSY` in POSIX.
+        busy,
+        /// Resource deadlock would occur, similar to `EDEADLK` in POSIX.
+        deadlock,
+        /// Storage quota exceeded, similar to `EDQUOT` in POSIX.
+        quota,
+        /// File exists, similar to `EEXIST` in POSIX.
+        exist,
+        /// File too large, similar to `EFBIG` in POSIX.
+        file-too-large,
+        /// Illegal byte sequence, similar to `EILSEQ` in POSIX.
+        illegal-byte-sequence,
+        /// Operation in progress, similar to `EINPROGRESS` in POSIX.
+        in-progress,
+        /// Interrupted function, similar to `EINTR` in POSIX.
+        interrupted,
+        /// Invalid argument, similar to `EINVAL` in POSIX.
+        invalid,
+        /// I/O error, similar to `EIO` in POSIX.
+        io,
+        /// Is a directory, similar to `EISDIR` in POSIX.
+        is-directory,
+        /// Too many levels of symbolic links, similar to `ELOOP` in POSIX.
+        loop,
+        /// Too many links, similar to `EMLINK` in POSIX.
+        too-many-links,
+        /// Message too large, similar to `EMSGSIZE` in POSIX.
+        message-size,
+        /// Filename too long, similar to `ENAMETOOLONG` in POSIX.
+        name-too-long,
+        /// No such device, similar to `ENODEV` in POSIX.
+        no-device,
+        /// No such file or directory, similar to `ENOENT` in POSIX.
+        no-entry,
+        /// No locks available, similar to `ENOLCK` in POSIX.
+        no-lock,
+        /// Not enough space, similar to `ENOMEM` in POSIX.
+        insufficient-memory,
+        /// No space left on device, similar to `ENOSPC` in POSIX.
+        insufficient-space,
+        /// Not a directory or a symbolic link to a directory, similar to `ENOTDIR` in POSIX.
+        not-directory,
+        /// Directory not empty, similar to `ENOTEMPTY` in POSIX.
+        not-empty,
+        /// State not recoverable, similar to `ENOTRECOVERABLE` in POSIX.
+        not-recoverable,
+        /// Not supported, similar to `ENOTSUP` and `ENOSYS` in POSIX.
+        unsupported,
+        /// Inappropriate I/O control operation, similar to `ENOTTY` in POSIX.
+        no-tty,
+        /// No such device or address, similar to `ENXIO` in POSIX.
+        no-such-device,
+        /// Value too large to be stored in data type, similar to `EOVERFLOW` in POSIX.
+        overflow,
+        /// Operation not permitted, similar to `EPERM` in POSIX.
+        not-permitted,
+        /// Broken pipe, similar to `EPIPE` in POSIX.
+        pipe,
+        /// Read-only file system, similar to `EROFS` in POSIX.
+        read-only,
+        /// Invalid seek, similar to `ESPIPE` in POSIX.
+        invalid-seek,
+        /// Text file busy, similar to `ETXTBSY` in POSIX.
+        text-file-busy,
+        /// Cross-device link, similar to `EXDEV` in POSIX.
+        cross-device,
+    }
+
+    /// File or memory access pattern advisory information.
+    enum advice {
+        /// The application has no advice to give on its behavior with respect
+        /// to the specified data.
+        normal,
+        /// The application expects to access the specified data sequentially
+        /// from lower offsets to higher offsets.
+        sequential,
+        /// The application expects to access the specified data in a random
+        /// order.
+        random,
+        /// The application expects to access the specified data in the near
+        /// future.
+        will-need,
+        /// The application expects that it will not access the specified data
+        /// in the near future.
+        dont-need,
+        /// The application expects to access the specified data once and then
+        /// not reuse it thereafter.
+        no-reuse,
+    }
+
+    /// A 128-bit hash value, split into parts because wasm doesn't have a
+    /// 128-bit integer type.
+    record metadata-hash-value {
+       /// 64 bits of a 128-bit hash value.
+       lower: u64,
+       /// Another 64 bits of a 128-bit hash value.
+       upper: u64,
+    }
+
+    /// A descriptor is a reference to a filesystem object, which may be a file,
+    /// directory, named pipe, special file, or other object on which filesystem
+    /// calls may be made.
+    resource descriptor {
+        /// Return a stream for reading from a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be read.
+        ///
+        /// Multiple read, write, and append streams may be active on the same open
+        /// file and they do not interfere with each other.
+        ///
+        /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+        read-via-stream: func(
+            /// The offset within the file at which to start reading.
+            offset: filesize,
+        ) -> result<input-stream, error-code>;
+
+        /// Return a stream for writing to a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be written.
+        ///
+        /// Note: This allows using `write-stream`, which is similar to `write` in
+        /// POSIX.
+        write-via-stream: func(
+            /// The offset within the file at which to start writing.
+            offset: filesize,
+        ) -> result<output-stream, error-code>;
+
+        /// Return a stream for appending to a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be appended.
+        ///
+        /// Note: This allows using `write-stream`, which is similar to `write` with
+        /// `O_APPEND` in in POSIX.
+        append-via-stream: func() -> result<output-stream, error-code>;
+
+        /// Provide file advisory information on a descriptor.
+        ///
+        /// This is similar to `posix_fadvise` in POSIX.
+        advise: func(
+            /// The offset within the file to which the advisory applies.
+            offset: filesize,
+            /// The length of the region to which the advisory applies.
+            length: filesize,
+            /// The advice.
+            advice: advice
+        ) -> result<_, error-code>;
+
+        /// Synchronize the data of a file to disk.
+        ///
+        /// This function succeeds with no effect if the file descriptor is not
+        /// opened for writing.
+        ///
+        /// Note: This is similar to `fdatasync` in POSIX.
+        sync-data: func() -> result<_, error-code>;
+
+        /// Get flags associated with a descriptor.
+        ///
+        /// Note: This returns similar flags to `fcntl(fd, F_GETFL)` in POSIX.
+        ///
+        /// Note: This returns the value that was the `fs_flags` value returned
+        /// from `fdstat_get` in earlier versions of WASI.
+        get-flags: func() -> result<descriptor-flags, error-code>;
+
+        /// Get the dynamic type of a descriptor.
+        ///
+        /// Note: This returns the same value as the `type` field of the `fd-stat`
+        /// returned by `stat`, `stat-at` and similar.
+        ///
+        /// Note: This returns similar flags to the `st_mode & S_IFMT` value provided
+        /// by `fstat` in POSIX.
+        ///
+        /// Note: This returns the value that was the `fs_filetype` value returned
+        /// from `fdstat_get` in earlier versions of WASI.
+        get-type: func() -> result<descriptor-type, error-code>;
+
+        /// Adjust the size of an open file. If this increases the file's size, the
+        /// extra bytes are filled with zeros.
+        ///
+        /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
+        set-size: func(size: filesize) -> result<_, error-code>;
+
+        /// Adjust the timestamps of an open file or directory.
+        ///
+        /// Note: This is similar to `futimens` in POSIX.
+        ///
+        /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
+        set-times: func(
+            /// The desired values of the data access timestamp.
+            data-access-timestamp: new-timestamp,
+            /// The desired values of the data modification timestamp.
+            data-modification-timestamp: new-timestamp,
+        ) -> result<_, error-code>;
+
+        /// Read from a descriptor, without using and updating the descriptor's offset.
+        ///
+        /// This function returns a list of bytes containing the data that was
+        /// read, along with a bool which, when true, indicates that the end of the
+        /// file was reached. The returned list will contain up to `length` bytes; it
+        /// may return fewer than requested, if the end of the file is reached or
+        /// if the I/O operation is interrupted.
+        ///
+        /// In the future, this may change to return a `stream<u8, error-code>`.
+        ///
+        /// Note: This is similar to `pread` in POSIX.
+        read: func(
+            /// The maximum number of bytes to read.
+            length: filesize,
+            /// The offset within the file at which to read.
+            offset: filesize,
+        ) -> result<tuple<list<u8>, bool>, error-code>;
+
+        /// Write to a descriptor, without using and updating the descriptor's offset.
+        ///
+        /// It is valid to write past the end of a file; the file is extended to the
+        /// extent of the write, with bytes between the previous end and the start of
+        /// the write set to zero.
+        ///
+        /// In the future, this may change to take a `stream<u8, error-code>`.
+        ///
+        /// Note: This is similar to `pwrite` in POSIX.
+        write: func(
+            /// Data to write
+            buffer: list<u8>,
+            /// The offset within the file at which to write.
+            offset: filesize,
+        ) -> result<filesize, error-code>;
+
+        /// Read directory entries from a directory.
+        ///
+        /// On filesystems where directories contain entries referring to themselves
+        /// and their parents, often named `.` and `..` respectively, these entries
+        /// are omitted.
+        ///
+        /// This always returns a new stream which starts at the beginning of the
+        /// directory. Multiple streams may be active on the same directory, and they
+        /// do not interfere with each other.
+        read-directory: func() -> result<directory-entry-stream, error-code>;
+
+        /// Synchronize the data and metadata of a file to disk.
+        ///
+        /// This function succeeds with no effect if the file descriptor is not
+        /// opened for writing.
+        ///
+        /// Note: This is similar to `fsync` in POSIX.
+        sync: func() -> result<_, error-code>;
+
+        /// Create a directory.
+        ///
+        /// Note: This is similar to `mkdirat` in POSIX.
+        create-directory-at: func(
+            /// The relative path at which to create the directory.
+            path: string,
+        ) -> result<_, error-code>;
+
+        /// Return the attributes of an open file or directory.
+        ///
+        /// Note: This is similar to `fstat` in POSIX, except that it does not return
+        /// device and inode information. For testing whether two descriptors refer to
+        /// the same underlying filesystem object, use `is-same-object`. To obtain
+        /// additional data that can be used do determine whether a file has been
+        /// modified, use `metadata-hash`.
+        ///
+        /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
+        stat: func() -> result<descriptor-stat, error-code>;
+
+        /// Return the attributes of a file or directory.
+        ///
+        /// Note: This is similar to `fstatat` in POSIX, except that it does not
+        /// return device and inode information. See the `stat` description for a
+        /// discussion of alternatives.
+        ///
+        /// Note: This was called `path_filestat_get` in earlier versions of WASI.
+        stat-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the file or directory to inspect.
+            path: string,
+        ) -> result<descriptor-stat, error-code>;
+
+        /// Adjust the timestamps of a file or directory.
+        ///
+        /// Note: This is similar to `utimensat` in POSIX.
+        ///
+        /// Note: This was called `path_filestat_set_times` in earlier versions of
+        /// WASI.
+        set-times-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the file or directory to operate on.
+            path: string,
+            /// The desired values of the data access timestamp.
+            data-access-timestamp: new-timestamp,
+            /// The desired values of the data modification timestamp.
+            data-modification-timestamp: new-timestamp,
+        ) -> result<_, error-code>;
+
+        /// Create a hard link.
+        ///
+        /// Note: This is similar to `linkat` in POSIX.
+        link-at: func(
+            /// Flags determining the method of how the path is resolved.
+            old-path-flags: path-flags,
+            /// The relative source path from which to link.
+            old-path: string,
+            /// The base directory for `new-path`.
+            new-descriptor: borrow<descriptor>,
+            /// The relative destination path at which to create the hard link.
+            new-path: string,
+        ) -> result<_, error-code>;
+
+        /// Open a file or directory.
+        ///
+        /// The returned descriptor is not guaranteed to be the lowest-numbered
+        /// descriptor not currently open/ it is randomized to prevent applications
+        /// from depending on making assumptions about indexes, since this is
+        /// error-prone in multi-threaded contexts. The returned descriptor is
+        /// guaranteed to be less than 2**31.
+        ///
+        /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
+        /// descriptor doesn't have `descriptor-flags::mutate-directory` set,
+        /// `open-at` fails with `error-code::read-only`.
+        ///
+        /// If `flags` contains `write` or `mutate-directory`, or `open-flags`
+        /// contains `truncate` or `create`, and the base descriptor doesn't have
+        /// `descriptor-flags::mutate-directory` set, `open-at` fails with
+        /// `error-code::read-only`.
+        ///
+        /// Note: This is similar to `openat` in POSIX.
+        open-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the object to open.
+            path: string,
+            /// The method by which to open the file.
+            open-flags: open-flags,
+            /// Flags to use for the resulting descriptor.
+            %flags: descriptor-flags,
+            /// Permissions to use when creating a new file.
+            modes: modes
+        ) -> result<descriptor, error-code>;
+
+        /// Read the contents of a symbolic link.
+        ///
+        /// If the contents contain an absolute or rooted path in the underlying
+        /// filesystem, this function fails with `error-code::not-permitted`.
+        ///
+        /// Note: This is similar to `readlinkat` in POSIX.
+        readlink-at: func(
+            /// The relative path of the symbolic link from which to read.
+            path: string,
+        ) -> result<string, error-code>;
+
+        /// Remove a directory.
+        ///
+        /// Return `error-code::not-empty` if the directory is not empty.
+        ///
+        /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+        remove-directory-at: func(
+            /// The relative path to a directory to remove.
+            path: string,
+        ) -> result<_, error-code>;
+
+        /// Rename a filesystem object.
+        ///
+        /// Note: This is similar to `renameat` in POSIX.
+        rename-at: func(
+            /// The relative source path of the file or directory to rename.
+            old-path: string,
+            /// The base directory for `new-path`.
+            new-descriptor: borrow<descriptor>,
+            /// The relative destination path to which to rename the file or directory.
+            new-path: string,
+        ) -> result<_, error-code>;
+
+        /// Create a symbolic link (also known as a "symlink").
+        ///
+        /// If `old-path` starts with `/`, the function fails with
+        /// `error-code::not-permitted`.
+        ///
+        /// Note: This is similar to `symlinkat` in POSIX.
+        symlink-at: func(
+            /// The contents of the symbolic link.
+            old-path: string,
+            /// The relative destination path at which to create the symbolic link.
+            new-path: string,
+        ) -> result<_, error-code>;
+
+        /// Check accessibility of a filesystem path.
+        ///
+        /// Check whether the given filesystem path names an object which is
+        /// readable, writable, or executable, or whether it exists.
+        ///
+        /// This does not a guarantee that subsequent accesses will succeed, as
+        /// filesystem permissions may be modified asynchronously by external
+        /// entities.
+        ///
+        /// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
+        access-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path to check.
+            path: string,
+            /// The type of check to perform.
+            %type: access-type
+        ) -> result<_, error-code>;
+
+        /// Unlink a filesystem object that is not a directory.
+        ///
+        /// Return `error-code::is-directory` if the path refers to a directory.
+        /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
+        unlink-file-at: func(
+            /// The relative path to a file to unlink.
+            path: string,
+        ) -> result<_, error-code>;
+
+        /// Change the permissions of a filesystem object that is not a directory.
+        ///
+        /// Note that the ultimate meanings of these permissions is
+        /// filesystem-specific.
+        ///
+        /// Note: This is similar to `fchmodat` in POSIX.
+        change-file-permissions-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path to operate on.
+            path: string,
+            /// The new permissions for the filesystem object.
+            modes: modes,
+        ) -> result<_, error-code>;
+
+        /// Change the permissions of a directory.
+        ///
+        /// Note that the ultimate meanings of these permissions is
+        /// filesystem-specific.
+        ///
+        /// Unlike in POSIX, the `executable` flag is not reinterpreted as a "search"
+        /// flag. `read` on a directory implies readability and searchability, and
+        /// `execute` is not valid for directories.
+        ///
+        /// Note: This is similar to `fchmodat` in POSIX.
+        change-directory-permissions-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path to operate on.
+            path: string,
+            /// The new permissions for the directory.
+            modes: modes,
+        ) -> result<_, error-code>;
+
+        /// Request a shared advisory lock for an open file.
+        ///
+        /// This requests a *shared* lock; more than one shared lock can be held for
+        /// a file at the same time.
+        ///
+        /// If the open file has an exclusive lock, this function downgrades the lock
+        /// to a shared lock. If it has a shared lock, this function has no effect.
+        ///
+        /// This requests an *advisory* lock, meaning that the file could be accessed
+        /// by other programs that don't hold the lock.
+        ///
+        /// It is unspecified how shared locks interact with locks acquired by
+        /// non-WASI programs.
+        ///
+        /// This function blocks until the lock can be acquired.
+        ///
+        /// Not all filesystems support locking; on filesystems which don't support
+        /// locking, this function returns `error-code::unsupported`.
+        ///
+        /// Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
+        lock-shared: func() -> result<_, error-code>;
+
+        /// Request an exclusive advisory lock for an open file.
+        ///
+        /// This requests an *exclusive* lock; no other locks may be held for the
+        /// file while an exclusive lock is held.
+        ///
+        /// If the open file has a shared lock and there are no exclusive locks held
+        /// for the file, this function upgrades the lock to an exclusive lock. If the
+        /// open file already has an exclusive lock, this function has no effect.
+        ///
+        /// This requests an *advisory* lock, meaning that the file could be accessed
+        /// by other programs that don't hold the lock.
+        ///
+        /// It is unspecified whether this function succeeds if the file descriptor
+        /// is not opened for writing. It is unspecified how exclusive locks interact
+        /// with locks acquired by non-WASI programs.
+        ///
+        /// This function blocks until the lock can be acquired.
+        ///
+        /// Not all filesystems support locking; on filesystems which don't support
+        /// locking, this function returns `error-code::unsupported`.
+        ///
+        /// Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
+        lock-exclusive: func() -> result<_, error-code>;
+
+        /// Request a shared advisory lock for an open file.
+        ///
+        /// This requests a *shared* lock; more than one shared lock can be held for
+        /// a file at the same time.
+        ///
+        /// If the open file has an exclusive lock, this function downgrades the lock
+        /// to a shared lock. If it has a shared lock, this function has no effect.
+        ///
+        /// This requests an *advisory* lock, meaning that the file could be accessed
+        /// by other programs that don't hold the lock.
+        ///
+        /// It is unspecified how shared locks interact with locks acquired by
+        /// non-WASI programs.
+        ///
+        /// This function returns `error-code::would-block` if the lock cannot be
+        /// acquired.
+        ///
+        /// Not all filesystems support locking; on filesystems which don't support
+        /// locking, this function returns `error-code::unsupported`.
+        ///
+        /// Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
+        try-lock-shared: func() -> result<_, error-code>;
+
+        /// Request an exclusive advisory lock for an open file.
+        ///
+        /// This requests an *exclusive* lock; no other locks may be held for the
+        /// file while an exclusive lock is held.
+        ///
+        /// If the open file has a shared lock and there are no exclusive locks held
+        /// for the file, this function upgrades the lock to an exclusive lock. If the
+        /// open file already has an exclusive lock, this function has no effect.
+        ///
+        /// This requests an *advisory* lock, meaning that the file could be accessed
+        /// by other programs that don't hold the lock.
+        ///
+        /// It is unspecified whether this function succeeds if the file descriptor
+        /// is not opened for writing. It is unspecified how exclusive locks interact
+        /// with locks acquired by non-WASI programs.
+        ///
+        /// This function returns `error-code::would-block` if the lock cannot be
+        /// acquired.
+        ///
+        /// Not all filesystems support locking; on filesystems which don't support
+        /// locking, this function returns `error-code::unsupported`.
+        ///
+        /// Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
+        try-lock-exclusive: func() -> result<_, error-code>;
+
+        /// Release a shared or exclusive lock on an open file.
+        ///
+        /// Note: This is similar to `flock(fd, LOCK_UN)` in Unix.
+        unlock: func() -> result<_, error-code>;
+
+        /// Test whether two descriptors refer to the same filesystem object.
+        ///
+        /// In POSIX, this corresponds to testing whether the two descriptors have the
+        /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
+        /// wasi-filesystem does not expose device and inode numbers, so this function
+        /// may be used instead.
+        is-same-object: func(other: borrow<descriptor>) -> bool;
+
+        /// Return a hash of the metadata associated with a filesystem object referred
+        /// to by a descriptor.
+        ///
+        /// This returns a hash of the last-modification timestamp and file size, and
+        /// may also include the inode number, device number, birth timestamp, and
+        /// other metadata fields that may change when the file is modified or
+        /// replaced. It may also include a secret value chosen by the
+        /// implementation and not otherwise exposed.
+        ///
+        /// Implementations are encourated to provide the following properties:
+        ///
+        ///  - If the file is not modified or replaced, the computed hash value should
+        ///    usually not change.
+        ///  - If the object is modified or replaced, the computed hash value should
+        ///    usually change.
+        ///  - The inputs to the hash should not be easily computable from the
+        ///    computed hash.
+        ///
+        /// However, none of these is required.
+        metadata-hash: func() -> result<metadata-hash-value, error-code>;
+
+        /// Return a hash of the metadata associated with a filesystem object referred
+        /// to by a directory descriptor and a relative path.
+        ///
+        /// This performs the same hash computation as `metadata-hash`.
+        metadata-hash-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the file or directory to inspect.
+            path: string,
+        ) -> result<metadata-hash-value, error-code>;
+    }
+
+    /// A stream of directory entries.
+    resource directory-entry-stream {
+        /// Read a single directory entry from a `directory-entry-stream`.
+        read-directory-entry: func() -> result<option<directory-entry>, error-code>;
+    }
+
+    /// Attempts to extract a filesystem-related `error-code` from the stream
+    /// `error` provided.
+    ///
+    /// Stream operations which return `stream-error::last-operation-failed`
+    /// have a payload with more information about the operation that failed.
+    /// This payload can be passed through to this function to see if there's
+    /// filesystem-related information about the error to return.
+    ///
+    /// Note that this function is fallible because not all stream-related
+    /// errors are filesystem-related errors.
+    filesystem-error-code: func(err: borrow<error>) -> option<error-code>;
+}

--- a/wit/deps/filesystem/world.wit
+++ b/wit/deps/filesystem/world.wit
@@ -1,0 +1,6 @@
+package wasi:filesystem@0.2.0-rc-2023-10-18;
+
+world imports {
+    import types;
+    import preopens;
+}

--- a/wit/deps/http/incoming-handler.wit
+++ b/wit/deps/http/incoming-handler.wit
@@ -7,7 +7,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface incoming-handler {
-  use types.{incoming-request, response-outparam}
+  use types.{incoming-request, response-outparam};
 
   // The `handle` function takes an outparam instead of returning its response
   // so that the component may stream its response while streaming any other
@@ -20,5 +20,5 @@ interface incoming-handler {
   handle: func(
     request: incoming-request,
     response-out: response-outparam
-  )
+  );
 }

--- a/wit/deps/http/outgoing-handler.wit
+++ b/wit/deps/http/outgoing-handler.wit
@@ -6,7 +6,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response, error}
+  use types.{outgoing-request, request-options, future-incoming-response, error};
 
   // The parameter and result types of the `handle` function allow the caller
   // to concurrently stream the bodies of the outgoing request and the incoming
@@ -16,5 +16,5 @@ interface outgoing-handler {
   handle: func(
     request: outgoing-request,
     options: option<request-options>
-  ) -> result<future-incoming-response, error>
+  ) -> result<future-incoming-response, error>;
 }

--- a/wit/deps/http/proxy.wit
+++ b/wit/deps/http/proxy.wit
@@ -1,0 +1,34 @@
+package wasi:http@0.2.0-rc-2023-10-18;
+
+// The `wasi:http/proxy` world captures a widely-implementable intersection of
+// hosts that includes HTTP forward and reverse proxies. Components targeting
+// this world may concurrently stream in and out any number of incoming and
+// outgoing HTTP requests.
+world proxy {
+  // HTTP proxies have access to time and randomness.
+  import wasi:clocks/wall-clock@0.2.0-rc-2023-10-18;
+  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-10-18;
+  import wasi:clocks/timezone@0.2.0-rc-2023-10-18;
+  import wasi:random/random@0.2.0-rc-2023-10-18;
+
+  // Proxies have standard output and error streams which are expected to
+  // terminate in a developer-facing console provided by the host.
+  import wasi:cli/stdout@0.2.0-rc-2023-10-18;
+  import wasi:cli/stderr@0.2.0-rc-2023-10-18;
+
+  // TODO: this is a temporary workaround until component tooling is able to
+  // gracefully handle the absence of stdin. Hosts must return an eof stream
+  // for this import, which is what wasi-libc + tooling will do automatically
+  // when this import is properly removed.
+  import wasi:cli/stdin@0.2.0-rc-2023-10-18;
+
+  // This is the default handler to use when user code simply wants to make an
+  // HTTP request (e.g., via `fetch()`).
+  import outgoing-handler;
+
+  // The host delivers incoming HTTP requests to a component by calling the
+  // `handle` function of this exported interface. A host may arbitrarily reuse
+  // or not reuse component instance when delivering incoming HTTP requests and
+  // thus a component must be able to handle 0..N calls to `handle`.
+  export incoming-handler;
+}

--- a/wit/deps/http/types.wit
+++ b/wit/deps/http/types.wit
@@ -2,10 +2,10 @@
 /// define the HTTP resource types and operations used by the component's
 /// imported and exported interfaces.
 interface types {
-  use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream}
-  use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable}
+  use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream};
+  use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
 
-  /// This type corresponds to HTTP standard Methods.
+  // This type corresponds to HTTP standard Methods.
   variant method {
     get,
     head,
@@ -41,28 +41,28 @@ interface types {
   resource fields {
     // Multiple values for a header are multiple entries in the list with the
     // same key.
-    constructor(entries: list<tuple<string,list<u8>>>)
+    constructor(entries: list<tuple<string,list<u8>>>);
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    get: func(name: string) -> list<list<u8>>
+    get: func(name: string) -> list<list<u8>>;
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    set: func(name: string, value: list<list<u8>>)
-    delete: func(name: string)
-    append: func(name: string, value: list<u8>)
+    set: func(name: string, value: list<list<u8>>);
+    delete: func(name: string);
+    append: func(name: string, value: list<u8>);
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    entries: func() -> list<tuple<string,list<u8>>>
+    entries: func() -> list<tuple<string,list<u8>>>;
 
     // Deep copy of all contents in a fields.
-    clone: func() -> fields
+    clone: func() -> fields;
   }
 
-  type headers = fields
-  type trailers = fields
+  type headers = fields;
+  type trailers = fields;
 
   /// The following block defines the `incoming-request` and `outgoing-request`
   /// resource types that correspond to HTTP standard Requests.
@@ -70,20 +70,20 @@ interface types {
   /// The `consume` and `write` methods may only be called once (and
   /// return failure thereafter).
   resource incoming-request {
-    method: func() -> method
+    method: func() -> method;
 
-    path-with-query: func() -> option<string>
+    path-with-query: func() -> option<string>;
 
-    scheme: func() -> option<scheme>
+    scheme: func() -> option<scheme>;
 
-    authority: func() -> option<string>
+    authority: func() -> option<string>;
 
-    headers: func() -> /* child */ headers
+    headers: func() -> /* child */ headers;
 
     /// Returns the input-stream child at most once.
     ///
     /// If called more than once, subsequent calls return an error.
-    consume: func() -> result<incoming-body>
+    consume: func() -> result<incoming-body>;
   }
 
   resource outgoing-request {
@@ -93,12 +93,12 @@ interface types {
       scheme: option<scheme>,
       authority: option<string>,
       headers: borrow<headers>
-    )
+    );
 
     /// Will return the outgoing-body child at most once.
     ///
     /// If called more than once, subsequent calls return an error.
-    write: func() -> result< /* child */ outgoing-body>
+    write: func() -> result< /* child */ outgoing-body>;
   }
 
   /// Additional optional parameters that can be set when making a request.
@@ -124,25 +124,25 @@ interface types {
   /// (the `wasi:http/handler` interface used for both incoming and outgoing can
   /// simply return a `stream`).
   resource response-outparam {
-    set: static func(param: response-outparam, response: result<outgoing-response, error>)
+    set: static func(param: response-outparam, response: result<outgoing-response, error>);
   }
 
   // This type corresponds to the HTTP standard Status Code.
-  type status-code = u16
+  type status-code = u16;
 
   /// The following block defines the `incoming-response` and `outgoing-response`
   /// resource types that correspond to HTTP standard Responses.
   ///
   /// The `consume` and `write` methods may only be called once (and return failure thereafter).
   resource incoming-response {
-    status: func() -> status-code
+    status: func() -> status-code;
 
-    headers: func() -> /* child */ headers
+    headers: func() -> /* child */ headers;
 
     // May be called at most once. returns error if called additional times.
     // TODO: make incoming-request-consume work the same way, giving a child
     // incoming-body.
-    consume: func() -> result<incoming-body>
+    consume: func() -> result<incoming-body>;
   }
 
   resource incoming-body {
@@ -150,41 +150,41 @@ interface types {
     // incoming-body is dropped (or consumed by call to
     // incoming-body-finish) before the input-stream is dropped.
     // May be called at most once. returns error if called additional times.
-    %stream: func() -> result</* child */ input-stream>
+    %stream: func() -> result</* child */ input-stream>;
 
     // takes ownership of incoming-body. this will trap if the
     // incoming-body-stream child is still alive!
     finish: static func(this: incoming-body) ->
-    /* transitive child of the incoming-response of incoming-body */ future-trailers
+    /* transitive child of the incoming-response of incoming-body */ future-trailers;
   }
 
   resource future-trailers {
     /// Pollable that resolves when the body has been fully read, and the trailers
     /// are ready to be consumed.
-    subscribe: func() -> /* child */ pollable
+    subscribe: func() -> /* child */ pollable;
 
     /// Retrieve reference to trailers, if they are ready.
-    get: func() -> option<result</* child */ trailers, error>>
+    get: func() -> option<result</* child */ trailers, error>>;
   }
 
   resource outgoing-response {
-    constructor(status-code: status-code, headers: borrow<headers>)
+    constructor(status-code: status-code, headers: borrow<headers>);
 
     /// Will give the child outgoing-response at most once. subsequent calls will
     /// return an error.
-    write: func() -> result<outgoing-body>
+    write: func() -> result<outgoing-body>;
   }
 
   resource outgoing-body {
     /// Will give the child output-stream at most once. subsequent calls will
     /// return an error.
-    write: func() -> result</* child */ output-stream>
+    write: func() -> result</* child */ output-stream>;
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
     /// called to signal that the response is complete. If the `outgoing-body` is
     /// dropped without calling `outgoing-body-finalize`, the implementation
     /// should treat the body as corrupted.
-    finish: static func(this: outgoing-body, trailers: option<trailers>)
+    finish: static func(this: outgoing-body, trailers: option<trailers>);
   }
 
   /// The following block defines a special resource type used by the
@@ -201,8 +201,8 @@ interface types {
     /// will return an error here.
     /// inner result indicates whether the incoming-response was available, or an
     /// error occured.
-    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>
+    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>;
 
-    subscribe: func() -> /* child */ pollable
+    subscribe: func() -> /* child */ pollable;
   }
 }

--- a/wit/deps/http/world.wit
+++ b/wit/deps/http/world.wit
@@ -1,1 +1,0 @@
-package wasi:http@0.2.0-rc-2023-10-18

--- a/wit/deps/io/poll.wit
+++ b/wit/deps/io/poll.wit
@@ -2,7 +2,7 @@
 /// at once.
 interface poll {
     /// A "pollable" handle.
-    resource pollable
+    resource pollable;
 
     /// Poll for completion on a set of pollables.
     ///
@@ -22,11 +22,11 @@ interface poll {
     /// do any I/O so it doesn't fail. If any of the I/O sources identified by
     /// the pollables has an error, it is indicated by marking the source as
     /// being reaedy for I/O.
-    poll-list: func(in: list<borrow<pollable>>) -> list<u32>
+    poll-list: func(in: list<borrow<pollable>>) -> list<u32>;
 
     /// Poll for completion on a single pollable.
     ///
     /// This function is similar to `poll-list`, but operates on only a single
     /// pollable. When it returns, the handle is ready for I/O.
-    poll-one: func(in: borrow<pollable>)
+    poll-one: func(in: borrow<pollable>);
 }

--- a/wit/deps/io/streams.wit
+++ b/wit/deps/io/streams.wit
@@ -4,7 +4,7 @@
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
 interface streams {
-    use poll.{pollable}
+    use poll.{pollable};
 
     /// An error for input-stream and output-stream operations.
     variant stream-error {
@@ -35,7 +35,7 @@ interface streams {
         /// The returned string will change across platforms and hosts which
         /// means that parsing it, for example, would be a
         /// platform-compatibility hazard.
-        to-debug-string: func() -> string
+        to-debug-string: func() -> string;
     }
 
     /// An input bytestream.
@@ -72,14 +72,14 @@ interface streams {
         read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<list<u8>, stream-error>
+        ) -> result<list<u8>, stream-error>;
 
         /// Read bytes from a stream, after blocking until at least one byte can
         /// be read. Except for blocking, identical to `read`.
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<list<u8>, stream-error>
+        ) -> result<list<u8>, stream-error>;
 
         /// Skip bytes from a stream.
         ///
@@ -96,14 +96,14 @@ interface streams {
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Create a `pollable` which will resolve once either the specified stream
         /// has bytes available to read or the other end of the stream has been
@@ -111,7 +111,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `input-stream`.
         /// Implementations may trap if the `input-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
-        subscribe: func() -> pollable
+        subscribe: func() -> pollable;
     }
 
 
@@ -133,7 +133,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
-        check-write: func() -> result<u64, stream-error>
+        check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
         ///
@@ -144,7 +144,7 @@ interface streams {
         /// the last call to check-write provided a permit.
         write: func(
             contents: list<u8>
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
@@ -172,7 +172,7 @@ interface streams {
         /// ```
         blocking-write-and-flush: func(
             contents: list<u8>
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Request to flush buffered output. This function never blocks.
         ///
@@ -184,11 +184,11 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
-        flush: func() -> result<_, stream-error>
+        flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
-        blocking-flush: func() -> result<_, stream-error>
+        blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
         /// is ready for more writing, or an error has occured. When this
@@ -200,7 +200,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
-        subscribe: func() -> pollable
+        subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.
         ///
@@ -211,7 +211,7 @@ interface streams {
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 zeroes, and then flush the stream.
         /// Block until all of these operations are complete, or an error
@@ -240,7 +240,7 @@ interface streams {
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Read from one stream and write to another.
         ///
@@ -254,7 +254,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Read from one stream and write to another, with blocking.
         ///
@@ -265,7 +265,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Forward the entire contents of an input stream to an output stream.
         ///
@@ -282,6 +282,6 @@ interface streams {
         forward: func(
             /// The stream to read from
             src: input-stream
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
     }
 }

--- a/wit/deps/io/world.wit
+++ b/wit/deps/io/world.wit
@@ -1,1 +1,1 @@
-package wasi:io@0.2.0-rc-2023-10-18
+package wasi:io@0.2.0-rc-2023-10-18;

--- a/wit/deps/random/insecure-seed.wit
+++ b/wit/deps/random/insecure-seed.wit
@@ -1,0 +1,24 @@
+/// The insecure-seed interface for seeding hash-map DoS resistance.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface insecure-seed {
+    /// Return a 128-bit value that may contain a pseudo-random value.
+    ///
+    /// The returned value is not required to be computed from a CSPRNG, and may
+    /// even be entirely deterministic. Host implementations are encouraged to
+    /// provide pseudo-random values to any program exposed to
+    /// attacker-controlled content, to enable DoS protection built into many
+    /// languages' hash-map implementations.
+    ///
+    /// This function is intended to only be called once, by a source language
+    /// to initialize Denial Of Service (DoS) protection in its hash-map
+    /// implementation.
+    ///
+    /// # Expected future evolution
+    ///
+    /// This will likely be changed to a value import, to prevent it from being
+    /// called multiple times and potentially used for purposes other than DoS
+    /// protection.
+    insecure-seed: func() -> tuple<u64, u64>;
+}

--- a/wit/deps/random/insecure.wit
+++ b/wit/deps/random/insecure.wit
@@ -1,0 +1,21 @@
+/// The insecure interface for insecure pseudo-random numbers.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface insecure {
+    /// Return `len` insecure pseudo-random bytes.
+    ///
+    /// This function is not cryptographically secure. Do not use it for
+    /// anything related to security.
+    ///
+    /// There are no requirements on the values of the returned bytes, however
+    /// implementations are encouraged to return evenly distributed values with
+    /// a long period.
+    get-insecure-random-bytes: func(len: u64) -> list<u8>;
+
+    /// Return an insecure pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of pseudo-random data as
+    /// `get-insecure-random-bytes`, represented as a `u64`.
+    get-insecure-random-u64: func() -> u64;
+}

--- a/wit/deps/random/random.wit
+++ b/wit/deps/random/random.wit
@@ -1,0 +1,25 @@
+/// WASI Random is a random data API.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface random {
+    /// Return `len` cryptographically-secure random or pseudo-random bytes.
+    ///
+    /// This function must produce data at least as cryptographically secure and
+    /// fast as an adequately seeded cryptographically-secure pseudo-random
+    /// number generator (CSPRNG). It must not block, from the perspective of
+    /// the calling program, under any circumstances, including on the first
+    /// request and on requests for numbers of bytes. The returned data must
+    /// always be unpredictable.
+    ///
+    /// This function must always return fresh data. Deterministic environments
+    /// must omit this function, rather than implementing it with deterministic
+    /// data.
+    get-random-bytes: func(len: u64) -> list<u8>;
+
+    /// Return a cryptographically-secure random or pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of data as `get-random-bytes`,
+    /// represented as a `u64`.
+    get-random-u64: func() -> u64;
+}

--- a/wit/deps/random/world.wit
+++ b/wit/deps/random/world.wit
@@ -1,0 +1,7 @@
+package wasi:random@0.2.0-rc-2023-10-18;
+
+world imports {
+    import random;
+    import insecure;
+    import insecure-seed;
+}

--- a/wit/deps/sockets/instance-network.wit
+++ b/wit/deps/sockets/instance-network.wit
@@ -1,0 +1,9 @@
+
+/// This interface provides a value-export of the default network handle..
+interface instance-network {
+	use network.{network};
+
+	/// Get a handle to the default network.
+	instance-network: func() -> network;
+
+}

--- a/wit/deps/sockets/ip-name-lookup.wit
+++ b/wit/deps/sockets/ip-name-lookup.wit
@@ -1,0 +1,61 @@
+
+interface ip-name-lookup {
+	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+	use network.{network, error-code, ip-address, ip-address-family};
+
+
+	/// Resolve an internet host name to a list of IP addresses.
+	///
+	/// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
+	///
+	/// # Parameters
+	/// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
+	///     to ASCII using IDNA encoding.
+	/// - `address-family`: If provided, limit the results to addresses of this specific address family.
+	/// - `include-unavailable`: When set to true, this function will also return addresses of which the runtime
+	///   thinks (or knows) can't be connected to at the moment. For example, this will return IPv6 addresses on
+	///   systems without an active IPv6 interface. Notes:
+	///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
+	///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
+	///
+	/// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
+	/// that can be used to (asynchronously) fetch the results.
+	///
+	/// At the moment, the stream never completes successfully with 0 items. Ie. the first call
+	/// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
+	///
+	/// # Typical errors
+	/// - `invalid-argument`:     `name` is a syntactically invalid domain name.
+	/// - `invalid-argument`:     `name` is an IP address.
+	/// - `not-supported`:        The specified `address-family` is not supported. (EAI_FAMILY)
+	///
+	/// # References:
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
+	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+	resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>;
+
+	resource resolve-address-stream {
+		/// Returns the next address from the resolver.
+		///
+		/// This function should be called multiple times. On each call, it will
+		/// return the next address in connection order preference. If all
+		/// addresses have been exhausted, this function returns `none`.
+		///
+		/// This function never returns IPv4-mapped IPv6 addresses.
+		///
+		/// # Typical errors
+		/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
+		/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
+		/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+		/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+		resolve-next-address: func() -> result<option<ip-address>, error-code>;
+
+		/// Create a `pollable` which will resolve once the stream is ready for I/O.
+		///
+		/// Note: this function is here for WASI Preview2 only.
+		/// It's planned to be removed when `future` is natively supported in Preview3.
+		subscribe: func() -> pollable;
+	}
+}

--- a/wit/deps/sockets/network.wit
+++ b/wit/deps/sockets/network.wit
@@ -1,0 +1,146 @@
+
+interface network {
+	/// An opaque resource that represents access to (a subset of) the network.
+	/// This enables context-based security for networking.
+	/// There is no need for this to map 1:1 to a physical network interface.
+	resource network;
+
+	/// Error codes.
+	///
+	/// In theory, every API can return any error code.
+	/// In practice, API's typically only return the errors documented per API
+	/// combined with a couple of errors that are always possible:
+	/// - `unknown`
+	/// - `access-denied`
+	/// - `not-supported`
+	/// - `out-of-memory`
+	/// - `concurrency-conflict`
+	///
+	/// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+	enum error-code {
+		// ### GENERAL ERRORS ###
+
+		/// Unknown error
+		unknown,
+
+		/// Access denied.
+		///
+		/// POSIX equivalent: EACCES, EPERM
+		access-denied,
+
+		/// The operation is not supported.
+		///
+		/// POSIX equivalent: EOPNOTSUPP
+		not-supported,
+
+		/// One of the arguments is invalid.
+		///
+		/// POSIX equivalent: EINVAL
+		invalid-argument,
+
+		/// Not enough memory to complete the operation.
+		///
+		/// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+		out-of-memory,
+
+		/// The operation timed out before it could finish completely.
+		timeout,
+
+		/// This operation is incompatible with another asynchronous operation that is already in progress.
+		///
+		/// POSIX equivalent: EALREADY
+		concurrency-conflict,
+
+		/// Trying to finish an asynchronous operation that:
+		/// - has not been started yet, or:
+		/// - was already finished by a previous `finish-*` call.
+		///
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		not-in-progress,
+
+		/// The operation has been aborted because it could not be completed immediately.
+		///
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		would-block,
+
+
+
+		// ### TCP & UDP SOCKET ERRORS ###
+
+		/// The operation is not valid in the socket's current state.
+		invalid-state,
+
+		/// A new socket resource could not be created because of a system limit.
+		new-socket-limit,
+
+		/// A bind operation failed because the provided address is not an address that the `network` can bind to.
+		address-not-bindable,
+
+		/// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+		address-in-use,
+
+		/// The remote address is not reachable
+		remote-unreachable,
+
+
+		// ### TCP SOCKET ERRORS ###
+
+		/// The connection was forcefully rejected
+		connection-refused,
+
+		/// The connection was reset.
+		connection-reset,
+
+		/// A connection was aborted.
+		connection-aborted,
+
+		// ### UDP SOCKET ERRORS ###
+		datagram-too-large,
+
+
+		// ### NAME LOOKUP ERRORS ###
+
+		/// Name does not exist or has no suitable associated IP addresses.
+		name-unresolvable,
+
+		/// A temporary failure in name resolution occurred.
+		temporary-resolver-failure,
+
+		/// A permanent failure in name resolution occurred.
+		permanent-resolver-failure,
+	}
+
+	enum ip-address-family {
+		/// Similar to `AF_INET` in POSIX.
+		ipv4,
+
+		/// Similar to `AF_INET6` in POSIX.
+		ipv6,
+	}
+
+	type ipv4-address = tuple<u8, u8, u8, u8>;
+	type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
+
+	variant ip-address {
+		ipv4(ipv4-address),
+		ipv6(ipv6-address),
+	}
+
+	record ipv4-socket-address {
+		port: u16, // sin_port
+		address: ipv4-address, // sin_addr
+	}
+
+	record ipv6-socket-address {
+		port: u16, // sin6_port
+		flow-info: u32, // sin6_flowinfo
+		address: ipv6-address, // sin6_addr
+		scope-id: u32, // sin6_scope_id
+	}
+
+	variant ip-socket-address {
+		ipv4(ipv4-socket-address),
+		ipv6(ipv6-socket-address),
+	}
+
+}

--- a/wit/deps/sockets/tcp-create-socket.wit
+++ b/wit/deps/sockets/tcp-create-socket.wit
@@ -1,0 +1,26 @@
+
+interface tcp-create-socket {
+	use network.{network, error-code, ip-address-family};
+	use tcp.{tcp-socket};
+
+	/// Create a new TCP socket.
+	///
+	/// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+	///
+	/// This function does not require a network capability handle. This is considered to be safe because
+	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
+	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+	///
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	///
+	/// # Typical errors
+	/// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+	/// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+	///
+	/// # References
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
+}

--- a/wit/deps/sockets/tcp.wit
+++ b/wit/deps/sockets/tcp.wit
@@ -1,0 +1,268 @@
+
+interface tcp {
+	use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream};
+	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+	use network.{network, error-code, ip-socket-address, ip-address-family};
+
+	enum shutdown-type {
+		/// Similar to `SHUT_RD` in POSIX.
+		receive,
+
+		/// Similar to `SHUT_WR` in POSIX.
+		send,
+
+		/// Similar to `SHUT_RDWR` in POSIX.
+		both,
+	}
+
+
+	/// A TCP socket handle.
+	resource tcp-socket {
+		/// Bind the socket to a specific network on the provided IP address and port.
+		///
+		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+		/// network interface(s) to bind to.
+		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+		///
+		/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
+		/// implicitly bind the socket.
+		///
+		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+		///
+		/// # Typical `start` errors
+		/// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+		/// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
+		/// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL)
+		/// - `invalid-state`:             The socket is already bound. (EINVAL)
+		///
+		/// # Typical `finish` errors
+		/// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+		/// - `not-in-progress`:           A `bind` operation is not in progress.
+		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+		finish-bind: func() -> result<_, error-code>;
+
+		/// Connect to a remote endpoint.
+		///
+		/// On success:
+		/// - the socket is transitioned into the Connection state
+		/// - a pair of streams is returned that can be used to read & write to the connection
+		///
+		/// POSIX mentions:
+		/// > If connect() fails, the state of the socket is unspecified. Conforming applications should
+		/// > close the file descriptor and create a new socket before attempting to reconnect.
+		///
+		/// WASI prescribes the following behavior:
+		/// - If `connect` fails because an input/state validation error, the socket should remain usable.
+		/// - If a connection was actually attempted but failed, the socket should become unusable for further network communication.
+		///   Besides `drop`, any method after such a failure may return an error.
+		///
+		/// # Typical `start` errors
+		/// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+		/// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
+		/// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL, EADDRNOTAVAIL on Illumos)
+		/// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+		/// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+		/// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+		/// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+		/// - `invalid-state`:             The socket is already in the Connection state. (EISCONN)
+		/// - `invalid-state`:             The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
+		///
+		/// # Typical `finish` errors
+		/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+		/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+		/// - `connection-reset`:          The connection was reset. (ECONNRESET)
+		/// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
+		/// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+		/// - `not-in-progress`:           A `connect` operation is not in progress.
+		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
+		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
+
+		/// Start listening for new connections.
+		///
+		/// Transitions the socket into the Listener state.
+		///
+		/// Unlike POSIX:
+		/// - this function is async. This enables interactive WASI hosts to inject permission prompts.
+		/// - the socket must already be explicitly bound.
+		///
+		/// # Typical `start` errors
+		/// - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
+		/// - `invalid-state`:             The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
+		/// - `invalid-state`:             The socket is already in the Listener state.
+		///
+		/// # Typical `finish` errors
+		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+		/// - `not-in-progress`:           A `listen` operation is not in progress.
+		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+		/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+		start-listen: func() -> result<_, error-code>;
+		finish-listen: func() -> result<_, error-code>;
+
+		/// Accept a new client socket.
+		///
+		/// The returned socket is bound and in the Connection state. The following properties are inherited from the listener socket:
+		/// - `address-family`
+		/// - `ipv6-only`
+		/// - `keep-alive`
+		/// - `no-delay`
+		/// - `unicast-hop-limit`
+		/// - `receive-buffer-size`
+		/// - `send-buffer-size`
+		///
+		/// On success, this function returns the newly accepted client socket along with
+		/// a pair of streams that can be used to read & write to the connection.
+		///
+		/// # Typical errors
+		/// - `invalid-state`:      Socket is not in the Listener state. (EINVAL)
+		/// - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
+		/// - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
+		/// - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+		/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
+
+		/// Get the bound local address.
+		///
+		/// POSIX mentions:
+		/// > If the socket has not been bound to a local name, the value
+		/// > stored in the object pointed to by `address` is unspecified.
+		///
+		/// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+		///
+		/// # Typical errors
+		/// - `invalid-state`: The socket is not bound to any local address.
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+		local-address: func() -> result<ip-socket-address, error-code>;
+
+		/// Get the remote address.
+		///
+		/// # Typical errors
+		/// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+		remote-address: func() -> result<ip-socket-address, error-code>;
+
+		/// Whether this is a IPv4 or IPv6 socket.
+		///
+		/// Equivalent to the SO_DOMAIN socket option.
+		address-family: func() -> ip-address-family;
+
+		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
+		///
+		/// Equivalent to the IPV6_V6ONLY socket option.
+		///
+		/// # Typical errors
+		/// - `invalid-state`:        (set) The socket is already bound.
+		/// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
+		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+		ipv6-only: func() -> result<bool, error-code>;
+		set-ipv6-only: func(value: bool) -> result<_, error-code>;
+
+		/// Hints the desired listen queue size. Implementations are free to ignore this.
+		///
+		/// # Typical errors
+		/// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
+		/// - `invalid-state`:        (set) The socket is already in the Connection state.
+		set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
+
+		/// Equivalent to the SO_KEEPALIVE socket option.
+		keep-alive: func() -> result<bool, error-code>;
+		set-keep-alive: func(value: bool) -> result<_, error-code>;
+
+		/// Equivalent to the TCP_NODELAY socket option.
+		///
+		/// The default value is `false`.
+		no-delay: func() -> result<bool, error-code>;
+		set-no-delay: func(value: bool) -> result<_, error-code>;
+
+		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+		///
+		/// # Typical errors
+		/// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+		/// - `invalid-state`:        (set) The socket is already in the Connection state.
+		/// - `invalid-state`:        (set) The socket is already in the Listener state.
+		unicast-hop-limit: func() -> result<u8, error-code>;
+		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+
+		/// The kernel buffer space reserved for sends/receives on this socket.
+		///
+		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+		/// 	In other words, after setting a value, reading the same setting back may return a different value.
+		///
+		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
+		/// 	for internal metadata structures.
+		///
+		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+		///
+		/// # Typical errors
+		/// - `invalid-state`:        (set) The socket is already in the Connection state.
+		/// - `invalid-state`:        (set) The socket is already in the Listener state.
+		receive-buffer-size: func() -> result<u64, error-code>;
+		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+		send-buffer-size: func() -> result<u64, error-code>;
+		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+
+		/// Create a `pollable` which will resolve once the socket is ready for I/O.
+		///
+		/// Note: this function is here for WASI Preview2 only.
+		/// It's planned to be removed when `future` is natively supported in Preview3.
+		subscribe: func() -> pollable;
+
+		/// Initiate a graceful shutdown.
+		///
+		/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
+		///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
+		///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
+		/// - send: the socket is not expecting to send any more data to the peer. All subsequent write
+		///   operations on the `output-stream` associated with this socket will return an error.
+		/// - both: same effect as receive & send combined.
+		///
+		/// The shutdown function does not close (drop) the socket.
+		///
+		/// # Typical errors
+		/// - `invalid-state`: The socket is not in the Connection state. (ENOTCONN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+		/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+		shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
+	}
+}

--- a/wit/deps/sockets/udp-create-socket.wit
+++ b/wit/deps/sockets/udp-create-socket.wit
@@ -1,0 +1,26 @@
+
+interface udp-create-socket {
+	use network.{network, error-code, ip-address-family};
+	use udp.{udp-socket};
+
+	/// Create a new UDP socket.
+	///
+	/// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
+	///
+	/// This function does not require a network capability handle. This is considered to be safe because
+	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
+	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+	///
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	///
+	/// # Typical errors
+	/// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+	/// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+	///
+	/// # References:
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
+}

--- a/wit/deps/sockets/udp.wit
+++ b/wit/deps/sockets/udp.wit
@@ -1,0 +1,213 @@
+
+interface udp {
+	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+	use network.{network, error-code, ip-socket-address, ip-address-family};
+
+
+	record datagram {
+		data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+		remote-address: ip-socket-address,
+
+		/// Possible future additions:
+		/// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
+		/// local-interface: u32, // IP_PKTINFO / IP_RECVIF
+		/// ttl: u8, // IP_RECVTTL
+		/// dscp: u6, // IP_RECVTOS
+		/// ecn: u2, // IP_RECVTOS
+	}
+
+
+
+	/// A UDP socket handle.
+	resource udp-socket {
+		/// Bind the socket to a specific network on the provided IP address and port.
+		///
+		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+		/// network interface(s) to bind to.
+		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+		///
+		/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
+		///
+		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+		///
+		/// # Typical `start` errors
+		/// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+		/// - `invalid-state`:             The socket is already bound. (EINVAL)
+		///
+		/// # Typical `finish` errors
+		/// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+		/// - `not-in-progress`:           A `bind` operation is not in progress.
+		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+		finish-bind: func() -> result<_, error-code>;
+
+		/// Set the destination address.
+		///
+		/// The local-address is updated based on the best network path to `remote-address`.
+		///
+		/// When a destination address is set:
+		/// - all receive operations will only return datagrams sent from the provided `remote-address`.
+		/// - the `send` function can only be used to send to this destination.
+		///
+		/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
+		///
+		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+		///
+		/// # Typical `start` errors
+		/// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+		/// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+		/// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+		/// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+		/// - `invalid-argument`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+		///
+		/// # Typical `finish` errors
+		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+		/// - `not-in-progress`:           A `connect` operation is not in progress.
+		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
+		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+		finish-connect: func() -> result<_, error-code>;
+
+		/// Receive messages on the socket.
+		///
+		/// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
+		/// The returned list may contain fewer elements than requested, but never more.
+		/// If `max-results` is 0, this function returns successfully with an empty list.
+		///
+		/// # Typical errors
+		/// - `invalid-state`:      The socket is not bound to any local address. (EINVAL)
+		/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+		/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
+		/// - <https://man7.org/linux/man-pages/man2/recv.2.html>
+		/// - <https://man7.org/linux/man-pages/man2/recvmmsg.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
+		/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+		receive: func(max-results: u64) -> result<list<datagram>, error-code>;
+
+		/// Send messages on the socket.
+		///
+		/// This function attempts to send all provided `datagrams` on the socket without blocking and
+		/// returns how many messages were actually sent (or queued for sending).
+		///
+		/// This function semantically behaves the same as iterating the `datagrams` list and sequentially
+		/// sending each individual datagram until either the end of the list has been reached or the first error occurred.
+		/// If at least one datagram has been sent successfully, this function never returns an error.
+		///
+		/// If the input list is empty, the function returns `ok(0)`.
+		///
+		/// The remote address option is required. To send a message to the "connected" peer,
+		/// call `remote-address` to get their address.
+		///
+		/// # Typical errors
+		/// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+		/// - `invalid-argument`:        `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+		/// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+		/// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+		/// - `invalid-argument`:        The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
+		/// - `invalid-state`:           The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
+		/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+		/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+		/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
+		/// - <https://man7.org/linux/man-pages/man2/send.2.html>
+		/// - <https://man7.org/linux/man-pages/man2/sendmmsg.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+		send: func(datagrams: list<datagram>) -> result<u64, error-code>;
+
+		/// Get the current bound address.
+		///
+		/// POSIX mentions:
+		/// > If the socket has not been bound to a local name, the value
+		/// > stored in the object pointed to by `address` is unspecified.
+		///
+		/// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+		///
+		/// # Typical errors
+		/// - `invalid-state`: The socket is not bound to any local address.
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+		local-address: func() -> result<ip-socket-address, error-code>;
+
+		/// Get the address set with `connect`.
+		///
+		/// # Typical errors
+		/// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+		///
+		/// # References
+		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+		remote-address: func() -> result<ip-socket-address, error-code>;
+
+		/// Whether this is a IPv4 or IPv6 socket.
+		///
+		/// Equivalent to the SO_DOMAIN socket option.
+		address-family: func() -> ip-address-family;
+
+		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
+		///
+		/// Equivalent to the IPV6_V6ONLY socket option.
+		///
+		/// # Typical errors
+		/// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
+		/// - `invalid-state`:        (set) The socket is already bound.
+		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+		ipv6-only: func() -> result<bool, error-code>;
+		set-ipv6-only: func(value: bool) -> result<_, error-code>;
+
+		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+		unicast-hop-limit: func() -> result<u8, error-code>;
+		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+
+		/// The kernel buffer space reserved for sends/receives on this socket.
+		///
+		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+		/// 	In other words, after setting a value, reading the same setting back may return a different value.
+		///
+		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
+		/// 	for internal metadata structures.
+		///
+		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+		receive-buffer-size: func() -> result<u64, error-code>;
+		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+		send-buffer-size: func() -> result<u64, error-code>;
+		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+
+		/// Create a `pollable` which will resolve once the socket is ready for I/O.
+		///
+		/// Note: this function is here for WASI Preview2 only.
+		/// It's planned to be removed when `future` is natively supported in Preview3.
+		subscribe: func() -> pollable;
+	}
+}

--- a/wit/deps/sockets/world.wit
+++ b/wit/deps/sockets/world.wit
@@ -1,0 +1,11 @@
+package wasi:sockets@0.2.0-rc-2023-10-18;
+
+world imports {
+    import instance-network;
+    import network;
+    import udp;
+    import udp-create-socket;
+    import tcp;
+    import tcp-create-socket;
+    import ip-name-lookup;
+}

--- a/wit/deps/spin@unversioned/config.wit
+++ b/wit/deps/spin@unversioned/config.wit
@@ -1,7 +1,7 @@
 interface config {
   // Get a configuration value for the current component.
   // The config key must match one defined in in the component manifest.
-  get-config: func(key: string) -> result<string, error>
+  get-config: func(key: string) -> result<string, error>;
 
   variant error {
       provider(string),

--- a/wit/deps/spin@unversioned/http-types.wit
+++ b/wit/deps/spin@unversioned/http-types.wit
@@ -1,13 +1,13 @@
 interface http-types {
-   type http-status = u16
+   type http-status = u16;
 
-   type body = list<u8>
+   type body = list<u8>;
 
-   type headers = list<tuple<string, string>>
+   type headers = list<tuple<string, string>>;
 
-   type params = list<tuple<string, string>>
+   type params = list<tuple<string, string>>;
 
-   type uri = string
+   type uri = string;
 
     enum method {
         get,

--- a/wit/deps/spin@unversioned/http.wit
+++ b/wit/deps/spin@unversioned/http.wit
@@ -1,5 +1,5 @@
 interface http {
-    use http-types.{request, response, http-error}
+    use http-types.{request, response, http-error};
 
-    send-request: func(req: request) -> result<response, http-error>
+    send-request: func(req: request) -> result<response, http-error>;
 }

--- a/wit/deps/spin@unversioned/inbound-http.wit
+++ b/wit/deps/spin@unversioned/inbound-http.wit
@@ -1,5 +1,5 @@
 interface inbound-http {
-    use http-types.{request, response}
+    use http-types.{request, response};
 
-    handle-request: func(req: request) -> response
+    handle-request: func(req: request) -> response;
 }

--- a/wit/deps/spin@unversioned/inbound-redis.wit
+++ b/wit/deps/spin@unversioned/inbound-redis.wit
@@ -1,6 +1,6 @@
 interface inbound-redis {
-  use redis-types.{payload, error}
+  use redis-types.{payload, error};
 
   // The entrypoint for a Redis handler.
-  handle-message: func(message: payload) -> result<_, error>
+  handle-message: func(message: payload) -> result<_, error>;
 }

--- a/wit/deps/spin@unversioned/key-value.wit
+++ b/wit/deps/spin@unversioned/key-value.wit
@@ -1,6 +1,6 @@
 interface key-value {
   // A handle to an open key-value store
-  type store = u32
+  type store = u32;
 
   // The set of errors which may be raised by functions in this interface
   variant error {
@@ -36,7 +36,7 @@ interface key-value {
   // configuration file supplied with the application.
   //
   // `error::no-such-store` will be raised if the `name` is not recognized.
-  open: func(name: string) -> result<store, error>
+  open: func(name: string) -> result<store, error>;
 
   // Get the value associated with the specified `key` from the specified
   // `store`.
@@ -44,37 +44,37 @@ interface key-value {
   // `error::invalid-store` will be raised if `store` is not a valid handle
   // to an open store, and `error::no-such-key` will be raised if there is no
   // tuple for `key` in `store`.
-  get: func(store: store, key: string) -> result<list<u8>, error>
+  get: func(store: store, key: string) -> result<list<u8>, error>;
 
   // Set the `value` associated with the specified `key` in the specified
   // `store`, overwriting any existing value.
   //
   // `error::invalid-store` will be raised if `store` is not a valid handle
   // to an open store.
-  set: func(store: store, key: string, value: list<u8>) -> result<_, error>
+  set: func(store: store, key: string, value: list<u8>) -> result<_, error>;
 
   // Delete the tuple with the specified `key` from the specified `store`.
   //
   // `error::invalid-store` will be raised if `store` is not a valid handle
   // to an open store.  No error is raised if a tuple did not previously
   // exist for `key`.
-  delete: func(store: store, key: string) -> result<_, error>
+  delete: func(store: store, key: string) -> result<_, error>;
 
   // Return whether a tuple exists for the specified `key` in the specified
   // `store`.
   //
   // `error::invalid-store` will be raised if `store` is not a valid handle
   // to an open store.
-  exists: func(store: store, key: string) -> result<bool, error>
+  exists: func(store: store, key: string) -> result<bool, error>;
 
   // Return a list of all the keys in the specified `store`.
   //
   // `error::invalid-store` will be raised if `store` is not a valid handle
   // to an open store.
-  get-keys: func(store: store) -> result<list<string>, error>
+  get-keys: func(store: store) -> result<list<string>, error>;
 
   // Close the specified `store`.
   //
   // This has no effect if `store` is not a valid handle to an open store.
-  close: func(store: store)
+  close: func(store: store);
 }

--- a/wit/deps/spin@unversioned/llm.wit
+++ b/wit/deps/spin@unversioned/llm.wit
@@ -1,7 +1,7 @@
 // A WASI interface dedicated to performing inferencing for Large Language Models.
 interface llm {
 	/// A Large Language Model.
-	type inferencing-model = string
+	type inferencing-model = string;
 
 	/// Inference request parameters
 	record inferencing-params {
@@ -46,13 +46,13 @@ interface llm {
 	}
 
 	/// Perform inferencing using the provided model and prompt with the given optional params
-	infer: func(model: inferencing-model, prompt: string, params: option<inferencing-params>) -> result<inferencing-result, error>
+	infer: func(model: inferencing-model, prompt: string, params: option<inferencing-params>) -> result<inferencing-result, error>;
 
 	/// The model used for generating embeddings
-	type embedding-model = string
+	type embedding-model = string;
 
 	/// Generate embeddings for the supplied list of text
-	generate-embeddings: func(model: embedding-model, text: list<string>) -> result<embeddings-result, error>
+	generate-embeddings: func(model: embedding-model, text: list<string>) -> result<embeddings-result, error>;
 
 	/// Result of generating embeddings
 	record embeddings-result {

--- a/wit/deps/spin@unversioned/mysql.wit
+++ b/wit/deps/spin@unversioned/mysql.wit
@@ -1,5 +1,5 @@
 interface mysql {
-  use rdbms-types.{parameter-value, row-set}
+  use rdbms-types.{parameter-value, row-set};
 
   // General purpose error.
   variant mysql-error {
@@ -12,8 +12,8 @@ interface mysql {
   }
 
   // query the database: select
-  query: func(address: string, statement: string, params: list<parameter-value>) -> result<row-set, mysql-error>
+  query: func(address: string, statement: string, params: list<parameter-value>) -> result<row-set, mysql-error>;
 
   // execute command to the database: insert, update, delete
-  execute: func(address: string, statement: string, params: list<parameter-value>) -> result<_, mysql-error>
+  execute: func(address: string, statement: string, params: list<parameter-value>) -> result<_, mysql-error>;
 }

--- a/wit/deps/spin@unversioned/postgres.wit
+++ b/wit/deps/spin@unversioned/postgres.wit
@@ -1,5 +1,5 @@
 interface postgres {
-  use rdbms-types.{parameter-value, row-set}
+  use rdbms-types.{parameter-value, row-set};
 
   // General purpose error.
   variant pg-error {
@@ -12,8 +12,8 @@ interface postgres {
   }
 
   // query the database: select
-  query: func(address: string, statement: string, params: list<parameter-value>) -> result<row-set, pg-error>
+  query: func(address: string, statement: string, params: list<parameter-value>) -> result<row-set, pg-error>;
 
   // execute command to the database: insert, update, delete
-  execute: func(address: string, statement: string, params: list<parameter-value>) -> result<u64, pg-error>
+  execute: func(address: string, statement: string, params: list<parameter-value>) -> result<u64, pg-error>;
 }

--- a/wit/deps/spin@unversioned/rdbms-types.wit
+++ b/wit/deps/spin@unversioned/rdbms-types.wit
@@ -56,7 +56,7 @@ interface rdbms-types {
       data-type: db-data-type,
   }
 
-  type row = list<db-value>
+  type row = list<db-value>;
 
   record row-set {
       columns: list<column>,

--- a/wit/deps/spin@unversioned/redis-types.wit
+++ b/wit/deps/spin@unversioned/redis-types.wit
@@ -6,7 +6,7 @@ interface redis-types {
   }
 
   /// The message payload.
-  type payload = list<u8>
+  type payload = list<u8>;
 
   /// A parameter type for the general-purpose `execute` function.
   variant redis-parameter {

--- a/wit/deps/spin@unversioned/redis.wit
+++ b/wit/deps/spin@unversioned/redis.wit
@@ -1,31 +1,31 @@
 interface redis {
-  use redis-types.{payload, redis-parameter, redis-result, error}
+  use redis-types.{payload, redis-parameter, redis-result, error};
 
   // Publish a Redis message to the specificed channel and return an error, if any.
-  publish: func(address: string, channel: string, payload: payload) -> result<_, error>
+  publish: func(address: string, channel: string, payload: payload) -> result<_, error>;
 
   // Get the value of a key.
-  get: func(address: string, key: string) -> result<payload, error>
+  get: func(address: string, key: string) -> result<payload, error>;
 
   // Set key to value. If key alreads holds a value, it is overwritten.
-  set: func(address: string, key: string, value: payload) -> result<_, error>
+  set: func(address: string, key: string, value: payload) -> result<_, error>;
 
   // Increments the number stored at key by one. If the key does not exist, it is set to 0 before performing the operation.
   // An error is returned if the key contains a value of the wrong type or contains a string that can not be represented as integer.
-  incr: func(address: string, key: string) -> result<s64, error>
+  incr: func(address: string, key: string) -> result<s64, error>;
 
   // Removes the specified keys. A key is ignored if it does not exist.
-  del: func(address: string, keys: list<string>) -> result<s64, error>
+  del: func(address: string, keys: list<string>) -> result<s64, error>;
 
   // Add the specified `values` to the set named `key`, returning the number of newly-added values.
-  sadd: func(address: string, key: string, values: list<string>) -> result<s64, error>
+  sadd: func(address: string, key: string, values: list<string>) -> result<s64, error>;
 
   // Retrieve the contents of the set named `key`.
-  smembers: func(address: string, key: string) -> result<list<string>, error>
+  smembers: func(address: string, key: string) -> result<list<string>, error>;
 
   // Remove the specified `values` from the set named `key`, returning the number of newly-removed values.
-  srem: func(address: string, key: string, values: list<string>) -> result<s64, error>
+  srem: func(address: string, key: string, values: list<string>) -> result<s64, error>;
 
   // Execute an arbitrary Redis command and receive the result.
-  execute: func(address: string, command: string, arguments: list<redis-parameter>) -> result<list<redis-result>, error>
+  execute: func(address: string, command: string, arguments: list<redis-parameter>) -> result<list<redis-result>, error>;
 }

--- a/wit/deps/spin@unversioned/sqlite.wit
+++ b/wit/deps/spin@unversioned/sqlite.wit
@@ -1,6 +1,6 @@
 interface sqlite {
   // A handle to an open sqlite instance
-  type connection = u32
+  type connection = u32;
 
   // The set of errors which may be raised by functions in this interface
   variant error {
@@ -21,13 +21,13 @@ interface sqlite {
   // If `database` is "default", the default instance is opened.
   //
   // `error::no-such-database` will be raised if the `name` is not recognized.
-  open: func(database: string) -> result<connection, error>
+  open: func(database: string) -> result<connection, error>;
 
   // Execute a statement returning back data if there is any
-  execute: func(conn: connection, statement: string, parameters: list<value>) -> result<query-result, error>
+  execute: func(conn: connection, statement: string, parameters: list<value>) -> result<query-result, error>;
 
   // Close the specified `connection`.
-  close: func(conn: connection)
+  close: func(conn: connection);
 
   // A result of a query
   record query-result {
@@ -41,7 +41,7 @@ interface sqlite {
   record row-result {
     values: list<value>
   }
-  
+
   variant value {
     integer(s64),
     real(float64),

--- a/wit/deps/spin@unversioned/world.wit
+++ b/wit/deps/spin@unversioned/world.wit
@@ -1,29 +1,29 @@
-package fermyon:spin
+package fermyon:spin;
 
 world host {
-  include platform
+  include platform;
 
-  export inbound-http
-  export inbound-redis
+  export inbound-http;
+  export inbound-redis;
 }
 
 world redis-trigger {
-  include platform
-  export inbound-redis
+  include platform;
+  export inbound-redis;
 }
 
 world http-trigger {
-  include platform
-  export inbound-http
+  include platform;
+  export inbound-http;
 }
 
 world platform {
-  import config
-  import http
-  import postgres
-  import mysql
-  import sqlite
-  import redis
-  import key-value
-  import llm
+  import config;
+  import http;
+  import postgres;
+  import mysql;
+  import sqlite;
+  import redis;
+  import key-value;
+  import llm;
 }

--- a/wit/key-value.wit
+++ b/wit/key-value.wit
@@ -6,26 +6,26 @@ interface key-value {
     /// `label` must refer to a store allowed in the spin.toml manifest.
     ///
     /// `error::no-such-store` will be raised if the `label` is not recognized.
-    open: static func(label: string) -> result<store, error>
+    open: static func(label: string) -> result<store, error>;
 
     /// Get the value associated with the specified `key`
     ///
     /// Returns `ok(none)` if the key does not exist.
-    get: func(key: string) -> result<option<list<u8>>, error>
+    get: func(key: string) -> result<option<list<u8>>, error>;
 
     /// Set the `value` associated with the specified `key` overwriting any existing value.
-    set: func(key: string, value: list<u8>) -> result<_, error>
+    set: func(key: string, value: list<u8>) -> result<_, error>;
 
     /// Delete the tuple with the specified `key`
     ///
     /// No error is raised if a tuple did not previously exist for `key`.
-    delete: func(key: string) -> result<_, error>
+    delete: func(key: string) -> result<_, error>;
 
     /// Return whether a tuple exists for the specified `key`
-    exists: func(key: string) -> result<bool, error>
+    exists: func(key: string) -> result<bool, error>;
 
     /// Return a list of all the keys
-    get-keys: func() -> result<list<string>, error>
+    get-keys: func() -> result<list<string>, error>;
   }
 
   /// The set of errors which may be raised by functions in this interface

--- a/wit/llm.wit
+++ b/wit/llm.wit
@@ -1,7 +1,7 @@
 // A WASI interface dedicated to performing inferencing for Large Language Models.
 interface llm {
 	/// A Large Language Model.
-	type inferencing-model = string
+	type inferencing-model = string;
 
 	/// Inference request parameters
 	record inferencing-params {
@@ -46,13 +46,13 @@ interface llm {
 	}
 
 	/// Perform inferencing using the provided model and prompt with the given optional params
-	infer: func(model: inferencing-model, prompt: string, params: option<inferencing-params>) -> result<inferencing-result, error>
+	infer: func(model: inferencing-model, prompt: string, params: option<inferencing-params>) -> result<inferencing-result, error>;
 
 	/// The model used for generating embeddings
-	type embedding-model = string
+	type embedding-model = string;
 
 	/// Generate embeddings for the supplied list of text
-	generate-embeddings: func(model: embedding-model, text: list<string>) -> result<embeddings-result, error>
+	generate-embeddings: func(model: embedding-model, text: list<string>) -> result<embeddings-result, error>;
 
 	/// Result of generating embeddings
 	record embeddings-result {

--- a/wit/mysql.wit
+++ b/wit/mysql.wit
@@ -1,15 +1,15 @@
 interface mysql {
-  use rdbms-types.{parameter-value, row-set, error}
+  use rdbms-types.{parameter-value, row-set, error};
 
   /// A connection to a MySQL database.
   resource connection {
     /// Open a connection to the MySQL instance at `address`.
-    open: static func(address: string) -> result<connection, error>
+    open: static func(address: string) -> result<connection, error>;
 
     /// query the database: select
-    query: func(statement: string, params: list<parameter-value>) -> result<row-set, error>
+    query: func(statement: string, params: list<parameter-value>) -> result<row-set, error>;
 
     /// execute command to the database: insert, update, delete
-    execute: func(statement: string, params: list<parameter-value>) -> result<_, error>
+    execute: func(statement: string, params: list<parameter-value>) -> result<_, error>;
   }
 }

--- a/wit/postgres.wit
+++ b/wit/postgres.wit
@@ -1,15 +1,15 @@
 interface postgres {
-  use rdbms-types.{parameter-value, row-set, error}
+  use rdbms-types.{parameter-value, row-set, error};
 
   /// A connection to a postgres database.
   resource connection {
     /// Open a connection to the Postgres instance at `address`.
-    open: static func(address: string) -> result<connection, error>
+    open: static func(address: string) -> result<connection, error>;
 
     /// Query the database.
-    query: func(statement: string, params: list<parameter-value>) -> result<row-set, error>
+    query: func(statement: string, params: list<parameter-value>) -> result<row-set, error>;
 
     /// Execute command to the database.
-    execute: func(statement: string, params: list<parameter-value>) -> result<u64, error>
+    execute: func(statement: string, params: list<parameter-value>) -> result<u64, error>;
   }
 }

--- a/wit/rdbms-types.wit
+++ b/wit/rdbms-types.wit
@@ -70,7 +70,7 @@ interface rdbms-types {
   }
 
   /// A database row
-  type row = list<db-value>
+  type row = list<db-value>;
 
   /// A set of database rows
   record row-set {

--- a/wit/redis.wit
+++ b/wit/redis.wit
@@ -10,49 +10,49 @@ interface redis {
       /// Some other error occurred
       other(string),
   }
-  
+
   resource connection {
     /// Open a connection to the Redis instance at `address`.
-    open: static func(address: string) -> result<connection, error>
+    open: static func(address: string) -> result<connection, error>;
 
     /// Publish a Redis message to the specified channel.
-    publish: func(channel: string, payload: payload) -> result<_, error>
+    publish: func(channel: string, payload: payload) -> result<_, error>;
 
     /// Get the value of a key.
-    get: func(key: string) -> result<option<payload>, error>
+    get: func(key: string) -> result<option<payload>, error>;
 
     /// Set key to value.
     ///
     /// If key already holds a value, it is overwritten.
-    set: func(key: string, value: payload) -> result<_, error>
+    set: func(key: string, value: payload) -> result<_, error>;
 
     /// Increments the number stored at key by one.
     ///
     /// If the key does not exist, it is set to 0 before performing the operation.
     /// An `error::type-error` is returned if the key contains a value of the wrong type
     /// or contains a string that can not be represented as integer.
-    incr: func(key: string) -> result<s64, error>
+    incr: func(key: string) -> result<s64, error>;
 
     /// Removes the specified keys.
     ///
     /// A key is ignored if it does not exist. Returns the number of keys deleted.
-    del: func(keys: list<string>) -> result<u32, error>
+    del: func(keys: list<string>) -> result<u32, error>;
 
     /// Add the specified `values` to the set named `key`, returning the number of newly-added values.
-    sadd: func(key: string, values: list<string>) -> result<u32, error>
+    sadd: func(key: string, values: list<string>) -> result<u32, error>;
 
     /// Retrieve the contents of the set named `key`.
-    smembers: func(key: string) -> result<list<string>, error>
+    smembers: func(key: string) -> result<list<string>, error>;
 
     /// Remove the specified `values` from the set named `key`, returning the number of newly-removed values.
-    srem: func(key: string, values: list<string>) -> result<u32, error>
+    srem: func(key: string, values: list<string>) -> result<u32, error>;
 
     /// Execute an arbitrary Redis command and receive the result.
-    execute: func(command: string, arguments: list<redis-parameter>) -> result<list<redis-result>, error>
+    execute: func(command: string, arguments: list<redis-parameter>) -> result<list<redis-result>, error>;
   }
 
   /// The message payload.
-  type payload = list<u8>
+  type payload = list<u8>;
 
   /// A parameter type for the general-purpose `execute` function.
   variant redis-parameter {

--- a/wit/sqlite.wit
+++ b/wit/sqlite.wit
@@ -6,10 +6,10 @@ interface sqlite {
     /// If `database` is "default", the default instance is opened.
     ///
     /// `error::no-such-database` will be raised if the `name` is not recognized.
-    open: static func(database: string) -> result<connection, error>
+    open: static func(database: string) -> result<connection, error>;
 
     /// Execute a statement returning back data if there is any
-    execute: func(statement: string, parameters: list<value>) -> result<query-result, error>
+    execute: func(statement: string, parameters: list<value>) -> result<query-result, error>;
   }
 
   /// The set of errors which may be raised by functions in this interface
@@ -38,7 +38,7 @@ interface sqlite {
   record row-result {
     values: list<value>
   }
-  
+
   /// A single column's result from a database query
   variant value {
     integer(s64),

--- a/wit/variables.wit
+++ b/wit/variables.wit
@@ -2,7 +2,7 @@ interface variables {
     /// Get an application variable value for the current component.
     ///
     /// The name must match one defined in in the component manifest.
-    get: func(name: string) -> result<string, error>
+    get: func(name: string) -> result<string, error>;
 
     /// The set of errors which may be raised by functions in this interface.
     variant error {

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,19 +1,19 @@
-package fermyon:spin@2.0.0
+package fermyon:spin@2.0.0;
 
 /// The full world of a guest targeting an http-trigger
 world http-trigger {
-  include platform
-  export wasi:http/incoming-handler@0.2.0-rc-2023-10-18
+  include platform;
+  export wasi:http/incoming-handler@0.2.0-rc-2023-10-18;
 }
 
 /// The imports needed for a guest to run on a Spin host
 world platform {
-  import wasi:http/outgoing-handler@0.2.0-rc-2023-10-18
-  import llm
-  import redis
-  import postgres
-  import mysql
-  import sqlite
-  import key-value
-  import variables
+  import wasi:http/outgoing-handler@0.2.0-rc-2023-10-18;
+  import llm;
+  import redis;
+  import postgres;
+  import mysql;
+  import sqlite;
+  import key-value;
+  import variables;
 }


### PR DESCRIPTION
This commit updates the Wasmtime crate to 15.0.0 from the previous fork which was 14.0.4 plus some patches which are all present in the 15.0.0 release. The major consequence of this update, however, is that WASI proposals upstream in the `wasmtime-wasi` crate have moved from `rc-2023-10-18` to`rc-2023-11-10`. This new release candidate has breaking changes relative to the prior release candidate such as:

* Redesigned UDP send/receive
* Refactored HTTP errors
* Header-related HTTP methods now return a result instead of being infallible
* Removal of filesystem "modes" and permissions
* Some minor tweaks here and there about how things are represented along with some minor renamings

If this PR "only" updated the Wasmtime dependency then taht would mean that the previously supported snapshot, `rc-2023-10-18`, would no longer work. That would mean that preexisting binaries, plus the preexisting SDKs, would not work. To fix that this PR introduces the additional step of simultaneously supporting multiple WASI snapshots at the same time. This feature is only relevant until WASI reaches a stable release at which point support will likely move into Wasmtime itself for supporting multiple compatible releases. For now though leading up to that point in time Spin is the one which will need to support multiple incompatible releases.

The general idea behind supporting multiple snapshots of WASI in this PR is to vendor all the WITs of the old version and generate bindings using the latest `wasmtime::component::bindgen!` macro. This generates a set of bindings and traits all targetting the old version of WASI which are distinct from the bindings in the `wasmtime-wasi` crate. These traits are then all implemented, in Rust, in terms of the latest traits in the `wasmtime-wasi` crate. This effectively provides a bridge  between the two snapshots. Most functionality is a pass-through but more significant changes such as with UDP end up defining a custom resource just for this adaptation. The source of truth for each implementation still lives in the `wasmtime-wasi` crate, however. This adaptation is then registered by adding the old snapshot namespace to a `wasmtime::component::Linker` in addition to the latest supported snapshot.

Currently this adaptation layer is housed in one large file and is not exactly the prettiest thing to read or write. It's a pain to get working the first time but the hope is that maintenance over time won't be so bad. It's additionally also expected that this adaptation won't need to continue to be redone between WASI 0.2.0 and 0.2.1 for example, as that would be handled internally by Wasmtime.

Other changes in this PR are:

* Wasmtime now requires semicolons in WIT files, so lots of semicolons are added.
* A more complete copy of the WITs for `rc-2023-10-18` are added and vendored to generate full bindings.
* In addition to imports exports are also allowed to be either the old-or-new so the invocation of the HTTP trigger now works with either the old or new snapshot.

One major consequence of this PR at this time is that the SDKs are not updated to the newest snapshot of WASI. Not because there's a reason not to do that, moreso this is showcasing how the upgrades to the SDK don't have to happen in lockstep with Wasmtime. A future PR can vendor all the WITs for the latest snapshot and move the SDKs to the new WITs.