### PR TITLE
Fix regrettable trigger help heading when no app

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -256,9 +256,13 @@ fn warn_if_wasm_build_slothful() -> sloth::SlothGuard {
 }
 
 fn help_heading<E: TriggerExecutor>() -> Option<&'static str> {
-    let heading = format!("{} TRIGGER OPTIONS", E::TRIGGER_TYPE.to_uppercase());
-    let as_str = Box::new(heading).leak();
-    Some(as_str)
+    if E::TRIGGER_TYPE == help::HelpArgsOnlyTrigger::TRIGGER_TYPE {
+        Some("TRIGGER OPTIONS")
+    } else {
+        let heading = format!("{} TRIGGER OPTIONS", E::TRIGGER_TYPE.to_uppercase());
+        let as_str = Box::new(heading).leak();
+        Some(as_str)
+    }
 }
 
 pub mod help {


### PR DESCRIPTION
Internally, if there is no application, `spin up --help` calls a dummy trigger to list the common trigger options.  As a result of #2256, this dummy trigger ID is leaked into the "trigger options" help heading, so you see:

```
HELP-ARGS-ONLY TRIGGER OPTIONS:
        --allow-transient-write
            Set the static assets of the components in the temporary directory as writable
```

While not particularly impactful, this is regrettable, and this PR fixes it so it goes back to displaying only `TRIGGER OPTIONS` in the no-app case.
