### PR TITLE
In process runtime tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6640,14 +6640,21 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fslock",
+ "http 1.0.0",
+ "http-body-util",
  "log",
  "nix 0.26.4",
  "regex",
  "reqwest",
+ "spin-http",
+ "spin-loader",
+ "spin-trigger",
+ "spin-trigger-http",
  "temp-dir",
  "test-components",
  "tokio",
  "toml 0.8.8",
+ "wasmtime-wasi-http",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,7 +5092,6 @@ dependencies = [
  "anyhow",
  "env_logger",
  "log",
- "reqwest",
  "testing-framework",
 ]
 

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod cli;
 pub mod loader;
-mod network;
+pub mod network;
 mod runtime_config;
 mod stdio;
 

--- a/tests/runtime-tests/Cargo.toml
+++ b/tests/runtime-tests/Cargo.toml
@@ -12,5 +12,4 @@ rust-version.workspace = true
 anyhow = "1.0"
 env_logger = "0.10.0"
 log = "0.4"
-reqwest = { workspace = true }
 testing-framework = { path = "../testing-framework" }

--- a/tests/runtime-tests/src/lib.rs
+++ b/tests/runtime-tests/src/lib.rs
@@ -124,7 +124,7 @@ impl RuntimeTest<InProcessSpin> {
             Ok(())
         };
         let services_config = services_config(&config)?;
