### PR TITLE
Seize control of the means of producing 404s

### DIFF
--- a/crates/plugins/tests/nonexistent-url/nonexistent-url.json
+++ b/crates/plugins/tests/nonexistent-url/nonexistent-url.json
@@ -7,7 +7,7 @@
         {
             "os": "linux",
             "arch": "amd64",
-            "url": "http://example.com/402f926a-44e3-4d62-93c1-ecc39761afbe",
+            "url": "https://random-data-api.fermyon.app/snuffleupaguses/png",
             "sha256": "ho ho ho"
         }
     ]


### PR DESCRIPTION
The joyless suits of Big Example have changed example.com to return 500s instead of 404s, resulting in a spurious test failure.  Fortunately a plucky startup is ready to take up the reins.
