### PR TITLE
cargo cfg: fix build on aarch64-linux

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [net]
     git-fetch-with-cli = true
+
+[target.aarch64-unknown-linux-gnu]
+    rustflags = ["-C", "target-feature=+fp16"]


### PR DESCRIPTION
Fixes spin builds on aarch64 linux (we set this via ENV for ci release builds, but that is unhelpful when building spin as a developer on arm)