### PR TITLE
remove `pip3 install componentize-py` from `http_python_template_smoke_test`

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -413,9 +413,6 @@ Caused by:
             let mut tidy = std::process::Command::new("pip3");
             tidy.args(["install", "-r", "requirements.txt", "-t", "."]);
             env.run_in(&mut tidy)?;
-            let mut tidy = std::process::Command::new("pip3");
-            tidy.args(["install", "componentize-py"]);
-            env.run_in(&mut tidy)?;
             Ok(())
         };
         http_smoke_test_template(


### PR DESCRIPTION
It was redundant and contradictory since the `requirements.txt` specifies to install a specific version, which is not necessarily the latest version.