### PR TITLE
Rename 'Test Spin SDK - Rust' to 'Test Spin'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
 
 
   test-rust:
-    name: Test Spin SDK - Rust
+    name: Test Spin
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:


### PR DESCRIPTION
This does not test the SDK - it tests all of Spin.