### PR TITLE
allow installing select templates

### DIFF
--- a/crates/templates/src/test_built_ins/mod.rs
+++ b/crates/templates/src/test_built_ins/mod.rs
@@ -28,6 +28,7 @@ async fn add_fileserver_does_not_create_dir() -> anyhow::Result<()> {
             &built_ins_src,
             &InstallOptions::default(),
             &DiscardingReporter,
+            &Vec::new(),
         )
         .await?;
 


### PR DESCRIPTION
Adds the ability to be able to install specific templates using the following:

```
spin templates install --git https://github.com/fermyon/spin --id https-rust,http-go
...
Installed 2 template(s)

+-------------------------------------------------+
| Name        Description                         |
+=================================================+
| http-go     HTTP request handler using (Tiny)Go |
| http-rust   HTTP request handler using Rust     |
+-------------------------------------------------+

Skipped 10 template(s)

+-------------------------------------+
| Name                Reason skipped  |
+=====================================+
| http-c              Id not included |
| http-empty          Id not included |
| http-grain          Id not included |
| http-php            Id not included |
| http-swift          Id not included |
| http-zig            Id not included |
| redirect            Id not included |
| redis-go            Id not included |
| redis-rust          Id not included |
| static-fileserver   Id not included |
+-------------------------------------+
```

~~Todo: fix inconsistency between install and upgrade where upgrade always installs all the existing templates.~~ Currently `upgrade` installs all the templates it finds even if the user has manually deleted some templates. Is this the behavior we want or should it actually check if a template exists before upgrading it?

fixes #2235 