### PR TITLE
Mutable access to request headers

### DIFF
--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -116,6 +116,16 @@ impl Request {
         self.headers.get(&name.to_lowercase())
     }
 
+    /// Set a header
+    pub fn set_header(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        self.headers.insert(
+            name.into(),
+            HeaderValue {
+                inner: HeaderValueRep::String(value.into()),
+            },
+        );
+    }
+
     /// The request body
     pub fn body(&self) -> &[u8] {
         &self.body


### PR DESCRIPTION
Fixes #2186.

This ended up being not symmetric with `Request::headers()` but I couldn't see a way to get closer (e.g. `iter_mut()` didn't seem like it would allow for inserts).  It also surfaces the implementation in what feels like a rather raw way.  @rylev Please feel free to close in favour of a better way if you have one, I'd love a learning opportunity!