### PR TITLE
trigger-http: Log TLS startup errors instead of propagating

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -344,8 +344,10 @@ impl HttpTrigger {
 
         loop {
             let (stream, addr) = listener.accept().await?;
-            let stream = acceptor.accept(stream).await?;
-            Self::serve_connection(self_.clone(), stream, addr);
+            match acceptor.accept(stream).await {
+                Ok(stream) => Self::serve_connection(self_.clone(), stream, addr),
+                Err(err) => tracing::error!(?err, "Failed to start TLS session"),
+            }
         }
     }
 }


### PR DESCRIPTION
This prevents TLS handshake errors from exiting the server loop.