### PR TITLE
Abstract the runtime used in runtime tests so that it's not hardcoded as Spin

### DIFF
--- a/tests/runtime-tests/src/io.rs
+++ b/tests/runtime-tests/src/io.rs
@@ -1,0 +1,44 @@
+use std::io::Read;
+
+/// Helper for reading from a child process stream in a non-blocking way
+pub struct OutputStream {
+    rx: std::sync::mpsc::Receiver<Result<Vec<u8>, std::io::Error>>,
+    buffer: Vec<u8>,
+}
+
+impl OutputStream {
+    pub fn new<R: Read + Send + 'static>(mut stream: R) -> Self {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut buffer = vec![0; 1024];
+            loop {
+                let msg = stream.read(&mut buffer).map(|n| buffer[..n].to_vec());
+                if let Err(e) = tx.send(msg) {
+                    if let Err(e) = e.0 {
+                        eprintln!("Error reading from stream: {e}");
+                    }
+                    break;
+                }
+            }
+        });
+        Self {
+            rx,
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Get the output of the stream so far
+    pub fn output(&mut self) -> &[u8] {
+        while let Ok(Ok(s)) = self.rx.try_recv() {
+            self.buffer.extend(s);
+        }
+        &self.buffer
+    }
+
+    /// Get the output of the stream so far
+    ///
+    /// Returns None if the output is not valid utf8
+    pub fn output_as_str(&mut self) -> Option<&str> {
+        std::str::from_utf8(self.output()).ok()
+    }
+}

