### PR TITLE
fix(registry/auth): auth validation workaround

### DIFF
--- a/crates/oci/src/auth.rs
+++ b/crates/oci/src/auth.rs
@@ -50,7 +50,7 @@ impl AuthConfig {
         Ok(())
     }
 
-    fn default_path() -> Result<PathBuf> {
+    pub(crate) fn default_path() -> Result<PathBuf> {
         Ok(dirs::config_dir()
             .context("Cannot find configuration directory")?
             .join("fermyon")

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -490,7 +490,9 @@ impl Client {
         // First, validate the credentials. If a user accidentally enters a wrong credential set, this
         // can catch the issue early rather than getting an error at the first operation that needs
         // to use the credentials (first time they do a push/pull/up).
-        Self::validate_credentials(&server, &username, &password).await?;
+        if let Err(_) = Self::validate_credentials(&server, &username, &password).await {
+            tracing::error!("Cannot validate regsitry credentials. The server does not accept this operation, or the credentials might be wrong. Adding the credentials to the configuration and attempting to use them in future registry operations. You can check the registries spin is logged in at {:?}", AuthConfig::default_path()?);
+        }
 
         // Save an encoded representation of the credential set in the local configuration file.
         let mut auth = AuthConfig::load_default().await?;


### PR DESCRIPTION
This commit updates the registry login logic to not error if the credential validation fails, but log the message and attempt to continue.

This behavior unblocks the use of registries whose login flow does not accept certain auth types, but if the credentials entered are wrong, could lead to users being appearing to be logged in, but unable to access the registry without logging in again with the right credentials.

Specifically, this most likely needs a --skip-validation flag to be explicitly passed by the user when logging in, but we probably need to rethink the login (and potentially add a logout / retry) flow.

We should most likely not merge this commit in its current state, its goal is to immediately unblock a current use case, but posted for future reference.