### PR TITLE
docs(release-process): small amendment

### DIFF
--- a/docs/content/release-process.md
+++ b/docs/content/release-process.md
@@ -42,7 +42,7 @@ To cut a major / minor release of Spin, you will need to do the following:
     > When the [release action] completes, binary artifacts and checksums will be
     > automatically uploaded to the GitHub release.
 
-1. Switch back to `main` and update the `Cargo.toml` and `templates/Makefile` versions again, this time to e.g. `2.1.0-pre0` if `2.1.0` is the next anticipated release.
+1. Switch back to `main` and update the `Cargo.toml` and `spin-macro` versions again, this time to e.g. `2.1.0-pre0` if `2.1.0` is the next anticipated release.
    - Run `make build update-cargo-locks` so that `Cargo.lock` and example/test `Cargo.lock` files are updated
    - PR this to `main`
    - See [sips/011-component-versioning.md](sips/011-component-versioning.md)


### PR DESCRIPTION
- We no longer update `templates/Makefile`, but we do now need to bump the `spin-macro` crate version in the `spin-sdk` crate Cargo.toml.