### PR TITLE
Tweak spin-loader to be able to run in Wasm

### DIFF
--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.4.0"
 mime_guess = { version = "2.0" }
 outbound-http = { path = "../outbound-http", default-features = false }
 spin-outbound-networking = { path = "../outbound-networking" }
-path-absolutize = "3.0.11"
+path-absolutize = { version = "3.0.11", features = ["use_unix_paths_on_wasm"] }
 regex = "1.5.4"
 reqwest = "0.11.9"
 semver = "1.0"
@@ -31,7 +31,7 @@ spin-manifest = { path = "../manifest" }
 tempfile = "3.8.0"
 terminal = { path = "../terminal" }
 thiserror = "1.0.49"
-tokio = { version = "1.23", features = ["full"] }
+tokio = "1.23"
 tokio-util = "0.6"
 toml = "0.8.2"
 tracing = { workspace = true }
@@ -40,6 +40,10 @@ walkdir = "2.3.2"
 [dev-dependencies]
 tokio = { version = "1.23", features = ["rt", "macros"] }
 ui-testing = { path = "../ui-testing" }
+
+[features]
+default = ["async-io"]
+async-io = ["tokio/fs"]
 
 [[test]]
 name = "ui"

--- a/crates/loader/src/cache.rs
+++ b/crates/loader/src/cache.rs
@@ -1,9 +1,10 @@
 //! Cache for OCI registry entities.
 
 use anyhow::{ensure, Context, Result};
-use tokio::fs;
 
 use std::path::{Path, PathBuf};
+
+use crate::fs::{create_dir_all, write_file};
 
 const CONFIG_DIR: &str = "spin";
 const REGISTRY_CACHE_DIR: &str = "registry";
@@ -79,13 +80,13 @@ impl Cache {
 
     /// Write the contents in the cache's wasm directory.
     pub async fn write_wasm(&self, bytes: impl AsRef<[u8]>, digest: impl AsRef<str>) -> Result<()> {
-        fs::write(self.wasm_path(digest), bytes.as_ref()).await?;
+        write_file(&self.wasm_path(digest), bytes.as_ref()).await?;
         Ok(())
     }
 
     /// Write the contents in the cache's data directory.
     pub async fn write_data(&self, bytes: impl AsRef<[u8]>, digest: impl AsRef<str>) -> Result<()> {
-        fs::write(self.data_path(digest), bytes.as_ref()).await?;
+        write_file(&self.data_path(digest), bytes.as_ref()).await?;
         Ok(())
     }
 
@@ -110,21 +111,21 @@ impl Cache {
 
         let p = root.join(MANIFESTS_DIR);
         if !p.is_dir() {
-            fs::create_dir_all(&p).await.with_context(|| {
+            create_dir_all(&p).await.with_context(|| {
                 format!("failed to create manifests directory `{}`", p.display())
             })?;
         }
 
         let p = root.join(WASM_DIR);
         if !p.is_dir() {
-            fs::create_dir_all(&p)
+            create_dir_all(&p)
                 .await
                 .with_context(|| format!("failed to create wasm directory `{}`", p.display()))?;
         }
 
         let p = root.join(DATA_DIR);
         if !p.is_dir() {
-            fs::create_dir_all(&p)
+            create_dir_all(&p)
                 .await
                 .with_context(|| format!("failed to create assets directory `{}`", p.display()))?;
         }

--- a/crates/loader/src/fs.rs
+++ b/crates/loader/src/fs.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use std::path::Path;
+
+#[cfg(feature = "async-io")]
+mod io {
+    use super::*;
+
+    pub async fn write_file(path: &Path, bytes: &[u8]) -> Result<()> {
+        tokio::fs::write(path, bytes).await?;
+        Ok(())
+    }
+
+    pub async fn create_dir_all(path: &Path) -> Result<()> {
+        tokio::fs::create_dir_all(path).await?;
+        Ok(())
+    }
+
+    pub async fn copy(from: &Path, to: &Path) -> Result<u64> {
+        tokio::fs::copy(from, to).await.map_err(Into::into)
+    }
+
+    pub async fn metadata(path: &Path) -> Result<std::fs::Metadata> {
+        tokio::fs::metadata(path).await.map_err(Into::into)
+    }
+}
+
+#[cfg(not(feature = "async-io"))]
+mod io {
+    use super::*;
+
+    pub async fn write_file(path: &Path, bytes: &[u8]) -> Result<()> {
+        std::fs::write(path, bytes)?;
+        Ok(())
+    }
+
+    pub async fn create_dir_all(path: &Path) -> Result<()> {
+        std::fs::create_dir_all(path)?;
+        Ok(())
+    }
+
+    pub async fn copy(from: &Path, to: &Path) -> Result<u64> {
+        Ok(std::fs::copy(from, to)?)
+    }
+
+    pub async fn metadata(path: &Path) -> Result<std::fs::Metadata> {
+        Ok(std::fs::metadata(path)?)
+    }
+}
+
+pub use io::*;

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -12,12 +12,14 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use local::LocalLoader;
 use spin_common::paths::parent_dir;
 use spin_locked_app::locked::LockedApp;
 
 pub mod cache;
+mod fs;
+#[cfg(feature = "async-io")]
 mod http;
 mod local;
 
@@ -33,7 +35,7 @@ pub async fn from_file(
     cache_root: Option<PathBuf>,
 ) -> Result<LockedApp> {
     let path = manifest_path.as_ref();
-    let app_root = parent_dir(path)?;
+    let app_root = parent_dir(path).context("manifest path has no parent directory")?;
     let loader = LocalLoader::new(&app_root, files_mount_strategy, cache_root).await?;
     loader.load_file(path).await
 }


### PR DESCRIPTION
This allows the `spin-loader` crate to run in WebAssembly. 

This should be a no-op for non-Wasm code with one exception:
* `safe_canonicalize` now always runs through `path_absolutize::Absolutize` instead of only on Windows. If there's a reason this should not happen on Unix systems, let me know.

For WebAssembly, all features are supported except for downloading wasm from source. In a future PR, we'll need to figure out an appropriate wasi friendly replacement for `reqwest`.

For I/O the WebAssembly simply uses std lib's blocking alternatives rather than the tokio APIs. 