### PR TITLE
temporarily switch to Wasmtime commit 0b632023

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-entity",
 ]
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -1274,12 +1274,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "cranelift-control"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "arbitrary",
 ]
@@ -1287,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1307,12 +1307,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "cranelift-native"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -7363,7 +7363,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7385,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -7404,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "wasi-tokio"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -7582,7 +7582,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7620,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cfg-if",
 ]
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -7647,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7661,12 +7661,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7690,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cranelift-shared"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -7727,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cc",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -7767,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "object",
  "once_cell",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7788,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cc",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -7829,7 +7829,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7874,7 +7874,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7896,7 +7896,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -7923,7 +7923,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wmemcheck"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "wast"
@@ -8075,7 +8075,7 @@ dependencies = [
 [[package]]
 name = "wiggle"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8089,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8145,7 +8145,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "0.15.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8551,7 +8551,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.1"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,14 +131,14 @@ reqwest = { version = "0.11", features = ["stream", "blocking"] }
 tracing = { version = "0.1", features = ["log"] }
 
 # TODO: update to final 17.0.0 release once it's available
-wasi-common-preview1 = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-17.0.0", package = "wasi-common" }
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-17.0.0", features = [
+wasi-common-preview1 = { git = "https://github.com/bytecodealliance/wasmtime", rev = "0b632023", package = "wasi-common" }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "0b632023", features = [
   "component-model",
 ] }
-wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-17.0.0", features = [
+wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "0b632023", features = [
   "tokio",
 ] }
-wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-17.0.0" }
+wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", rev = "0b632023" }
 
 spin-componentize = { git = "https://github.com/fermyon/spin-componentize", rev = "191789170abde10cd55590466c0660dd6c7d472a" }
 

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-entity",
 ]
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -655,12 +655,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "cranelift-control"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "arbitrary",
 ]
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "serde",
  "serde_derive",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -688,12 +688,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "cranelift-native"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.104.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -4654,7 +4654,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasi-cap-std-sync"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "wasi-common"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "wasi-tokio"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4874,7 +4874,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cfg-if",
 ]
@@ -4920,7 +4920,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -4939,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4953,12 +4953,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cranelift-shared"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -5019,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cc",
@@ -5033,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "object 0.32.1",
  "once_cell",
@@ -5070,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5080,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cc",
@@ -5109,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5131,7 +5131,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5166,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5204,7 +5204,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "heck",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wmemcheck"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 
 [[package]]
 name = "wast"
@@ -5285,7 +5285,7 @@ dependencies = [
 [[package]]
 name = "wiggle"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5299,7 +5299,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "heck",
@@ -5313,7 +5313,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "17.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5355,7 +5355,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "0.15.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5665,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.1"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-17.0.0#2c9160acc0d4aa4456d2cd32e46f9058ebbeaf71"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=0b632023#0b632023308d55275d595dfc3dc507620284fb16"
 dependencies = [
  "anyhow",
  "log",

--- a/examples/spin-timer/Cargo.toml
+++ b/examples/spin-timer/Cargo.toml
@@ -14,6 +14,6 @@ spin-core = { path = "../../crates/core" }
 spin-trigger = { path = "../../crates/trigger" }
 tokio = { version = "1.11", features = ["full"] }
 tokio-scoped = "0.2.0"
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-17.0.0", features = ["component-model"] }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "0b632023", features = ["component-model"] }
 
 [workspace]


### PR DESCRIPTION
This commit is from the `release-17.0.0` branch just prior to when `wasmtime-wasi` was updated to the `rc-2024-01-16` WASI snapshot, which we don't yet support.  Updating the code should be easy enough, but we'll wait for the final Wasmtime 17 release before we do that.