### PR TITLE
feat: add support for setting the pushed oci image manifest annotations

### DIFF
--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -1,6 +1,6 @@
 //! Spin's client for distributing applications via OCI registries
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -97,6 +97,7 @@ impl Client {
         &mut self,
         manifest_path: &Path,
         reference: impl AsRef<str>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<Option<String>> {
         let reference: Reference = reference
             .as_ref()
@@ -115,7 +116,8 @@ impl Client {
         )
         .await?;
 
-        self.push_locked_core(locked, auth, reference).await
+        self.push_locked_core(locked, auth, reference, annotations)
+            .await
     }
 
     /// Push a Spin application to an OCI registry and return the digest (or None
@@ -124,6 +126,7 @@ impl Client {
         &mut self,
         locked: LockedApp,
         reference: impl AsRef<str>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<Option<String>> {
         let reference: Reference = reference
             .as_ref()
@@ -131,7 +134,8 @@ impl Client {
             .with_context(|| format!("cannot parse reference {}", reference.as_ref()))?;
         let auth = Self::auth(&reference).await?;
 
-        self.push_locked_core(locked, auth, reference).await
+        self.push_locked_core(locked, auth, reference, annotations)
+            .await
     }
 
     /// Push a Spin application to an OCI registry and return the digest (or None
@@ -141,6 +145,7 @@ impl Client {
         locked: LockedApp,
         auth: RegistryAuth,
         reference: Reference,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<Option<String>> {
         let mut locked_app = locked.clone();
         let mut layers = self
@@ -193,7 +198,7 @@ impl Client {
         };
         let oci_config =
             oci_distribution::client::Config::oci_v1_from_config_file(oci_config_file, None)?;
-        let manifest = OciImageManifest::build(&layers, &oci_config, None);
+        let manifest = OciImageManifest::build(&layers, &oci_config, annotations);
 
         let response = self
             .oci


### PR DESCRIPTION
This closes https://github.com/fermyon/spin/issues/2236.

You can see how GitHub Container Registry shows an image without annotations at:

https://github.com/rgl/spin-http-ts-example/pkgs/container/spin-http-ts-example/171707227?tag=0.2.0

And the one with annotations at:

https://github.com/rgl/spin-http-ts-example/pkgs/container/spin-http-ts-example/171719572?tag=0.0.0-test1

This is how I've pushed it the image with my local spin version:

```console
$ echo my-github-token-with-write-packages-scope | docker login ghcr.io -u rgl --password-stdin
$ ~/Projects/spin/target/debug/spin registry push --annotation "org.opencontainers.image.description=$(jq -r .description package.json)" ghcr.io/rgl/spin-http-ts-example:0.0.0-test1
Pushing app to the Registry...
Pushed with digest sha256:60373ae9983dac0356fc91b1ff016f3580fd7664a9061f71d8a5fd266c646a0c
```
