### PR TITLE
ci(release): consolidate GH release logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
       id-token: write
       # needed to upload artifacts to a GH release
       contents: write
-    outputs:
-      prerelease: ${{ steps.release-version.outputs.prerelease }}
     strategy:
       matrix:
         config:
@@ -116,14 +114,6 @@ jobs:
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
           echo 'rustflags = ["-Ctarget-feature=+fp16"]' >> ${HOME}/.cargo/config.toml
 
-      - name: Check if pre-release
-        id: release-version
-        shell: bash
-        run: |
-          [[ "${{ env.RELEASE_VERSION }}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]] && \
-            echo "prerelease=false" >> "$GITHUB_OUTPUT" || \
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-
       - name: build release
         shell: bash
         run: cargo build --release ${{ matrix.config.extraArgs }}
@@ -166,30 +156,12 @@ jobs:
           name: spin
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
-      - name: upload binary to Github release
-        if: startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows'
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-          tag: ${{ github.ref }}
-          prerelease: ${{ steps.release-version.outputs.prerelease == 'true' }}
-
       - name: upload binary as GitHub artifact
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v3
         with:
           name: spin
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
-
-      - name: upload binary to Github release
-        if: startsWith(github.ref, 'refs/tags/v') &&  runner.os == 'Windows'
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
-          tag: ${{ github.ref }}
-          prerelease: ${{ steps.release-version.outputs.prerelease == 'true' }}
 
       - name: Configure AWS Credentials
         if: |
@@ -240,45 +212,47 @@ jobs:
           name: spin
           path: checksums-${{ env.RELEASE_VERSION }}.txt
 
-      - name: upload checksums to Github release
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: checksums-${{ env.RELEASE_VERSION }}.txt
-          tag: ${{ github.ref }}
-          prerelease: ${{ needs.build-and-sign.outputs.prerelease == 'true' }}
-
-  update-canary:
-    name: update canary release
+  create-gh-release:
+    name: create GitHub release
     runs-on: ubuntu-latest
     needs: checksums
-    if: github.ref == 'refs/heads/main'
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Download release assets
+      - uses: actions/checkout@v3
+
+      - name: download release assets
         uses: actions/download-artifact@v3
         with:
           name: spin
+          path: _dist
 
-      - name: Delete canary tag
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: canary
-          delete_release: true
+      - name: check if pre-release
+        shell: bash
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]
+          then
+            echo "PRERELEASE=--prerelease" >> "$GITHUB_ENV"
+          fi
 
-      - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.13.0
-        with:
-          tag: canary
-          allowUpdates: true
-          prerelease: true
-          artifacts: "checksums-canary.txt,spin-canary*"
-          commit: ${{ github.sha }}
-          body: |
+      - name: create GitHub release (canary)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          gh release delete canary --cleanup-tag
+          gh release create canary _dist/* \
+            --title canary \
+            --prerelease \
+            --notes-file - <<- EOF
             This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
             It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.
+          EOF
+
+      - name: create GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          gh release create ${{ github.ref_name }} _dist/* \
+            --title ${{ github.ref_name }} \
+            --generate-notes ${{ env.PRERELEASE }}
 
   create-go-sdk-tag:
     name: create tag sdk/go/v*


### PR DESCRIPTION
- Consolidate logic around creation of the GH release for v* tag or canary
  - only create the release after all assets are ready to be uploaded (see https://github.com/fermyon/spin/issues/2049)
- Swap out third-party actions in favor of the [gh](https://cli.github.com/) cli

Workflow runs/releases from this PR:
- v* prerelease: [workflow run](https://github.com/vdice/spin/actions/runs/7228255514) / [release](https://github.com/vdice/spin/releases/tag/v2.1.0-vdice-test)
- v* release: [workflow run](https://github.com/vdice/spin/actions/runs/7228248785) / [release](https://github.com/vdice/spin/releases/tag/v99.99.99)
- canary: [workflow run](https://github.com/vdice/spin/actions/runs/7228250485) / [release](https://github.com/vdice/spin/releases/tag/canary)

Fixes https://github.com/fermyon/spin/issues/2049