### PR TITLE
Use the bundled version of paho and remove vendored openssl

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -78,6 +78,12 @@ inputs:
     default: 'false'
     type: bool
 
+  vcpkg:
+    description: 'setup vcpkg'
+    required: false
+    default: 'false'
+    type: bool
+
 runs:
   using: "composite"
   steps:
@@ -129,3 +135,11 @@ runs:
       if: ${{ inputs.tinygo == 'true' }}
       with:
         version: ${{ inputs.tinygo-version }}
+
+    ## Install vcpgk
+    - name: "Install vcpkg"
+      run: |
+        echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        vcpkg install openssl:x64-windows-static-md
+      shell: pwsh
+      if: ${{ inputs.vcpkg == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
           rust: true
           rust-wasm: true
           rust-cache: true
+          vcpkg: "${{ matrix.os == 'windows-latest' }}"
 
       - name: Cargo Build
         run: cargo build --workspace --release --all-targets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,11 @@ jobs:
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
           echo 'rustflags = ["-Ctarget-feature=+fp16"]' >> ${HOME}/.cargo/config.toml
 
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
+        with:
+          vcpkg: "${{ matrix.os == 'windows-latest' }}"
+
       - name: build release
         shell: bash
         run: cargo build --release ${{ matrix.config.extraArgs }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,15 +4146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.2.3+3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,7 +4153,6 @@ checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4315,7 +4305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e482419d847af4ec43c07eed70f5f94f87dc712d267aecc91ab940944ab6bf4"
 dependencies = [
  "cmake",
- "openssl-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,6 +4305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e482419d847af4ec43c07eed70f5f94f87dc712d267aecc91ab940944ab6bf4"
 dependencies = [
  "cmake",
+ "openssl-sys",
 ]
 
 [[package]]

--- a/crates/outbound-mqtt/Cargo.toml
+++ b/crates/outbound-mqtt/Cargo.toml
@@ -9,9 +9,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-paho-mqtt = { version = "0.12.3", default-features = false, features = [
-    "bundled",
-] }
+paho-mqtt = "0.12.3"
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }

--- a/crates/outbound-mqtt/Cargo.toml
+++ b/crates/outbound-mqtt/Cargo.toml
@@ -9,7 +9,9 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0"
-paho-mqtt = { version = "0.12.3", default-features = false, features = ["vendored-ssl"] }
+paho-mqtt = { version = "0.12.3", default-features = false, features = [
+    "bundled",
+] }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -2509,15 +2509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.2.1+3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,7 +2516,6 @@ checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2672,7 +2662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e482419d847af4ec43c07eed70f5f94f87dc712d267aecc91ab940944ab6bf4"
 dependencies = [
  "cmake",
- "openssl-sys",
 ]
 
 [[package]]

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -2662,6 +2662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e482419d847af4ec43c07eed70f5f94f87dc712d267aecc91ab940944ab6bf4"
 dependencies = [
  "cmake",
+ "openssl-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
It seems that we're building openssl from source which causes all kinds of build issues. It's not clear to me why this is needed instead of going to default route of bundling the paho C library which allows us to not have to build openssl from source.

cc @suneetnangia for insights into the original thought behind how we were building `paho-mqtt`.