### PR TITLE
fix `push-templates-tag` grep pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Set the tag to spin/templates/v*
         shell: bash
         run: |
-          spin_tag=$(echo "${{ github.ref }}" | grep -Eo "refs/tags/v[0-9.]+")
+          spin_tag=$(echo "${{ github.ref }}" | grep -Eo "v[0-9.]+")
           IFS=. read -r major minor patch <<< "${spin_tag}"
           echo "TEMPLATE_TAG=spin/templates/$major.$minor" >> $GITHUB_ENV
 


### PR DESCRIPTION
I messed this one up the first time; we should convert e.g. refs/tags/v2.3.0 to spin/templates/v2.3, not spin/templates/refs/tags/v2.3.