### PR TITLE
Fix double backslashes in printed Windows paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5910,6 +5910,7 @@ dependencies = [
  "rand 0.8.5",
  "safetensors",
  "serde",
+ "spin-common",
  "spin-core",
  "spin-llm",
  "spin-world",

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -6,7 +6,7 @@ mod manifest;
 
 use anyhow::{anyhow, bail, Context, Result};
 use manifest::ComponentBuildInfo;
-use spin_common::paths::parent_dir;
+use spin_common::{paths::parent_dir, ui::quoted_path};
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -19,7 +19,12 @@ use crate::manifest::component_build_configs;
 pub async fn build(manifest_file: &Path, component_ids: &[String]) -> Result<()> {
     let components = component_build_configs(manifest_file)
         .await
-        .with_context(|| format!("Cannot read manifest file from {}", manifest_file.display()))?;
+        .with_context(|| {
+            format!(
+                "Cannot read manifest file from {}",
+                quoted_path(manifest_file)
+            )
+        })?;
     let app_dir = parent_dir(manifest_file)?;
 
     let components_to_build = if component_ids.is_empty() {
@@ -69,7 +74,7 @@ fn build_component(build_info: ComponentBuildInfo, app_dir: &Path) -> Result<()>
             );
             let workdir = construct_workdir(app_dir, b.workdir.as_ref())?;
             if b.workdir.is_some() {
-                println!("Working directory: {:?}", workdir);
+                println!("Working directory: {}", quoted_path(&workdir));
             }
 
             let exit_status = Exec::shell(&b.command)

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -13,4 +13,5 @@ pub mod data_dir;
 pub mod paths;
 pub mod sha256;
 pub mod sloth;
+pub mod ui;
 pub mod url;

--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -3,6 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use std::path::{Path, PathBuf};
 
+use crate::ui::quoted_path;
+
 /// The name given to the default manifest file.
 pub const DEFAULT_MANIFEST_FILE: &str = "spin.toml";
 
@@ -40,7 +42,7 @@ pub fn parent_dir(path: impl AsRef<Path>) -> Result<PathBuf> {
     let path = path.as_ref();
     let mut parent = path
         .parent()
-        .with_context(|| format!("No parent directory for path {path:?}"))?;
+        .with_context(|| format!("No parent directory for path {}", quoted_path(path)))?;
     if parent == Path::new("") {
         parent = Path::new(".");
     }

--- a/crates/common/src/ui.rs
+++ b/crates/common/src/ui.rs
@@ -1,0 +1,10 @@
+//! Functions supporting common UI behaviour and standards
+
+use std::path::Path;
+
+/// Renders a Path with double quotes. This is the standard
+/// for displaying paths in Spin. It is preferred to the Debug
+/// format because the latter doubles up backlashes on Windows.
+pub fn quoted_path(path: impl AsRef<Path>) -> impl std::fmt::Display {
+    format!("\"{}\"", path.as_ref().display())
+}

--- a/crates/doctor/src/lib.rs
+++ b/crates/doctor/src/lib.rs
@@ -5,6 +5,7 @@ use std::{collections::VecDeque, fmt::Debug, fs, path::PathBuf};
 
 use anyhow::{ensure, Context, Result};
 use async_trait::async_trait;
+use spin_common::ui::quoted_path;
 use toml_edit::Document;
 
 /// Diagnoses for app manifest format problems.
@@ -88,15 +89,23 @@ impl PatientApp {
         let path = manifest_path.into();
         ensure!(
             path.is_file(),
-            "No Spin app manifest file found at {path:?}"
+            "No Spin app manifest file found at {}",
+            quoted_path(&path),
         );
 
-        let contents = fs::read_to_string(&path)
-            .with_context(|| format!("Couldn't read Spin app manifest file at {path:?}"))?;
+        let contents = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "Couldn't read Spin app manifest file at {}",
+                quoted_path(&path)
+            )
+        })?;
 
-        let manifest_doc: Document = contents
-            .parse()
-            .with_context(|| format!("Couldn't parse manifest file at {path:?} as valid TOML"))?;
+        let manifest_doc: Document = contents.parse().with_context(|| {
+            format!(
+                "Couldn't parse manifest file at {} as valid TOML",
+                quoted_path(&path)
+            )
+        })?;
 
         Ok(Self {
             manifest_path: path,

--- a/crates/doctor/src/manifest.rs
+++ b/crates/doctor/src/manifest.rs
@@ -2,6 +2,7 @@ use std::fs;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use spin_common::ui::quoted_path;
 use toml_edit::Document;
 
 use crate::Treatment;
@@ -37,8 +38,9 @@ impl<T: ManifestTreatment + Sync> Treatment for T {
         let after = after_doc.to_string();
         let diff = similar::udiff::unified_diff(Default::default(), &before, &after, 1, None);
         Ok(format!(
-            "Apply the following diff to {:?}:\n{}",
-            patient.manifest_path, diff
+            "Apply the following diff to {}:\n{}",
+            quoted_path(&patient.manifest_path),
+            diff
         ))
     }
 
@@ -47,6 +49,6 @@ impl<T: ManifestTreatment + Sync> Treatment for T {
         self.treat_manifest(doc).await?;
         let path = &patient.manifest_path;
         fs::write(path, doc.to_string())
-            .with_context(|| format!("failed to write fixed manifest to {path:?}"))
+            .with_context(|| format!("failed to write fixed manifest to {}", quoted_path(path)))
     }
 }

--- a/crates/doctor/src/manifest/upgrade.rs
+++ b/crates/doctor/src/manifest/upgrade.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+use spin_common::ui::quoted_path;
 use spin_manifest::{compat::v1_to_v2_app, schema::v1::AppManifestV1, ManifestVersion};
 use toml_edit::{de::from_document, ser::to_document, Item, Table};
 
@@ -97,7 +98,10 @@ impl Treatment for UpgradeDiagnosis {
         let v1_backup_path = patient.manifest_path.with_extension("toml.v1_backup");
         std::fs::rename(&patient.manifest_path, &v1_backup_path)
             .context("failed to back up existing manifest")?;
-        println!("Version 1 manifest backed up to {v1_backup_path:?}.");
+        println!(
+            "Version 1 manifest backed up to {}.",
+            quoted_path(&v1_backup_path)
+        );
 
         // Write new V2 manifest
         std::fs::write(&patient.manifest_path, v2_doc.to_string())

--- a/crates/doctor/src/wasm/missing.rs
+++ b/crates/doctor/src/wasm/missing.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 use anyhow::{ensure, Context, Result};
 use async_trait::async_trait;
+use spin_common::ui::quoted_path;
 
 use crate::{Diagnosis, PatientApp, Treatment};
 
@@ -52,7 +53,10 @@ impl Diagnosis for WasmMissing {
         let Some(rel_path) = self.0.source_path() else {
             unreachable!("unsupported source");
         };
-        format!("Component {id:?} source {rel_path:?} is missing")
+        format!(
+            "Component {id:?} source {} is missing",
+            quoted_path(rel_path)
+        )
     }
 
     fn treatment(&self) -> Option<&dyn Treatment> {

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -18,6 +18,7 @@ num_cpus = "1"
 rand = "0.8.5"
 safetensors = "0.3.3"
 serde = { version = "1.0.150", features = ["derive"] }
+spin-common = { path = "../common" }
 spin-core = { path = "../core" }
 spin-llm = { path = "../llm" }
 spin-world = { path = "../world" }

--- a/crates/oci/src/auth.rs
+++ b/crates/oci/src/auth.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use oci_distribution::secrets::RegistryAuth;
 use serde::{Deserialize, Serialize};
+use spin_common::ui::quoted_path;
 
 #[derive(Serialize, Deserialize)]
 pub struct AuthConfig {
@@ -84,7 +85,7 @@ impl AuthConfig {
     async fn load(p: &Path) -> Result<Self> {
         let contents = tokio::fs::read_to_string(&p).await?;
         serde_json::from_str(&contents)
-            .with_context(|| format!("cannot load authentication file {:?}", p))
+            .with_context(|| format!("cannot load authentication file {}", quoted_path(p)))
     }
 
     async fn save(&self, p: &Path) -> Result<()> {
@@ -95,6 +96,6 @@ impl AuthConfig {
         }
         tokio::fs::write(&p, &serde_json::to_vec_pretty(&self)?)
             .await
-            .with_context(|| format!("cannot save authentication file {:?}", p))
+            .with_context(|| format!("cannot save authentication file {}", quoted_path(p)))
     }
 }

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -12,6 +12,7 @@ use oci_distribution::{
 };
 use reqwest::Url;
 use spin_common::sha256;
+use spin_common::ui::quoted_path;
 use spin_common::url::parse_file_url;
 use spin_loader::cache::Cache;
 use spin_loader::FilesMountStrategy;
@@ -148,11 +149,17 @@ impl Client {
                 if archive_layers {
                     self.push_archive_layer(&source, &mut files, &mut layers)
                         .await
-                        .context(format!("cannot push archive layer for source {:?}", source))?;
+                        .context(format!(
+                            "cannot push archive layer for source {}",
+                            quoted_path(&source)
+                        ))?;
                 } else {
                     self.push_file_layers(&source, &mut files, &mut layers)
                         .await
-                        .context(format!("cannot push file layers for source {:?}", source))?;
+                        .context(format!(
+                            "cannot push file layers for source {}",
+                            quoted_path(&source)
+                        ))?;
                 }
             }
             c.files = files;

--- a/crates/oci/src/utils.rs
+++ b/crates/oci/src/utils.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use async_compression::tokio::bufread::GzipDecoder;
 use async_compression::tokio::write::GzipEncoder;
 use async_tar::Archive;
+use spin_common::ui::quoted_path;
 use std::path::{Path, PathBuf};
 
 /// Create a compressed archive of source, returning its path in working_dir
@@ -15,8 +16,8 @@ pub async fn archive(source: &Path, working_dir: &Path) -> Result<PathBuf> {
     let tar_gz = tokio::fs::File::create(tar_gz_path.as_path())
         .await
         .context(format!(
-            "Unable to create tar archive for source {:?}",
-            source
+            "Unable to create tar archive for source {}",
+            quoted_path(source)
         ))?;
 
     // Create encoder
@@ -31,8 +32,8 @@ pub async fn archive(source: &Path, working_dir: &Path) -> Result<PathBuf> {
         .append_dir_all(".", source)
         .await
         .context(format!(
-            "Unable to create tar archive for source {:?}",
-            source
+            "Unable to create tar archive for source {}",
+            quoted_path(source)
         ))?;
     // Finish writing the archive
     tar_builder.finish().await?;

--- a/crates/trigger/src/runtime_config/key_value.rs
+++ b/crates/trigger/src/runtime_config/key_value.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
 use crate::{runtime_config::RuntimeConfig, TriggerHooks};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
+use spin_common::ui::quoted_path;
 use spin_key_value::{
     CachingStoreManager, DelegatingStoreManager, KeyValueComponent, StoreManager,
     KEY_VALUE_STORES_KEY,
@@ -159,7 +160,7 @@ impl TriggerHooks for KeyValuePersistenceMessageHook {
             }
             KeyValueStoreOpts::Spin(store_opts) => {
                 if let Some(path) = &store_opts.path {
-                    println!("Storing default key-value data to {path:?}");
+                    println!("Storing default key-value data to {}", quoted_path(path));
                 } else {
                     println!("Using in-memory default key-value store; data will not be saved!");
                 }

--- a/crates/trigger/src/runtime_config/sqlite.rs
+++ b/crates/trigger/src/runtime_config/sqlite.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use crate::{runtime_config::RuntimeConfig, TriggerHooks};
 use anyhow::Context;
+use spin_common::ui::quoted_path;
 use spin_sqlite::{Connection, ConnectionsStore, SqliteComponent, DATABASES_KEY};
 
 use super::RuntimeConfigOpts;
@@ -178,7 +179,7 @@ impl TriggerHooks for SqlitePersistenceMessageHook {
         match runtime_config.default_sqlite_opts() {
             SqliteDatabaseOpts::Spin(s) => {
                 if let Some(path) = &s.path {
-                    println!("Storing default SQLite data to {path:?}");
+                    println!("Storing default SQLite data to {}", quoted_path(path));
                 } else {
                     println!("Using in-memory default SQLite database; data will not be saved!");
                 }

--- a/crates/trigger/src/stdio.rs
+++ b/crates/trigger/src/stdio.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use spin_common::ui::quoted_path;
 use tokio::io::AsyncWrite;
 
 use crate::{runtime_config::RuntimeConfig, TriggerHooks};
@@ -61,7 +62,7 @@ impl StdioLoggingTriggerHooks {
         let log_path = log_dir.join(format!("{sanitized_component_id}_{log_suffix}.txt"));
         let follow = self.follow_components.should_follow(component_id);
         ComponentStdioWriter::new(&log_path, follow)
-            .with_context(|| format!("Failed to open log file {log_path:?}"))
+            .with_context(|| format!("Failed to open log file {}", quoted_path(&log_path)))
     }
 
     fn validate_follows(&self, app: &spin_app::App) -> anyhow::Result<()> {
@@ -97,9 +98,9 @@ impl TriggerHooks for StdioLoggingTriggerHooks {
         if let Some(dir) = &self.log_dir {
             // Ensure log dir exists if set
             std::fs::create_dir_all(dir)
-                .with_context(|| format!("Failed to create log dir {dir:?}"))?;
+                .with_context(|| format!("Failed to create log dir {}", quoted_path(dir)))?;
 
-            println!("Logging component stdio to {:?}", dir.join(""))
+            println!("Logging component stdio to {}", quoted_path(dir.join("")))
         }
 
         Ok(())

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::{CommandFactory, Parser};
 use reqwest::Url;
 use spin_app::locked::LockedApp;
+use spin_common::ui::quoted_path;
 use spin_loader::FilesMountStrategy;
 use spin_oci::OciLoader;
 use spin_trigger::cli::{SPIN_LOCAL_APP_DIR, SPIN_LOCKED_URL, SPIN_WORKING_DIR};
@@ -284,9 +285,9 @@ impl UpCommand {
             serde_json::to_vec_pretty(&locked_app).context("failed to serialize locked app")?;
         tokio::fs::write(&locked_path, locked_app_contents)
             .await
-            .with_context(|| format!("failed to write {:?}", locked_path))?;
+            .with_context(|| format!("failed to write {}", quoted_path(&locked_path)))?;
         let locked_url = Url::from_file_path(&locked_path)
-            .map_err(|_| anyhow!("cannot convert to file URL: {locked_path:?}"))?
+            .map_err(|_| anyhow!("cannot convert to file URL: {}", quoted_path(&locked_path)))?
             .to_string();
 
         Ok(locked_url)
@@ -336,7 +337,12 @@ impl UpCommand {
                 };
                 spin_loader::from_file(&manifest_path, files_mount_strategy, None)
                     .await
-                    .with_context(|| format!("Failed to load manifest from {manifest_path:?}"))
+                    .with_context(|| {
+                        format!(
+                            "Failed to load manifest from {}",
+                            quoted_path(&manifest_path)
+                        )
+                    })
             }
             ResolvedAppSource::OciRegistry { locked_app } => Ok(locked_app),
         }

--- a/src/commands/up/app_source.rs
+++ b/src/commands/up/app_source.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::ensure;
+use spin_common::ui::quoted_path;
 use spin_locked_app::locked::LockedApp;
 use spin_manifest::schema::v2::AppManifest;
 
@@ -60,7 +61,7 @@ impl AppSource {
 impl std::fmt::Display for AppSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::File(path) => write!(f, "local app {path:?}"),
+            Self::File(path) => write!(f, "local app {}", quoted_path(path)),
             Self::OciRegistry(reference) => write!(f, "remote app {reference:?}"),
             Self::Unresolvable(s) => write!(f, "unknown app source: {s:?}"),
             Self::None => write!(f, "<no source>"),


### PR DESCRIPTION
Fixes #2158.

This changes user-facing messages (errors and prints; I skipped logs) to print paths correctly on Windows.

```
# Before
Logging component stdio to ".\\target\\..\\..\\dirmounttest\\.spin\\logs\\"
# After
Logging component stdio to .\target\..\..\dirmounttest\.spin\logs\
```

