### PR TITLE
logging: Emit wasmtime-wasi-http WARN logs by default

### DIFF
--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -46,6 +46,7 @@ async fn _main() -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("wasmtime_wasi_http=warn".parse()?)
                 .add_directive("watchexec=off".parse()?),
         )
         .with_ansi(std::io::stderr().is_terminal())


### PR DESCRIPTION
Many hyper errors are converted to the generic HttpProtocolError by wasmtime-wasi-http, which makes debugging difficult. The original hyper error is emitted as a tracing event, so let's print those by default.