### PR TITLE
Remove credentials before printing Redis subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6483,6 +6483,7 @@ dependencies = [
  "redis 0.21.7",
  "serde",
  "spin-app",
+ "spin-common",
  "spin-core",
  "spin-expressions",
  "spin-testing",

--- a/crates/common/src/url.rs
+++ b/crates/common/src/url.rs
@@ -11,3 +11,34 @@ pub fn parse_file_url(url: &str) -> anyhow::Result<PathBuf> {
         .to_file_path()
         .map_err(|_| anyhow!("Invalid file URL path: {url:?}"))
 }
+
+/// Remove the credentials from a URL string
+pub fn remove_credentials(url: &str) -> anyhow::Result<String> {
+    let mut url = url::Url::parse(url).with_context(|| format!("Invalid URL: {url:?}"))?;
+    url.set_username("")
+        .map_err(|_| anyhow!("Could not remove username"))?;
+    url.set_password(None)
+        .map_err(|_| anyhow!("Could not remove password"))?;
+    Ok(url.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn remove_credentials_removes_credentials() {
+        assert_eq!(
+            "redis://example.com:4567",
+            remove_credentials("redis://example.com:4567").unwrap()
+        );
+        assert_eq!(
+            "redis://example.com:4567",
+            remove_credentials("redis://me:secret@example.com:4567").unwrap()
+        );
+        assert_eq!(
+            "http://example.com/users",
+            remove_credentials("http://me:secret@example.com/users").unwrap()
+        );
+    }
+}

--- a/crates/trigger-redis/Cargo.toml
+++ b/crates/trigger-redis/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1"
 futures = "0.3"
 serde = "1.0.188"
 spin-app = { path = "../app" }
+spin-common = { path = "../common" }
 spin-core = { path = "../core" }
 spin-expressions = { path = "../expressions" }
 spin-trigger = { path = "../trigger" }


### PR DESCRIPTION
Fixes #2341.

@seungjin can you test this please?  I don't have a Redis instance that accepts credentials, and due to a separate issue that seems to prevent me from checking the output.  Thanks!
