### PR TITLE
Fix two triggers not being able to use same component

### DIFF
--- a/tests/http/simple-spin-rust/double-trouble.toml
+++ b/tests/http/simple-spin-rust/double-trouble.toml
@@ -1,0 +1,22 @@
+spin_manifest_version = 2
+
+[application]
+name = "spin-hello-world"
+version = "1.0.0"
+
+[[trigger.http]]
+route = "/route1"
+component = "hello"
+
+[[trigger.http]]
+route = "/route2"
+component = "hello" # intentionally pointing to same component
+
+[variables]
+object = { default = "teapot" }
+
+[component.hello]
+source = "target/wasm32-wasi/release/simple_spin_rust.wasm"
+files = [{ source = "assets", destination = "/" }]
+[component.hello.variables]
+message = "I'm a {{object}}"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -64,6 +64,22 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn test_duplicate_rust_local() -> Result<()> {
+        let s = SpinTestController::with_manifest(
+            &format!("{}/{}", RUST_HTTP_INTEGRATION_TEST, "double-trouble.toml"),
+            &[],
+            &[],
+        )
+        .await?;
+
+        assert_status(&s, "/route1", 200).await?;
+        assert_status(&s, "/route2", 200).await?;
+        assert_status(&s, "/thisshouldfail", 404).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_timer_trigger() -> Result<()> {
         use std::fs;
 


### PR DESCRIPTION
Fixes #2143.

The problem occurred because the list of trigger configurations was passed through a hash map indexed on component ID, which with Manifest 2 changes to break the 1-1 trigger-component mapping could result in overwrites.  The map was only needed when pre-instantiating components according to component ID.  With this PR, trigger configurations are retained as a vector, which is scanned during pre-instantiation - if we are concerned about the lookup cost (N^2) of doing a linear search per component, then we can make a temporary map to avoid it.

There is a subtler issue which this PR does not address.  The pre-instantiation map (`TriggerAppEngine::component_instance_pres`) is a map from component ID to pre-instance - i.e. one pre-instance per component.  But the function that constructs pre-instances (`Executor::instantiate_pre`) accepts a `Self::TriggerConfig` parameter - meaning a trigger type could specify different instantiation parameters for the same component.  The only current example is this rather absurd one:

```toml
[[trigger.http]]
route = "/1"
component = "foo"

[[trigger.http]]
route = "/2"
component = "foo"
executor = { type = "wagi" }
```

So it is currently a theoretical problem rather than a practical one.  I don't tackle it here because it looks rather invasive and higher risk than we need for the practical case, but would be good to consider.