--- a/tests/runtime-tests/src/main.rs
+++ b/tests/runtime-tests/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use runtime_tests::{run_all, Config, OnTestError};
+use runtime_tests::{run_all, spin::Spin, Config, OnTestError};
 
 fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -9,8 +9,11 @@ fn main() -> anyhow::Result<()> {
     let tests_path = args
         .next()
         .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests"));
+
     let config = Config {
-        spin_binary_path,
+        create_runtime: Box::new(move |temp, services| {
+            Ok(Box::new(Spin::start(&spin_binary_path, temp, services)?) as _)
+        }),
         tests_path,
         on_error: OnTestError::Log,
     };

--- a/tests/runtime-tests/src/services/python.rs
+++ b/tests/runtime-tests/src/services/python.rs
@@ -1,4 +1,4 @@
-use crate::OutputStream;
+use crate::io::OutputStream;
 
 use super::Service;
 use anyhow::Context as _;

--- a/tests/runtime-tests/src/spin.rs
+++ b/tests/runtime-tests/src/spin.rs
@@ -1,0 +1,138 @@
+use crate::{io::OutputStream, services::Services, Runtime, TestResult};
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+pub struct Spin {
+    process: std::process::Child,
+    #[allow(dead_code)]
+    stdout: OutputStream,
+    stderr: OutputStream,
+    port: u16,
+}
+
+impl Spin {
+    pub fn start(
+        spin_binary_path: &Path,
+        current_dir: &Path,
+        services: &mut Services,
+    ) -> Result<Self, anyhow::Error> {
+        let port = get_random_port()?;
+        let mut child = Command::new(spin_binary_path)
+            .arg("up")
+            .current_dir(current_dir)
+            .args(["--listen", &format!("127.0.0.1:{port}")])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        let stdout = OutputStream::new(child.stdout.take().unwrap());
+        let stderr = OutputStream::new(child.stderr.take().unwrap());
+        log::debug!("Awaiting spin binary to start up on port {port}...");
+        let mut spin = Self {
+            process: child,
+            stdout,
+            stderr,
+            port,
+        };
+        let start = std::time::Instant::now();
+        loop {
+            services.error()?;
+            match std::net::TcpStream::connect(format!("127.0.0.1:{port}")) {
+                Ok(_) => {
+                    log::debug!("Spin started on port {}.", spin.port);
+                    return Ok(spin);
+                }
+                Err(e) => {
+                    let stderr = spin.stderr.output_as_str().unwrap_or("<non-utf8>");
+                    log::trace!("Checking that the Spin server started returned an error: {e}");
+                    log::trace!("Current spin stderr = '{stderr}'");
+                }
+            }
+            if let Some(status) = spin.try_wait()? {
+                anyhow::bail!(
+                    "Spin exited early with status code {:?}\n{}{}",
+                    status.code(),
+                    spin.stdout.output_as_str().unwrap_or("<non-utf8>"),
+                    spin.stderr.output_as_str().unwrap_or("<non-utf8>")
+                );
+            }
+
+            if start.elapsed() > std::time::Duration::from_secs(20) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        anyhow::bail!(
+            "`spin up` did not start server or error after 20 seconds. stderr:\n\t{}",
+            spin.stderr.output_as_str().unwrap_or("<non-utf8>")
+        )
+    }
+
+    fn make_http_request(&mut self) -> Result<reqwest::blocking::Response, anyhow::Error> {
+        if let Some(status) = self.try_wait()? {
+            anyhow::bail!("Spin exited early with status code {:?}", status.code());
+        }
+        log::debug!("Connecting to HTTP server on port {}...", self.port);
+        let response = reqwest::blocking::get(format!("http://127.0.0.1:{}", self.port))?;
+        log::debug!("Awaiting response from server");
+        if let Some(status) = self.try_wait()? {
+            anyhow::bail!("Spin exited early with status code {:?}", status.code());
+        }
+        Ok(response)
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        self.process.try_wait()
+    }
+}
+
+impl Drop for Spin {
+    fn drop(&mut self) {
+        kill_process(&mut self.process);
+    }
+}
+
+impl Runtime for Spin {
+    fn test(&mut self) -> anyhow::Result<TestResult> {
+        let response = self.make_http_request()?;
+        if response.status() == 200 {
+            return Ok(TestResult::Pass);
+        }
+        if response.status() != 500 {
+            anyhow::bail!("Response was neither 200 nor 500")
+        }
+        let text = response.text()?;
+        if text.is_empty() {
+            let stderr = self.stderr.output_as_str().unwrap_or("<non-utf8>");
+            return Ok(TestResult::RuntimeError(stderr.to_owned()));
+        }
+
+        Ok(TestResult::Fail(
+            text,
+            self.stderr
+                .output_as_str()
+                .unwrap_or("<non-utf8>")
+                .to_owned(),
+        ))
+    }
+}
+
+fn kill_process(process: &mut std::process::Child) {
+    #[cfg(windows)]
+    {
+        let _ = process.kill();
+    }
+    #[cfg(not(windows))]
+    {
+        let pid = nix::unistd::Pid::from_raw(process.id() as i32);
+        let _ = nix::sys::signal::kill(pid, nix::sys::signal::SIGTERM);
+    }
+}
+
+/// Uses a track to ge a random unused port
+fn get_random_port() -> anyhow::Result<u16> {
+    Ok(std::net::TcpListener::bind("localhost:0")?
+        .local_addr()?
+        .port())
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,6 +1,6 @@
 /// Run the tests found in `tests/runtime-tests` directory.
 mod runtime_tests {
-    use runtime_tests::Config;
+    use runtime_tests::{spin::Spin, Config};
     use std::path::PathBuf;
 
     // The macro inspects the tests directory and
@@ -8,11 +8,13 @@ mod runtime_tests {
     test_codegen_macro::codegen_tests!();
 
     fn run(name: &str) {
-        let spin_binary_path = env!("CARGO_BIN_EXE_spin").into();
+        let spin_binary_path: PathBuf = env!("CARGO_BIN_EXE_spin").into();
         let tests_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/runtime-tests/tests");
         let config = Config {
-            spin_binary_path,
+            create_runtime: Box::new(move |temp, services| {
+                Ok(Box::new(Spin::start(&spin_binary_path, temp, services)?) as _)
+            }),
             tests_path,
             on_error: runtime_tests::OnTestError::Panic,
         };


### PR DESCRIPTION
The next step after this is to see if we can put this to use against another Spin compliant runtime. 