### PR TITLE
Warn instead of trace when errors happen in the spin_redis_engine

### DIFF
--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -94,7 +94,11 @@ impl TriggerExecutor for RedisTrigger {
         let mut stream = pubsub.on_message();
         loop {
             match stream.next().await {
-                Some(msg) => drop(self.handle(msg).await),
+                Some(msg) => {
+                    if let Err(err) = self.handle(msg).await {
+                        tracing::warn!("Error handling message: {err}");
+                    }
+                }
                 None => {
                     tracing::trace!("Empty message");
                     if !client.check_connection() {


### PR DESCRIPTION
Changes the tracing level to `warn` as otherwise it leads to cases where the module errored and it looks like Spin hanged. I ran into this while using an invalid component. I could not understand its cause until @dicej recommended switching from `debug` to `trace`.
