### PR TITLE
remove workspace/all-targets from cross build cmd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,7 @@ jobs:
           rust-cache: true
 
       - name: Cargo Build
-        run: cross build --target ${{ matrix.config.target }} --workspace --release --all-targets --features openssl/vendored
+        run: cross build --target ${{ matrix.config.target }} --release --features openssl/vendored
         env:
           CARGO_INCREMENTAL: 0
           BUILD_SPIN_EXAMPLES: 0


### PR DESCRIPTION
it is a follow up of https://github.com/fermyon/spin/pull/2163#discussion_r1426791023, where we removed these from 'build.yml', but not from 'release.yml' GitHub actions. 