### PR TITLE
Map correct token count for llm:InferencingResult

### DIFF
--- a/crates/world/src/conversions.rs
+++ b/crates/world/src/conversions.rs
@@ -191,7 +191,7 @@ mod llm {
                 text: value.text,
                 usage: v1::llm::InferencingUsage {
                     prompt_token_count: value.usage.prompt_token_count,
-                    generated_token_count: value.usage.prompt_token_count,
+                    generated_token_count: value.usage.generated_token_count,
                 },
             }
         }


### PR DESCRIPTION
Used `generated_token_count` when mapping to `InferencingResult.usage.generated_token_count`