### PR TITLE
print active channels on redis trigger

### DIFF
--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -85,10 +85,12 @@ impl TriggerExecutor for RedisTrigger {
             .with_context(|| anyhow!("Redis trigger failed to connect to {}", address))?
             .into_pubsub();
 
+        println!("Active Channels on {address}:");
         // Subscribe to channels
         for (channel, component) in self.channel_components.iter() {
             tracing::info!("Subscribing component {component:?} to channel {channel:?}");
             pubsub.subscribe(channel).await?;
+            println!("\t{channel}: [{}]", component.join(","));
         }
 
         let mut stream = pubsub.on_message();


### PR DESCRIPTION
This PR prints active channels once the Redis trigger starts to improve the Ux slightly. In cases where the wasm modules take a while to prepare, it can look like Spin has hanged if there is no feedback to the user until they decide to send the first request and if it does not have any print statements, it will continue looking like that. 

(e.g.) 
```bash
$ spin up                                                                                                                  
Logging component stdio to ".spin/logs/"
Preparing Wasm modules is taking a few seconds...
```

after the pr it looks like

```bash
$ spin up
Logging component stdio to "examples/redis-rust/.spin/logs/"
Active Channels on redis://localhost:6379:
        messages: echo-message
```