### PR TITLE
Add async support to the rust-sdk router

### DIFF
--- a/examples/http-rust-router/src/lib.rs
+++ b/examples/http-rust-router/src/lib.rs
@@ -8,23 +8,29 @@ use spin_sdk::{
 #[http_component]
 fn handle_route(req: Request) -> Response {
     let mut router = Router::new();
-    router.get("/hello/:planet", api::hello_planet);
-    router.any("/*", api::echo_wildcard);
+    router.get("/goodbye/:planet", api::goodbye_planet);
+    router.get_async("/hello/:planet", api::hello_planet);
+    router.any_async("/*", api::echo_wildcard);
     router.handle(req)
 }
 
 mod api {
     use super::*;
 
-    // /hello/:planet
-    pub fn hello_planet(_req: Request, params: Params) -> Result<impl IntoResponse> {
+    // /goodbye/:planet
+    pub fn goodbye_planet(_req: Request, params: Params) -> Result<impl IntoResponse> {
         let planet = params.get("planet").expect("PLANET");
+        Ok(Response::new(200, planet.to_string()))
+    }
 
+    // /hello/:planet
+    pub async fn hello_planet(_req: Request, params: Params) -> Result<impl IntoResponse> {
+        let planet = params.get("planet").expect("PLANET");
         Ok(Response::new(200, planet.to_string()))
     }
 
     // /*
-    pub fn echo_wildcard(_req: Request, params: Params) -> Result<impl IntoResponse> {
+    pub async fn echo_wildcard(_req: Request, params: Params) -> Result<impl IntoResponse> {
         let capture = params.wildcard().unwrap_or_default();
         Ok(Response::new(200, capture.to_string()))
     }


### PR DESCRIPTION
This PR adds support for `async` functions/closures to be registered with the rust-sdk router. I update the `http-rust-router` example to demonstrate how to register `async` handlers using the suite of `*_async` registration methods on the router. Additionally the example demonstrates that you can register synchronous handlers along side asynchronous handlers.

A notable omission here is the lack of an `async` equivalent to the `http_router!` macro. Open for feedback on whether folks think this is a worthwhile pursuit. Ideally one could hint in the macro which registration method to use (e.g. `get` or `get_async`), for example:

```
async fn hello_planet(_req: Request, params: Params) -> anyhow::Result<impl IntoResponse> {
        let planet = params.get("planet").expect("PLANET");
        Ok(Response::new(200, planet.to_string()))
}

let router = http_router! {
        @async GET "/hello/:planet" => api::hello_planet, // --> calls router.get_async(...)
        _   "/*" => |_req: Request, params| {
            let capture = params.wildcard().unwrap_or_default();
            Response::new(200, capture.to_string())
        }
};
```

Closes #2114 