### PR TITLE
ci(templates): update rust templates automation to use the crates.io versions

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,4 +1,5 @@
 SDK_VERSION ?= v0.0.0
+CRATES_IO_VERSION := $(shell echo "${SDK_VERSION}" | tr -d 'v')
 
 bump-versions: bump-go-versions bump-rust-versions
 
@@ -14,9 +15,9 @@ bump-go-versions:
 	done
 
 bump-rust-versions:
-	@for dir in $$(ls -d *-rust) ; do \
+	for dir in $$(ls -d *-rust) ; do \
 		cd $$dir/content ; \
-		sed -r -i.sed-bak -e 's%"https://github.com/fermyon/spin", ((tag = "[-a-zA-Z0-9.]+")|(branch = "main"))%"https://github.com/fermyon/spin", tag = "${SDK_VERSION}"%g' Cargo.toml ; \
+		sed -r -i.sed-bak -e 's%(spin-sdk = )(("[0-9]+.[0-9]+.[0-9]+(-rc.[0-9]+)?")|(\{ git = "https://github.com/fermyon/spin", branch = "main" \}))%spin-sdk = "${CRATES_IO_VERSION}"%g' Cargo.toml ; \
 		rm *.sed-bak ; \
 		cd - 2>&1 >/dev/null ; \
 	done


### PR DESCRIPTION
- Updates rust templates during versioning automation to use the spin-sdk crate version

Tested on fork via https://github.com/vdice/spin/actions/runs/7480272473; see also bot PR https://github.com/vdice/spin/pull/9

Ref https://github.com/fermyon/spin/issues/2190

Not sure if we'd like this to fully close 2190 since Windows users may still have trouble running the rust templates from main/canary, where we'll still use the `git` reference for the spin-sdk.