### PR TITLE
fix(trigger): don't panic if a component is not attached to a trigger

### DIFF
--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -250,6 +250,12 @@ impl<Executor: TriggerExecutor> TriggerAppEngine<Executor> {
                         .await
                         .with_context(|| format!("Failed to instantiate component '{id}'"))?,
                 );
+            } else {
+                tracing::warn!(
+                    "component '{id}' is not used by any triggers in app '{app_name}'",
+                    id = id,
+                    app_name = app_name
+                )
             }
         }
 

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -243,12 +243,14 @@ impl<Executor: TriggerExecutor> TriggerAppEngine<Executor> {
         let mut component_instance_pres = HashMap::default();
         for component in app.borrowed().components() {
             let id = component.id();
-            component_instance_pres.insert(
-                id.to_owned(),
-                Executor::instantiate_pre(&engine, &component, trigger_configs.get(id).unwrap())
-                    .await
-                    .with_context(|| format!("Failed to instantiate component '{id}'"))?,
-            );
+            if let Some(config) = trigger_configs.get(id) {
+                component_instance_pres.insert(
+                    id.to_owned(),
+                    Executor::instantiate_pre(&engine, &component, config)
+                        .await
+                        .with_context(|| format!("Failed to instantiate component '{id}'"))?,
+                );
+            }
         }
 
         Ok(Self {


### PR DESCRIPTION
Instead of instantiate trigger for every component, we should only instantiate trigger that has attached to a component. This fixes #2130 