### PR TITLE
retry http assertions a few times before failing

### DIFF
--- a/crates/e2e-testing/src/http_asserts.rs
+++ b/crates/e2e-testing/src/http_asserts.rs
@@ -6,15 +6,13 @@ use std::thread::sleep;
 use std::time::Duration;
 
 pub async fn assert_status(url: &str, expected: u16) -> Result<()> {
-    let mut count = 0;
-    while count < 5 {
+    for _ in 0..5 {
         let result = assert_status_once(url, expected).await;
         if result.is_ok() {
             return Ok(());
         }
 
         println!("assert_status error is {:?}", result.err());
-        count += 1;
         sleep(Duration::from_secs(2))
     }
 
@@ -41,8 +39,7 @@ pub async fn assert_http_response(
     expected_headers: &[(&str, &str)],
     expected_body: Option<&str>,
 ) -> Result<()> {
-    let mut count = 0;
-    while count < 5 {
+    for _ in 0..5 {
         let result = assert_http_response_once(
             url,
             method.clone(),
@@ -57,7 +54,6 @@ pub async fn assert_http_response(
         }
 
         println!("assert_http_response error is {:?}", result.err());
-        count += 1;
         sleep(Duration::from_secs(2))
     }
 

--- a/crates/e2e-testing/src/http_asserts.rs
+++ b/crates/e2e-testing/src/http_asserts.rs
@@ -2,8 +2,26 @@ use crate::ensure_eq;
 use anyhow::Result;
 use reqwest::{Method, Request, Response};
 use std::str;
+use std::thread::sleep;
+use std::time::Duration;
 
 pub async fn assert_status(url: &str, expected: u16) -> Result<()> {
+    let mut count = 0;
+    while count < 5 {
+        let result = assert_status_once(url, expected).await;
+        if result.is_ok() {
+            return Ok(());
+        }
+
+        println!("assert_status error is {:?}", result.err());
+        count += 1;
+        sleep(Duration::from_secs(2))
+    }
+
+    panic!("failed assert_status after 5 retries")
+}
+
+pub async fn assert_status_once(url: &str, expected: u16) -> Result<()> {
     let resp = make_request(Method::GET, url, "").await?;
     let status = resp.status();
 
@@ -16,6 +34,37 @@ pub async fn assert_status(url: &str, expected: u16) -> Result<()> {
 }
 
 pub async fn assert_http_response(
+    url: &str,
+    method: Method,
+    body: &str,
+    expected: u16,
+    expected_headers: &[(&str, &str)],
+    expected_body: Option<&str>,
+) -> Result<()> {
+    let mut count = 0;
+    while count < 5 {
+        let result = assert_http_response_once(
+            url,
+            method.clone(),
+            body,
+            expected,
+            expected_headers,
+            expected_body,
+        )
+        .await;
+        if result.is_ok() {
+            return Ok(());
+        }
+
+        println!("assert_http_response error is {:?}", result.err());
+        count += 1;
+        sleep(Duration::from_secs(2))
+    }
+
+    panic!("failed assert_http_response after 5 retries")
+}
+
+pub async fn assert_http_response_once(
     url: &str,
     method: Method,
     body: &str,


### PR DESCRIPTION
we had a few occurences of the http assertions failing for no apparent reason, which works on re-running the tests. adding the retries here to ensure they fail only if they are real issues.