### PR TITLE
ci(release.yml): add crates publishing job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,3 +469,23 @@ jobs:
           file: _dist/spin-${{ env.RELEASE_VERSION }}-static-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           tag: ${{ github.ref }}
           prerelease: ${{ steps.release-version.outputs.prerelease == 'true' }}
+
+  crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: build-and-sign
+    if: |
+      startsWith(github.ref, 'refs/tags/v') &&
+      github.repository_owner == 'fermyon'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Publish spin-macro to crates.io
+        working-directory: ./sdk/rust/macro
+        run: |
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish spin-sdk to crates.io
+        working-directory: ./sdk/rust
+        run: |
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/docs/content/release-process.md
+++ b/docs/content/release-process.md
@@ -14,6 +14,7 @@ To cut a major / minor release of Spin, you will need to do the following:
 
 1. Switch to the release branch locally and update versions (e.g. `2.0.0-pre0` could be `2.0.0`).
    - Bump the version in Spin's `Cargo.toml`
+   - Bump the `spin-macro` version to the same in the spin-sdk's [Cargo.toml](../../sdk/rust/Cargo.toml)
    - Run `make build update-cargo-locks` so that `Cargo.lock` and example/test `Cargo.lock` files are updated
 
    PR these changes to the release branch ensuring that pull request has a base corresponding to the release branch (e.g. `v2.0`).
@@ -61,6 +62,7 @@ $ ./.github/gh-backport.sh <pull-request> <branch-name>
 
 1. Switch to the release branch locally and update versions (e.g. `2.0.0` could be `2.0.1`).
    - Bump the version in Spin's `Cargo.toml`
+   - Bump the `spin-macro` version to the same in the spin-sdk's [Cargo.toml](../../sdk/rust/Cargo.toml)
    - Run `make build update-cargo-locks` so that `Cargo.lock` and example/test `Cargo.lock` files are updated
 
    PR these changes to the release branch ensuring that pull request has a base corresponding to the release branch (e.g. `v2.0`).
@@ -99,6 +101,7 @@ Otherwise, switch to the branch locally.
 
 1. Update the Spin version with `-rc.N` where `N` is the release candidate number (e.g. `2.0.0-pre0` could be `2.0.0-rc.1`).
    - Bump the version in Spin's `Cargo.toml`
+   - Bump the `spin-macro` version to the same in the spin-sdk's [Cargo.toml](../../sdk/rust/Cargo.toml)
    - Run `make build update-cargo-locks` so that `Cargo.lock` and example/test `Cargo.lock` files are updated
 
    PR these changes to the release branch ensuring that pull request has a base corresponding to the release branch (e.g. `v2.0`).


### PR DESCRIPTION
- Adds a step to publish the `spin-sdk` crate on each v* release tag

Depends on https://github.com/fermyon/spin/pull/2151

TODO:
  - [x] Open Question: What to do re: publishing the `spin-macro` crate, a dependency of the `spin-sdk` crate?
     -  Keep `spin-macro` crate version separate from workspace/spin-sdk version (Currently it is [0.1.0](https://crates.io/crates/spin-macro))
         - Manually publish crate when this version is bumped, manually create PR to update crate version in spin-sdk's Cargo.toml
         - Add automation to publish crate when this version is bumped (could be slightly tricky if not associated with a git tag), potentially also add automation to create a PR to spin-sdk's Cargo.toml to rev the version
     - Align `spin-macro` crate version with workspace version (i.e. release tag version) and publish prior to publishing `spin-sdk` (Haven't tested this, will the approach work via back-to-back jobs in a GH workflow?)