### PR TITLE
set host header on self outbound requests

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use clap::Args;
-use http::{uri::Scheme, StatusCode, Uri};
+use http::{header::HOST, uri::Scheme, HeaderValue, StatusCode, Uri};
 use http_body_util::BodyExt;
 use hyper::{
     body::{Bytes, Incoming},
@@ -490,6 +490,9 @@ impl OutboundWasiHttpHandler for HttpRuntimeData {
                 .parse()
                 // origin together with the path and query must be a valid URI
                 .unwrap();
+            let host = format!("{}:{}", uri.host().unwrap(), uri.port().unwrap());
+            let headers = request.request.headers_mut();
+            headers.insert(HOST, HeaderValue::from_str(&host)?);
 
             request.use_tls = uri
                 .scheme()


### PR DESCRIPTION
Set the host header so that more than one level of `self` requests work. Not entirely sure if this is the correct approach but fixes the test app I had calling `a -> b -> c`

fixes #2296 