### PR TITLE
bump `PoolingAllocationConfig::max_core_instances_per_component` to 200

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -111,6 +111,7 @@ impl Default for Config {
             .max_component_instance_size(
                 env("SPIN_WASMTIME_INSTANCE_SIZE", (10 * MB) as u32) as usize
             )
+            .max_core_instances_per_component(env("SPIN_WASMTIME_CORE_INSTANCE_COUNT", 200))
             .max_tables_per_component(env("SPIN_WASMTIME_INSTANCE_TABLES", 20))
             .table_elements(env("SPIN_WASMTIME_INSTANCE_TABLE_ELEMENTS", 30_000))
             // The number of memories an instance can have effectively limits the number of inner components


### PR DESCRIPTION
This fixes an app built using `componentize-py` and `NumPy`, which has 34 core modules.