### PR TITLE
Update test to new Cloud plugin help text

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -684,7 +684,7 @@ route = "/..."
         // Ensure login help info is displayed
         assert!(std::str::from_utf8(&output.stdout)?
             .trim()
-            .contains("Login to Fermyon Cloud"));
+            .contains("Log into Fermyon Cloud"));
 
         Ok(())
     }


### PR DESCRIPTION
Fixes a test failure resulting from help text changes in Cloud plugin 0.6