### PR TITLE
chore(flake): Fix Darwin dependency on Accelerate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
             openssl
             pkg-config
             rustTarget
+          ] ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.Accelerate
           ];
 
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,10 @@
-
 {
   description = "Nix Devshell for Spin";
 
   inputs = {
-    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    flake-utils.url  = "github:numtide/flake-utils";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
@@ -16,9 +15,9 @@
           inherit system overlays;
         };
         rustTarget = pkgs.rust-bin.stable.latest.default.override {
-              extensions= [ "rust-src" "rust-analyzer" ];
-              targets = [ "wasm32-wasi" "wasm32-unknown-unknown" ];
-            };
+          extensions = [ "rust-src" "rust-analyzer" ];
+          targets = [ "wasm32-wasi" "wasm32-unknown-unknown" ];
+        };
       in
       with pkgs;
       {
@@ -33,7 +32,7 @@
 
           shellHook = ''
             '';
-        RUST_SRC_PATH = "${rustTarget}/lib/rustlib/src/rust/library";
+          RUST_SRC_PATH = "${rustTarget}/lib/rustlib/src/rust/library";
 
         };
       }


### PR DESCRIPTION
Follow up from: #2199 
We depend on Accelerate by default on Darwin to allow for metal-backed LLM inference. Nix requires us to explicitly include that in the closure we use to build the application.

Formatted at the same time to simplify ongoing maintenance.