### PR TITLE
fix(cmd/up): --help takes precedence over --build

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -151,10 +151,6 @@ impl UpCommand {
             }
         }
 
-        if self.build {
-            app_source.build().await?;
-        }
-
         // Get working dir holder and hold on to it for the rest of the function.
         // If the working dir is a temporary dir it will be deleted on drop.
         let working_dir_holder = self.get_canonical_working_dir()?;
@@ -184,6 +180,10 @@ impl UpCommand {
                 _ = help_process.wait().await;
             }
             return Ok(());
+        }
+
+        if self.build {
+            app_source.build().await?;
         }
 
         let mut locked_app = self


### PR DESCRIPTION
We shouldn't build applications when the user is requesting help.

I also did a quick local test to make sure a missing component binary doesn't print any new errors/cause issues when `--help`ing - and that the re-ordering is safe (`spin up --build` still works) although i assume our integration tests already somewhat cover that path.

fixes #2323 