### PR TITLE
Ignore unknown trigger flags

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -32,7 +32,8 @@ pub const SPIN_WORKING_DIR: &str = "SPIN_WORKING_DIR";
 #[derive(Parser, Debug)]
 #[clap(
     usage = "spin [COMMAND] [OPTIONS]",
-    next_help_heading = "TRIGGER OPTIONS"
+    next_help_heading = "TRIGGER OPTIONS",
+    ignore_errors = true
 )]
 pub struct TriggerExecutorCommand<Executor: TriggerExecutor>
 where


### PR DESCRIPTION
This is one approach to addressing #2251 - it's not the best, but it may be expedient in the short term.  It has the serious downside that users who mistype flags, even for their existing, single-trigger applications, will not get errors.  This may be unacceptable - I'd be completely on board with that decision!

The alternatives I can think of are:

* Document that multi-trigger applications can't take trigger-specific flags, i.e. a known limitation of an experimental feature.  Easy to do, but few people will read it, and so people will hit the error which is not very self-explanatory.
* Enforce that multi-trigger applications can't take trigger-specific flags during this experimental phase: that is, if `up` detects that it's a multi scenario and the collection of passthrough flags is non-empty then halt with a meaningful error.  Easy to do, self-explanatory, but blocks common flags like `--log-dir` as well.
* Provide a way for triggers to list their flags, and have `up` use that to filter what it passes through to each trigger.  Requires more time and thought, and careful coding in `up` - there will be all sorts of exciting edge cases here (positional arguments, just say no; correct handling of 'old' triggers), but allows for other nice features down the line (help combining, config validation, detection of non-multi-able triggers).  I think we should do this, but I'm wary of trying to jam it into 2.2.

Other ideas welcome!
