### PR TITLE
feat(up): Spawn multiple trigger commands

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -207,6 +207,23 @@ impl<'a, L> App<'a, L> {
             .map(|locked| AppTrigger { app: self, locked })
     }
 
+    /// Returns the trigger metadata for a specific trigger type.
+    pub fn get_trigger_metadata<'this, T: Deserialize<'this> + Default>(
+        &'this self,
+        trigger_type: &'a str,
+    ) -> Result<Option<T>> {
+        self.locked.metadata.get("triggers").map_or(Ok(None), |t| {
+            t.get(trigger_type)
+                .map(T::deserialize)
+                .transpose()
+                .map_err(|err| {
+                    Error::MetadataError(format!(
+                        "invalid metadata value for {trigger_type:?}: {err:?}"
+                    ))
+                })
+        })
+    }
+
     /// Returns an iterator of [`AppTrigger`]s defined for this app with
     /// the given `trigger_type`.
     pub fn triggers_with_type(

--- a/crates/http/src/trigger.rs
+++ b/crates/http/src/trigger.rs
@@ -7,8 +7,6 @@ pub const METADATA_KEY: MetadataKey<Metadata> = MetadataKey::new("trigger");
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Metadata {
-    // The type of trigger which should always been "http" in this case
-    pub r#type: String,
     // The based url
     #[serde(default = "default_base")]
     pub base: String,

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -96,8 +96,17 @@ impl TriggerExecutor for HttpTrigger {
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
         let mut base = engine
             .app()
-            .require_metadata(spin_http::trigger::METADATA_KEY)?
-            .base;
+            .get_metadata(spin_http::trigger::METADATA_KEY)?
+            .map_or_else(
+                || {
+                    engine
+                        .trigger_metadata::<spin_http::trigger::Metadata>()
+                        .unwrap_or_default()
+                        .map_or(String::new(), |f| f.base)
+                },
+                |t| t.base,
+            );
+
         if !base.starts_with('/') {
             base = format!("/{base}");
         }

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -95,17 +95,9 @@ impl TriggerExecutor for HttpTrigger {
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
         let mut base = engine
-            .app()
-            .get_metadata(spin_http::trigger::METADATA_KEY)?
-            .map_or_else(
-                || {
-                    engine
-                        .trigger_metadata::<spin_http::trigger::Metadata>()
-                        .unwrap_or_default()
-                        .map_or(String::new(), |f| f.base)
-                },
-                |t| t.base,
-            );
+            .trigger_metadata::<spin_http::trigger::Metadata>()?
+            .unwrap_or_default()
+            .base;
 
         if !base.starts_with('/') {
             base = format!("/{base}");

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -287,6 +287,10 @@ impl<Executor: TriggerExecutor> TriggerAppEngine<Executor> {
         self.app.borrowed()
     }
 
+    pub fn trigger_metadata<T: DeserializeOwned + Default>(&self) -> spin_app::Result<Option<T>> {
+        self.app().get_trigger_metadata(Executor::TRIGGER_TYPE)
+    }
+
     /// Returns AppTriggers and typed TriggerConfigs for this executor type.
     pub fn trigger_configs(&self) -> impl Iterator<Item = (AppTrigger, &Executor::TriggerConfig)> {
         self.app()

--- a/examples/spin-timer/src/lib.rs
+++ b/examples/spin-timer/src/lib.rs
@@ -29,11 +29,16 @@ pub struct TimerTrigger {
     component_timings: HashMap<String, u64>,
 }
 
-// Application settings (raw serialization format)
+// Picks out the timer entry from the application-level trigger settings
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct TriggerMetadataParent {
+    timer: Option<TriggerMetadata>,
+}
+
+// Application-level settings (raw serialization format)
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct TriggerMetadata {
-    r#type: String,
     speedup: Option<u64>,
 }
 
@@ -45,7 +50,7 @@ pub struct TimerTriggerConfig {
     interval_secs: u64,
 }
 
-const TRIGGER_METADATA_KEY: MetadataKey<TriggerMetadata> = MetadataKey::new("triggers");
+const TRIGGER_METADATA_KEY: MetadataKey<TriggerMetadataParent> = MetadataKey::new("triggers");
 
 #[async_trait]
 impl TriggerExecutor for TimerTrigger {
@@ -61,6 +66,8 @@ impl TriggerExecutor for TimerTrigger {
         let speedup = engine
             .app()
             .require_metadata(TRIGGER_METADATA_KEY)?
+            .timer
+            .unwrap_or_default()
             .speedup
             .unwrap_or(1);
 

--- a/examples/spin-timer/src/lib.rs
+++ b/examples/spin-timer/src/lib.rs
@@ -45,7 +45,7 @@ pub struct TimerTriggerConfig {
     interval_secs: u64,
 }
 
-const TRIGGER_METADATA_KEY: MetadataKey<TriggerMetadata> = MetadataKey::new("trigger");
+const TRIGGER_METADATA_KEY: MetadataKey<TriggerMetadata> = MetadataKey::new("triggers");
 
 #[async_trait]
 impl TriggerExecutor for TimerTrigger {

--- a/examples/spin-timer/trigger-timer.json
+++ b/examples/spin-timer/trigger-timer.json
@@ -3,7 +3,7 @@
     "description": "Run Spin components at timed intervals",
     "homepage": "https://github.com/fermyon/spin/tree/main/examples/spin-timer",
     "version": "0.1.0",
-    "spinCompatibility": ">=2.0",
+    "spinCompatibility": ">=2.2",
     "license": "Apache-2.0",
     "packages": [
         {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -237,7 +237,7 @@ impl UpCommand {
         #[cfg(not(windows))]
         {
             // https://github.com/nix-rust/nix/issues/656
-            let pid = nix::unistd::Pid::from_raw(child.id() as i32);
+            let pid = nix::unistd::Pid::from_raw(child.id() as u32);
             ctrlc::set_handler(move || {
                 if let Err(err) = nix::sys::signal::kill(pid, nix::sys::signal::SIGTERM) {
                     tracing::warn!("Failed to kill trigger handler process: {:?}", err)

--- a/src/commands/up/app_source.rs
+++ b/src/commands/up/app_source.rs
@@ -83,7 +83,7 @@ pub enum ResolvedAppSource {
 }
 
 impl ResolvedAppSource {
-    pub fn trigger_type(&self) -> anyhow::Result<&str> {
+    pub fn trigger_types(&self) -> anyhow::Result<Vec<&str>> {
         let types = match self {
             ResolvedAppSource::File { manifest, .. } => {
                 manifest.triggers.keys().collect::<HashSet<_>>()
@@ -96,7 +96,6 @@ impl ResolvedAppSource {
         };
 
         ensure!(!types.is_empty(), "no triggers in app");
-        ensure!(types.len() == 1, "multiple trigger types not yet supported");
-        Ok(types.into_iter().next().unwrap())
+        Ok(types.into_iter().map(|t| t.as_str()).collect())
     }
 }


### PR DESCRIPTION
This PR does a few things and fixes #1755:
- Fix the HTTP/Redis plugin to use the lock file's metadata.triggers.http/redis path instead of metadata.trigger field.
- Use tokio to async wait for the sub processes to end (I didn't want to introduce a new dependency on async processes)

End result:
![WindowsTerminal_fSadslpDYA](https://github.com/fermyon/spin/assets/238568/ea5674b7-55a3-4aca-b653-a7da571b5041)


One note: I cannot get the integration tests to run well on Windows. Probably a local issue, so I was unable to verify if the integration tests work.