### PR TITLE
Fix "duplicate package `key-value`" warning in Spin SDK git reference

### DIFF
--- a/tests/testcases/key-value/Cargo.lock
+++ b/tests/testcases/key-value/Cargo.lock
@@ -212,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "key-value"
+name = "key-value-testcase"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/tests/testcases/key-value/Cargo.toml
+++ b/tests/testcases/key-value/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "key-value"
+name = "key-value-testcase"
 version = "0.1.0"
 edition = "2021"
 

--- a/tests/testcases/key-value/spin.toml
+++ b/tests/testcases/key-value/spin.toml
@@ -8,7 +8,7 @@ version = "1.0.0"
 [[component]]
 id = "hello"
 key_value_stores = ["default"]
-source = "target/wasm32-wasi/release/key_value.wasm"
+source = "target/wasm32-wasi/release/key_value_testcase.wasm"
 [component.trigger]
 route = "/..."
 [component.build]


### PR DESCRIPTION
This will drop being an issue once we are fully on `crates.io` (it would be nice, for those times when we want to test with main, but it will stop being user-facing).  So if the crates.io stuff lands in time then we can close this.
