### PR TITLE
chore(*): post-2.2.0 release bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "http 0.2.11",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tests"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -5683,7 +5683,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spin-app"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "http 1.0.0",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5948,7 +5948,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-local"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "http 0.2.11",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6026,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "glob",
@@ -6068,7 +6068,7 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "spin-redis-engine"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6170,7 +6170,7 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "base64 0.21.5",
  "serde",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6191,7 +6191,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6253,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "spin-testing"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "http 1.0.0",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6321,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6361,7 +6361,7 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "wasmtime",
 ]
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 
 [[package]]
 name = "tar"
@@ -7146,7 +7146,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "ui-testing"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [workspace.package]
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/examples/http-rust-outbound-http/http-hello/Cargo.lock
+++ b/examples/http-rust-outbound-http/http-hello/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.lock
+++ b/examples/http-rust-outbound-http/outbound-http-to-same-app/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/http-rust-outbound-http/outbound-http/Cargo.lock
+++ b/examples/http-rust-outbound-http/outbound-http/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/http-rust-outbound-post/Cargo.lock
+++ b/examples/http-rust-outbound-post/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/http-rust-router-macro/Cargo.lock
+++ b/examples/http-rust-router-macro/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/http-rust-router/Cargo.lock
+++ b/examples/http-rust-router/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/json-http-rust/Cargo.lock
+++ b/examples/json-http-rust/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/redis-rust/Cargo.lock
+++ b/examples/redis-rust/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/rust-key-value/Cargo.lock
+++ b/examples/rust-key-value/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/rust-outbound-mysql/Cargo.lock
+++ b/examples/rust-outbound-mysql/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/rust-outbound-pg/Cargo.lock
+++ b/examples/rust-outbound-pg/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/rust-outbound-redis/Cargo.lock
+++ b/examples/rust-outbound-redis/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "http 0.2.9",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "redis",
@@ -3604,7 +3604,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-app"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "http 0.2.9",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "base64 0.21.4",
  "serde",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "wasmtime",
 ]
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 
 [[package]]
 name = "tar"

--- a/examples/spin-wagi-http/http-rust/Cargo.lock
+++ b/examples/spin-wagi-http/http-rust/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/variables-rust/Cargo.lock
+++ b/examples/variables-rust/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/vault-variable-test/Cargo.lock
+++ b/examples/vault-variable-test/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/wasi-http-rust-streaming-outgoing-body/Cargo.lock
+++ b/examples/wasi-http-rust-streaming-outgoing-body/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/wasi-http-streaming-file/Cargo.lock
+++ b/examples/wasi-http-streaming-file/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -21,7 +21,7 @@ name = "spin_sdk"
 anyhow = "1"
 async-trait = "0.1.74"
 form_urlencoded = "1.0"
-spin-macro = { version = "2.2.0-pre0", path = "macro" }
+spin-macro = { version = "2.3.0-pre0", path = "macro" }
 thiserror = "1.0.37"
 wit-bindgen = "0.13.0"
 routefinder = "0.5.3"

--- a/tests/test-components/components/Cargo.lock
+++ b/tests/test-components/components/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0-pre0"
+version = "2.3.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
- Bump spin version to next prerelease now that [v2.2.0](https://github.com/fermyon/spin/releases/tag/v2.2.0) is out