### PR TITLE
feat(cli.rs): allow setting app log dir via SPIN_LOG_DIR env var

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -44,6 +44,7 @@ where
         name = APP_LOG_DIR,
         short = 'L',
         long = "log-dir",
+        env = "SPIN_LOG_DIR",
     )]
     pub log: Option<PathBuf>,
 


### PR DESCRIPTION
- Allows setting the app's log directory via an `SPIN_LOG_DIR` env var

Unsure if it was an intentional decision to _not_ allow setting via env var, though?

I happened to notice this when deploying to the OSS Fermyon Platform, using Hippo, which attempts to set this env var: https://github.com/deislabs/hippo/blob/main/src/Infrastructure/Services/NomadJobService.cs#L189