-        let env_config = TestEnvironmentConfig::in_memory(services_config, preboot);
+        let env_config = TestEnvironmentConfig::in_process(services_config, preboot);
         let env = TestEnvironment::up(env_config)?;
         Ok(Self {
             test_path: config.test_path,

--- a/tests/runtime-tests/src/main.rs
+++ b/tests/runtime-tests/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use runtime_tests::RuntimeTest;
-use testing_framework::OnTestError;
+use testing_framework::{OnTestError, Spin};
 
 fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -12,5 +12,5 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests"));
 
     let config = OnTestError::Log;
-    RuntimeTest::run_all(&tests_path, spin_binary_path, config)
+    RuntimeTest::<Spin>::run_all(&tests_path, spin_binary_path, config)
 }

--- a/tests/runtime-tests/src/main.rs
+++ b/tests/runtime-tests/src/main.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use runtime_tests::RuntimeTest;
-use testing_framework::{OnTestError, Spin};
+use testing_framework::runtimes::spin_cli::SpinCli;
+use testing_framework::OnTestError;
 
 fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -12,5 +13,5 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests"));
 
     let config = OnTestError::Log;
-    RuntimeTest::<Spin>::run_all(&tests_path, spin_binary_path, config)
+    RuntimeTest::<SpinCli>::run_all(&tests_path, spin_binary_path, config)
 }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -6,7 +6,7 @@ mod runtime_tests {
     // generates individual tests for each one.
     test_codegen_macro::codegen_runtime_tests!(
         ignore: [
-            // This test is flacky. Often gets "Connection reset by peer" errors.
+            // This test is flaky. Often gets "Connection reset by peer" errors.
             // https://github.com/fermyon/spin/issues/2265
             "outbound-postgres"
         ]
@@ -15,10 +15,12 @@ mod runtime_tests {
     fn run(test_path: PathBuf) {
         let config = runtime_tests::RuntimeTestConfig {
             test_path,
-            spin_binary: env!("CARGO_BIN_EXE_spin").into(),
+            runtime_config: testing_framework::SpinConfig {
+                binary_path: env!("CARGO_BIN_EXE_spin").into(),
+            },
             on_error: testing_framework::OnTestError::Panic,
         };
-        runtime_tests::RuntimeTest::bootstrap(config)
+        runtime_tests::RuntimeTest::<testing_framework::Spin>::bootstrap(config)
             .expect("failed to bootstrap runtime tests tests")
             .run();
     }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -15,12 +15,13 @@ mod runtime_tests {
     fn run(test_path: PathBuf) {
         let config = runtime_tests::RuntimeTestConfig {
             test_path,
-            runtime_config: testing_framework::SpinConfig {
-                binary_path: env!("CARGO_BIN_EXE_spin").into(),
-            },
+            runtime_config: (),
+            // runtime_config: testing_framework::SpinConfig {
+            //     binary_path: env!("CARGO_BIN_EXE_spin").into(),
+            // },
             on_error: testing_framework::OnTestError::Panic,
         };
-        runtime_tests::RuntimeTest::<testing_framework::Spin>::bootstrap(config)
+        runtime_tests::RuntimeTest::<testing_framework::InMemorySpin>::bootstrap(config)
             .expect("failed to bootstrap runtime tests tests")
             .run();
     }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -2,6 +2,8 @@
 mod runtime_tests {
     use std::path::PathBuf;
 
+    use testing_framework::runtimes::in_process_spin::InProcessSpin;
+
     // The macro inspects the tests directory and
     // generates individual tests for each one.
     test_codegen_macro::codegen_runtime_tests!(
@@ -16,12 +18,9 @@ mod runtime_tests {
         let config = runtime_tests::RuntimeTestConfig {
             test_path,
             runtime_config: (),
-            // runtime_config: testing_framework::SpinConfig {
-            //     binary_path: env!("CARGO_BIN_EXE_spin").into(),
-            // },
             on_error: testing_framework::OnTestError::Panic,
         };
-        runtime_tests::RuntimeTest::<testing_framework::InMemorySpin>::bootstrap(config)
+        runtime_tests::RuntimeTest::<InProcessSpin>::bootstrap(config)
             .expect("failed to bootstrap runtime tests tests")
             .run();
     }

--- a/tests/testing-framework/Cargo.toml
+++ b/tests/testing-framework/Cargo.toml
@@ -6,11 +6,18 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 fslock = "0.2.1"
+http = "1.0"
+http-body-util = "0.1.0"
 log = "0.4"
 nix = "0.26.1"
 regex = "1.10.2"
 reqwest = { workspace = true }
 temp-dir = "0.1.11"
 test-components = { path = "../test-components" }
+spin-trigger-http = { path = "../../crates/trigger-http" }
+spin-http = { path = "../../crates/http" }
+spin-trigger = { path = "../../crates/trigger" }
+spin-loader = { path = "../../crates/loader" }
 toml = "0.8.6"
 tokio = "1.23"
+wasmtime-wasi-http = "17.0"

--- a/tests/testing-framework/src/http.rs
+++ b/tests/testing-framework/src/http.rs
@@ -1,0 +1,132 @@
+//! Utilities for tests that function over HTTP
+
+pub use reqwest::Method;
+use std::collections::HashMap;
+
+/// A request to the Spin server
+pub struct Request<'a, B> {
+    pub method: Method,
+    pub uri: &'a str,
+    pub headers: &'a [(&'a str, &'a str)],
+    pub body: Option<B>,
+}
+
+impl<'a, 'b> Request<'a, &'b [u8]> {
+    /// Create a new request with no headers or body
+    pub fn new(method: Method, uri: &'a str) -> Self {
+        Self {
+            method,
+            uri,
+            headers: &[],
+            body: None,
+        }
+    }
+}
+
+impl<'a, B> Request<'a, B> {
+    /// Create a new request with headers and a body
+    pub fn full(
+        method: Method,
+        uri: &'a str,
+        headers: &'a [(&'a str, &'a str)],
+        body: Option<B>,
+    ) -> Self {
+        Self {
+            method,
+            uri,
+            headers,
+            body,
+        }
+    }
+}
+
+/// A response from a Spin server
+pub struct Response {
+    status: u16,
+    headers: HashMap<String, String>,
+    chunks: Vec<Vec<u8>>,
+}
+
+impl Response {
+    /// A response with no headers or body
+    pub fn new(status: u16) -> Self {
+        Self {
+            status,
+            headers: Default::default(),
+            chunks: Default::default(),
+        }
+    }
+
+    /// A response with headers and a body
+    pub fn new_with_body(status: u16, chunks: impl IntoChunks) -> Self {
+        Self {
+            status,
+            headers: Default::default(),
+            chunks: chunks.into_chunks(),
+        }
+    }
+
+    /// A response with headers and a body
+    pub fn full(status: u16, headers: HashMap<String, String>, chunks: impl IntoChunks) -> Self {
+        Self {
+            status,
+            headers,
+            chunks: chunks.into_chunks(),
+        }
+    }
+
+    /// The status code of the response
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+
+    /// The headers of the response
+    pub fn headers(&self) -> &HashMap<String, String> {
+        &self.headers
+    }
+
+    /// The body of the response
+    pub fn body(&self) -> Vec<u8> {
+        self.chunks.iter().flatten().copied().collect()
+    }
+
+    /// The body of the response as chunks of bytes
+    ///
+    /// If the response is not stream this will be a single chunk equal to the body
+    pub fn chunks(&self) -> &[Vec<u8>] {
+        &self.chunks
+    }
+
+    /// The body of the response as a string
+    pub fn text(&self) -> Result<String, std::string::FromUtf8Error> {
+        String::from_utf8(self.body())
+    }
+}
+
+pub trait IntoChunks {
+    fn into_chunks(self) -> Vec<Vec<u8>>;
+}
+
+impl IntoChunks for Vec<Vec<u8>> {
+    fn into_chunks(self) -> Vec<Vec<u8>> {
+        self
+    }
+}
+
+impl IntoChunks for Vec<u8> {
+    fn into_chunks(self) -> Vec<Vec<u8>> {
+        vec![self]
+    }
+}
+
+impl IntoChunks for String {
+    fn into_chunks(self) -> Vec<Vec<u8>> {
+        vec![self.into_bytes()]
+    }
+}
+
+impl IntoChunks for &str {
+    fn into_chunks(self) -> Vec<Vec<u8>> {
+        vec![self.as_bytes().into()]
+    }
+}

--- a/tests/testing-framework/src/lib.rs
+++ b/tests/testing-framework/src/lib.rs
@@ -4,16 +4,16 @@
 //! * `RuntimeTest` - bootstraps and runs a single runtime test
 //! * `TestEnvironment` - bootstraps a test environment which can be used by more than just runtime tests
 
+pub mod http;
 mod io;
 mod manifest_template;
+pub mod runtimes;
 mod services;
-mod spin;
 mod test_environment;
 
 pub use manifest_template::EnvTemplate;
 pub use services::ServicesConfig;
-pub use spin::{Request, Response, Spin, SpinConfig, SpinMode};
-pub use test_environment::{InMemorySpin, TestEnvironment, TestEnvironmentConfig};
+pub use test_environment::{TestEnvironment, TestEnvironmentConfig};
 
 #[derive(Debug, Clone, Copy)]
 /// What to do when a test errors
@@ -27,6 +27,7 @@ pub enum OnTestError {
 /// A runtime which can be tested
 pub trait Runtime {
     type Config;
+
     /// Return an error if one has occurred
     fn error(&mut self) -> anyhow::Result<()>;
 }
@@ -47,9 +48,9 @@ pub trait Test {
 
 impl<F, E> Test for F
 where
-    F: FnOnce(&mut TestEnvironment<Spin>) -> TestResult<E> + 'static,
+    F: FnOnce(&mut TestEnvironment<runtimes::spin_cli::SpinCli>) -> TestResult<E> + 'static,
 {
-    type Runtime = Spin;
+    type Runtime = runtimes::spin_cli::SpinCli;
     type Failure = E;
 
     fn test(self, env: &mut TestEnvironment<Self::Runtime>) -> TestResult<Self::Failure> {

--- a/tests/testing-framework/src/lib.rs
+++ b/tests/testing-framework/src/lib.rs
@@ -12,8 +12,8 @@ mod test_environment;
 
 pub use manifest_template::EnvTemplate;
 pub use services::ServicesConfig;
-pub use spin::{Request, Response, Spin, SpinMode};
-pub use test_environment::{TestEnvironment, TestEnvironmentConfig};
+pub use spin::{Request, Response, Spin, SpinConfig, SpinMode};
+pub use test_environment::{InMemorySpin, TestEnvironment, TestEnvironmentConfig};
 
 #[derive(Debug, Clone, Copy)]
 /// What to do when a test errors
@@ -26,6 +26,7 @@ pub enum OnTestError {
 
 /// A runtime which can be tested
 pub trait Runtime {
+    type Config;
     /// Return an error if one has occurred
     fn error(&mut self) -> anyhow::Result<()>;
 }

--- a/tests/testing-framework/src/runtimes/in_process_spin.rs
+++ b/tests/testing-framework/src/runtimes/in_process_spin.rs
@@ -1,0 +1,59 @@
+//! The Spin runtime running in the same process as the test
+
+use crate::{
+    http::{Request, Response},
+    Runtime,
+};
+use anyhow::Context as _;
+
+/// An instance of Spin running in the same process as the tests instead of as a separate process
+///
+/// Use `runtimes::spin_cli::SpinCli` if you'd rather use Spin as a separate process
+pub struct InProcessSpin {
+    trigger: spin_trigger_http::HttpTrigger,
+}
+
+impl InProcessSpin {
+    pub fn new(trigger: spin_trigger_http::HttpTrigger) -> Self {
+        Self { trigger }
+    }
+
+    pub fn make_http_request(&self, req: Request<'_, &[u8]>) -> anyhow::Result<Response> {
+        tokio::runtime::Runtime::new()?.block_on(async {
+            let method = http::Method::from_bytes(req.method.as_str().as_bytes())
+                .context("could not parse runtime test HTTP method")?;
+            let req = http::request::Request::builder()
+                .method(method)
+                .uri(req.uri)
+                // TODO(rylev): convert headers and body as well
+                .body(spin_http::body::empty())
+                .unwrap();
+            let response = self
+                .trigger
+                .handle(
+                    req,
+                    http::uri::Scheme::HTTP,
+                    (std::net::Ipv4Addr::LOCALHOST, 80).into(),
+                )
+                .await?;
+            use http_body_util::BodyExt;
+            let status = response.status().as_u16();
+            let body = response.into_body();
+            let chunks = body
+                .collect()
+                .await
+                .context("could not get runtime test HTTP response")?
+                .to_bytes()
+                .to_vec();
+            Ok(Response::full(status, Default::default(), chunks))
+        })
+    }
+}
+
+impl Runtime for InProcessSpin {
+    type Config = ();
+
+    fn error(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/tests/testing-framework/src/runtimes/mod.rs
+++ b/tests/testing-framework/src/runtimes/mod.rs
@@ -1,0 +1,14 @@
+//! Various Spin conformant runtimes
+
+pub mod in_process_spin;
+pub mod spin_cli;
+
+/// The type of app Spin is running
+pub enum SpinAppType {
+    /// Expect an http listener to start
+    Http,
+    /// Expect a redis listener to start
+    Redis,
+    /// Don't expect Spin to start
+    None,
+}

--- a/tests/testing-framework/src/runtimes/spin_cli.rs
+++ b/tests/testing-framework/src/runtimes/spin_cli.rs
@@ -1,14 +1,20 @@
+//! The Spin CLI runtime (i.e., the `spin` command-line tool).
+
 use anyhow::Context;
 
-use crate::{io::OutputStream, Runtime, TestEnvironment};
+use super::SpinAppType;
+use crate::{
+    http::{Request, Response},
+    io::OutputStream,
+    Runtime, TestEnvironment,
+};
 use std::{
-    collections::HashMap,
     path::Path,
     process::{Command, Stdio},
 };
 
-/// A wrapper around a running Spin instance
-pub struct Spin {
+/// A wrapper around a running Spin CLI instance
+pub struct SpinCli {
     process: std::process::Child,
     #[allow(dead_code)]
     stdout: OutputStream,
@@ -16,21 +22,22 @@ pub struct Spin {
     io_mode: IoMode,
 }
 
-impl Spin {
+impl SpinCli {
+    /// Start Spin using the binary at `spin_binary_path` in the `env` testing environment
     pub fn start<R>(
         spin_binary_path: &Path,
         env: &TestEnvironment<R>,
         spin_up_args: Vec<impl AsRef<std::ffi::OsStr>>,
-        mode: SpinMode,
+        app_type: SpinAppType,
     ) -> anyhow::Result<Self> {
-        match mode {
-            SpinMode::Http => Self::start_http(spin_binary_path, env, spin_up_args),
-            SpinMode::Redis => Self::start_redis(spin_binary_path, env, spin_up_args),
-            SpinMode::None => Self::attempt_start(spin_binary_path, env, spin_up_args),
+        match app_type {
+            SpinAppType::Http => Self::start_http(spin_binary_path, env, spin_up_args),
+            SpinAppType::Redis => Self::start_redis(spin_binary_path, env, spin_up_args),
+            SpinAppType::None => Self::attempt_start(spin_binary_path, env, spin_up_args),
         }
     }
 
-    /// Start Spin in `current_dir` using the binary at `spin_binary_path`
+    /// Start Spin assuming an HTTP app in `env` testing directory using the binary at `spin_binary_path`
     pub fn start_http<R>(
         spin_binary_path: &Path,
         env: &TestEnvironment<R>,
@@ -87,6 +94,7 @@ impl Spin {
         )
     }
 
+    /// Start Spin assuming a Redis app in `env` testing directory using the binary at `spin_binary_path`
     pub fn start_redis<R>(
         spin_binary_path: &Path,
         env: &TestEnvironment<R>,
@@ -194,9 +202,9 @@ impl Spin {
             while let Some(chunk) = response.chunk().await? {
                 chunks.push(chunk.to_vec());
             }
-            Result::<_, anyhow::Error>::Ok(Response {
-                status: response.status().as_u16(),
-                headers: response
+            Result::<_, anyhow::Error>::Ok(Response::full(
+                response.status().as_u16(),
+                response
                     .headers()
                     .into_iter()
                     .map(|(k, v)| {
@@ -207,7 +215,7 @@ impl Spin {
                     })
                     .collect(),
                 chunks,
-            })
+            ))
         })?;
         log::debug!("Awaiting response from server");
         if let Some(status) = self.try_wait()? {
@@ -237,13 +245,13 @@ impl Spin {
     }
 }
 
-impl Drop for Spin {
+impl Drop for SpinCli {
     fn drop(&mut self) {
         kill_process(&mut self.process);
     }
 }
 
-impl Runtime for Spin {
+impl Runtime for SpinCli {
     type Config = SpinConfig;
 
     fn error(&mut self) -> anyhow::Result<()> {
@@ -281,146 +289,9 @@ enum IoMode {
     None,
 }
 
-/// The mode start Spin up in
-pub enum SpinMode {
-    /// Expect an http listener to start
-    Http,
-    /// Expect a redis listener to start
-    Redis,
-    /// Don't expect spin to start
-    None,
-}
-
 /// Uses a track to ge a random unused port
 fn get_random_port() -> anyhow::Result<u16> {
     Ok(std::net::TcpListener::bind("localhost:0")?
         .local_addr()?
         .port())
-}
-
-/// A request to the spin server
-pub struct Request<'a, B> {
-    pub method: reqwest::Method,
-    pub uri: &'a str,
-    pub headers: &'a [(&'a str, &'a str)],
-    pub body: Option<B>,
-}
-
-impl<'a, 'b> Request<'a, &'b [u8]> {
-    /// Create a new request with no headers or body
-    pub fn new(method: reqwest::Method, uri: &'a str) -> Self {
-        Self {
-            method,
-            uri,
-            headers: &[],
-            body: None,
-        }
-    }
-}
-
-impl<'a, B> Request<'a, B> {
-    /// Create a new request with headers and a body
-    pub fn full(
-        method: reqwest::Method,
-        uri: &'a str,
-        headers: &'a [(&'a str, &'a str)],
-        body: Option<B>,
-    ) -> Self {
-        Self {
-            method,
-            uri,
-            headers,
-            body,
-        }
-    }
-}
-
-pub struct Response {
-    status: u16,
-    headers: HashMap<String, String>,
-    chunks: Vec<Vec<u8>>,
-}
-
-impl Response {
-    /// A response with no headers or body
-    pub fn new(status: u16) -> Self {
-        Self {
-            status,
-            headers: Default::default(),
-            chunks: Default::default(),
-        }
-    }
-
-    /// A response with headers and a body
-    pub fn new_with_body(status: u16, chunks: impl IntoChunks) -> Self {
-        Self {
-            status,
-            headers: Default::default(),
-            chunks: chunks.into_chunks(),
-        }
-    }
-
-    /// A response with headers and a body
-    pub fn full(status: u16, headers: HashMap<String, String>, chunks: impl IntoChunks) -> Self {
-        Self {
-            status,
-            headers,
-            chunks: chunks.into_chunks(),
-        }
-    }
-
-    /// The status code of the response
-    pub fn status(&self) -> u16 {
-        self.status
-    }
-
-    /// The headers of the response
-    pub fn headers(&self) -> &HashMap<String, String> {
-        &self.headers
-    }
-
-    /// The body of the response
-    pub fn body(&self) -> Vec<u8> {
-        self.chunks.iter().flatten().copied().collect()
-    }
-
-    /// The body of the response as chunks of bytes
-    ///
-    /// If the response is not stream this will be a single chunk equal to the body
-    pub fn chunks(&self) -> &[Vec<u8>] {
-        &self.chunks
-    }
-
-    /// The body of the response as a string
-    pub fn text(&self) -> Result<String, std::string::FromUtf8Error> {
-        String::from_utf8(self.body())
-    }
-}
-
-pub trait IntoChunks {
-    fn into_chunks(self) -> Vec<Vec<u8>>;
-}
-
-impl IntoChunks for Vec<Vec<u8>> {
-    fn into_chunks(self) -> Vec<Vec<u8>> {
-        self
-    }
-}
-
-impl IntoChunks for Vec<u8> {
-    fn into_chunks(self) -> Vec<Vec<u8>> {
-        vec![self]
-    }
-}
-
-impl IntoChunks for String {
-    fn into_chunks(self) -> Vec<Vec<u8>> {
-        vec![self.into_bytes()]
-    }
-}
-
-impl IntoChunks for &str {
-    fn into_chunks(self) -> Vec<Vec<u8>> {
-        vec![self.as_bytes().into()]
-    }
 }

--- a/tests/testing-framework/src/spin.rs
+++ b/tests/testing-framework/src/spin.rs
@@ -244,6 +244,8 @@ impl Drop for Spin {
 }
 
 impl Runtime for Spin {
+    type Config = SpinConfig;
+
     fn error(&mut self) -> anyhow::Result<()> {
         if !matches!(self.io_mode, IoMode::None) && self.try_wait()?.is_some() {
             anyhow::bail!("Spin exited early: {}", self.stderr());
@@ -251,6 +253,10 @@ impl Runtime for Spin {
 
         Ok(())
     }
+}
+
+pub struct SpinConfig {
+    pub binary_path: std::path::PathBuf,
 }
 
 fn kill_process(process: &mut std::process::Child) {

--- a/tests/testing-framework/src/test_environment.rs
+++ b/tests/testing-framework/src/test_environment.rs
@@ -191,3 +191,28 @@ impl TestEnvironmentConfig<Spin> {
         }
     }
 }
+
+pub struct InMemorySpin;
+
+impl Runtime for InMemorySpin {
+    type Config = ();
+
+    fn error(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+impl TestEnvironmentConfig<InMemorySpin> {
+    pub fn in_memory(
+        services_config: ServicesConfig,
+        preboot: impl FnOnce(&mut TestEnvironment<InMemorySpin>) -> anyhow::Result<()> + 'static,
+    ) -> Self {
+        Self {
+            services_config,
+            create_runtime: Box::new(|env| {
+                preboot(env)?;
+                Ok(InMemorySpin)
+            }),
+        }
+    }
+}


### PR DESCRIPTION
This adjusts the runtime tests to use a Spin runtime that exists in the same process as the tests instead of as a separate Spin process which should make tests faster and more reliable. 

This is also the second runtime the runtime tests support so it's a stress test that the runtime testing framework is flexible enough to support different runtimes. This should make it easier to add additional runtimes in the future.

*Reviewers note*: you might want to review the first two commits as the third commit is just refactoring which will make the actual substantial changes harder to parse. 