### PR TITLE
ci(release): only upload spin static bin to release if semver tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,6 +463,7 @@ jobs:
           path: _dist/spin-${{ env.RELEASE_VERSION }}-static-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
       - name: upload binary to Github release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Only upload spin static bin to GH release if associated with a v* tag

Without this fix, merges to main will create a [main](https://github.com/fermyon/spin/releases/tag/main) tag and release (~~which we should delete~~ which I've deleted).

The spin static `canary` builds will still be collected as normal and attached to the canary release during the [update-canary](https://github.com/fermyon/spin/blob/main/.github/workflows/release.yml#L252-L281) job.

Test on fork: https://github.com/vdice/spin/actions/runs/7201886432; see also https://github.com/vdice/spin/releases/tag/canary