### PR TITLE
Fix test components build

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,9 @@
     },
     "rust-analyzer.files.excludeDirs": [
         "templates"
+    ],
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml",
+        "./tests/test-components/components/Cargo.toml"
     ]
 }

--- a/tests/test-components/build.rs
+++ b/tests/test-components/build.rs
@@ -25,8 +25,14 @@ fn main() {
     for package in packages {
         let crate_path = PathBuf::from("components").join(&package);
         let manifest_path = crate_path.join("Cargo.toml");
+        if !manifest_path.exists() {
+            eprintln!("No Cargo.toml in {crate_path:?}; skipping");
+            continue;
+        }
         let manifest = cargo_toml::Manifest::from_path(&manifest_path)
             .expect("failed to read and parse Cargo manifest");
+
+        eprintln!("Building test component {:?}", manifest.package().name());
 
         // Build the test component
         let mut cargo = Command::new("cargo");

--- a/tests/test-components/build.rs
+++ b/tests/test-components/build.rs
@@ -48,7 +48,7 @@ fn main() {
         let const_name = to_shouty_snake_case(&package);
         let package_name = manifest.package.expect("manifest has no package").name;
         let binary_name = package_name.replace(['-', '.'], "_");
-        let wasm_path = out_dir
+        let mut wasm_path = out_dir
             .join("wasm32-wasi")
             .join("debug")
             .join(format!("{binary_name}.wasm"));
@@ -71,6 +71,7 @@ fn main() {
                 .expect("failed to apply adapter")
                 .encode()
                 .expect("failed to encode component");
+            wasm_path = wasm_path.with_extension("adapted.wasm");
             std::fs::write(&wasm_path, new_bytes).expect("failed to write new wasm binary");
         }
 

--- a/tests/test-components/components/Cargo.toml
+++ b/tests/test-components/components/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 members = ["*"]
+exclude = ["target"]
 resolver = "2"


### PR DESCRIPTION
- Exclude test-components/components/target from workspace members
- Add test components to vscode rust-analyzer.linkedProjects
- Write adapted test components to new path instead of overwriting modules