### PR TITLE
point Go templates to `v2.2.0` instead of `main`

### DIFF
--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -2,6 +2,6 @@ module github.com/{{project-name | snake_case}}
 
 go 1.20
 
-require github.com/fermyon/spin/sdk/go/v2 main
+require github.com/fermyon/spin/sdk/go/v2 v2.2.0
 
 require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/templates/http-go/content/go.sum
+++ b/templates/http-go/content/go.sum
@@ -1,4 +1,4 @@
-github.com/fermyon/spin/sdk/go v1.5.1 h1:ROEw/Pooua8WjNzZJesuC4yTc3mGM7xeCIG+QSaQcvg=
-github.com/fermyon/spin/sdk/go v1.5.1/go.mod h1:BqOVRDNjh2LtRUX76TF6d0R+GsG7NAncgzcj0Xnjs5I=
+github.com/fermyon/spin/sdk/go/v2 v2.2.0 h1:zHZdIqjbUwyxiwdygHItnM+vUUNSZ3CX43jbIUemBI4=
+github.com/fermyon/spin/sdk/go/v2 v2.2.0/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.20
 
-require github.com/fermyon/spin/sdk/go/v2 main
+require github.com/fermyon/spin/sdk/go/v2 v2.2.0

--- a/templates/redis-go/content/go.sum
+++ b/templates/redis-go/content/go.sum
@@ -1,3 +1,2 @@
-github.com/fermyon/spin/sdk/go v1.5.1 h1:ROEw/Pooua8WjNzZJesuC4yTc3mGM7xeCIG+QSaQcvg=
-github.com/fermyon/spin/sdk/go v1.5.1/go.mod h1:BqOVRDNjh2LtRUX76TF6d0R+GsG7NAncgzcj0Xnjs5I=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/fermyon/spin/sdk/go/v2 v2.2.0 h1:zHZdIqjbUwyxiwdygHItnM+vUUNSZ3CX43jbIUemBI4=
+github.com/fermyon/spin/sdk/go/v2 v2.2.0/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=


### PR DESCRIPTION
CI used to take care of this when the SDKs lived in this repo and were versioned in lock-step with Spin itself.  Now that neither of those are true, we'll need to update the versions manually as necessary.

Once this is merged into `main`, I'll backport it to the 2.3.0 tags.