### PR TITLE
Fix Windows error with HTTP components

### DIFF
--- a/crates/loader/src/http.rs
+++ b/crates/loader/src/http.rs
@@ -38,7 +38,9 @@ pub async fn verified_download(url: &str, digest: &str, dest: &Path) -> Result<(
     );
 
     // Move to final destination
-    temp_path.persist_noclobber(dest)?;
+    temp_path
+        .persist_noclobber(dest)
+        .with_context(|| format!("Failed to save download from {url} to {}", dest.display()))?;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #2112.

The proposed fix is, on Windows, to save scheme-prefixed digests using an underscore separator, so a digest of `sha256:1234` becomes a file name of `sha256_1234`.  Mac and Linux would not be affected.

That said, there seems to be an oddity in the registry cache where some entries have the prefix and others don't - I think HTTP-downloaded components have the prefix and files from OCI don't?  It would be nicer to change it to remove the prefix before saving HTTP-downloaded components.  But that ended up involving more invasive changes to the download verifier, so I backed it out as being higher risk.  I can explore it if people have a strong preference.
