### PR TITLE
Don't pass services when constructing Spin instance in runtime test

### DIFF
--- a/tests/runtime-tests/src/main.rs
+++ b/tests/runtime-tests/src/main.rs
@@ -11,8 +11,8 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests"));
 
     let config = Config {
-        create_runtime: Box::new(move |temp, services| {
-            Ok(Box::new(Spin::start(&spin_binary_path, temp, services)?) as _)
+        create_runtime: Box::new(move |temp| {
+            Ok(Box::new(Spin::start(&spin_binary_path, temp)?) as _)
         }),
         tests_path,
         on_error: OnTestError::Log,

--- a/tests/runtime-tests/src/spin.rs
+++ b/tests/runtime-tests/src/spin.rs
@@ -1,4 +1,4 @@
-use crate::{io::OutputStream, services::Services, Runtime, TestResult};
+use crate::{io::OutputStream, Runtime, TestResult};
 use std::{
     path::Path,
     process::{Command, Stdio},
@@ -13,11 +13,8 @@ pub struct Spin {
 }
 
 impl Spin {
-    pub fn start(
-        spin_binary_path: &Path,
-        current_dir: &Path,
-        services: &mut Services,
-    ) -> Result<Self, anyhow::Error> {
+    /// Start Spin in `current_dir` using the binary at `spin_binary_path`
+    pub fn start(spin_binary_path: &Path, current_dir: &Path) -> anyhow::Result<Self> {
         let port = get_random_port()?;
         let mut child = Command::new(spin_binary_path)
             .arg("up")
@@ -37,7 +34,6 @@ impl Spin {
         };
         let start = std::time::Instant::now();
         loop {
-            services.error()?;
             match std::net::TcpStream::connect(format!("127.0.0.1:{port}")) {
                 Ok(_) => {
                     log::debug!("Spin started on port {}.", spin.port);

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -12,8 +12,8 @@ mod runtime_tests {
         let tests_path =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/runtime-tests/tests");
         let config = Config {
-            create_runtime: Box::new(move |temp, services| {
-                Ok(Box::new(Spin::start(&spin_binary_path, temp, services)?) as _)
+            create_runtime: Box::new(move |temp| {
+                Ok(Box::new(Spin::start(&spin_binary_path, temp)?) as _)
             }),
             tests_path,
             on_error: runtime_tests::OnTestError::Panic,


### PR DESCRIPTION
This is a very small refactoring which came out of an attempt to not use a Spin executable binary in runtime tests but rather to instantiate Spin in memory through use of the `spin-trigger` and `spin-trigger-http` libraries. 

Unfortunately the attempt to do so failed because it's not trivial to instantiate a `HttpTrigger` directly and the easiest way to do this is by recreating the same code path the CLI takes to instantiate the trigger. This doesn't win us very much and so the added complication of the fact that the CLI uses async and our testing does not means that it's just simpler to leave things as is.

That being said, this small refactoring is nice enough that I'd like to sneak it in.