### PR TITLE
Refactor `TriggerExecutor` to have associated types for instances

### DIFF
--- a/crates/trigger-http/src/handler.rs
+++ b/crates/trigger-http/src/handler.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, str, str::FromStr};
 
-use crate::{Body, HttpExecutor, HttpTrigger, Store};
+use crate::{Body, HttpExecutor, HttpInstance, HttpTrigger, Store};
 use anyhow::bail;
 use anyhow::{anyhow, Context, Result};
 use futures::TryFutureExt;
@@ -13,7 +13,7 @@ use spin_core::wasi_2023_10_18::exports::wasi::http::incoming_handler::Guest as 
 use spin_core::wasi_2023_11_10::exports::wasi::http::incoming_handler::Guest as IncomingHandler2023_11_10;
 use spin_core::Instance;
 use spin_http::body;
-use spin_trigger::{EitherInstance, TriggerAppEngine};
+use spin_trigger::TriggerAppEngine;
 use spin_world::v1::http_types;
 use std::sync::Arc;
 use tokio::{sync::oneshot, task};
@@ -39,7 +39,7 @@ impl HttpExecutor for HttpHandlerExecutor {
         );
 
         let (instance, mut store) = engine.prepare_instance(component_id).await?;
-        let EitherInstance::Component(instance) = instance else {
+        let HttpInstance::Component(instance) = instance else {
             unreachable!()
         };
 

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -32,7 +32,7 @@ use spin_http::{
     routes::{RoutePattern, Router},
 };
 use spin_outbound_networking::{AllowedHostsConfig, OutboundUrl};
-use spin_trigger::{EitherInstancePre, TriggerAppEngine, TriggerExecutor};
+use spin_trigger::{TriggerAppEngine, TriggerExecutor, TriggerInstancePre};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpListener,
@@ -86,12 +86,23 @@ impl CliArgs {
     }
 }
 
+pub enum HttpInstancePre {
+    Component(spin_core::InstancePre<RuntimeData>),
+    Module(spin_core::ModuleInstancePre<RuntimeData>),
+}
+
+pub enum HttpInstance {
+    Component(spin_core::Instance),
+    Module(spin_core::ModuleInstance),
+}
+
 #[async_trait]
 impl TriggerExecutor for HttpTrigger {
     const TRIGGER_TYPE: &'static str = "http";
     type RuntimeData = RuntimeData;
     type TriggerConfig = HttpTriggerConfig;
     type RunConfig = CliArgs;
+    type InstancePre = HttpInstancePre;
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
         let mut base = engine
@@ -167,20 +178,37 @@ impl TriggerExecutor for HttpTrigger {
         };
         Ok(())
     }
+}
+
+#[async_trait]
+impl TriggerInstancePre<RuntimeData, HttpTriggerConfig> for HttpInstancePre {
+    type Instance = HttpInstance;
 
     async fn instantiate_pre(
-        engine: &Engine<Self::RuntimeData>,
+        engine: &Engine<RuntimeData>,
         component: &AppComponent,
-        config: &Self::TriggerConfig,
-    ) -> Result<EitherInstancePre<Self::RuntimeData>> {
+        config: &HttpTriggerConfig,
+    ) -> Result<HttpInstancePre> {
         if let Some(HttpExecutorType::Wagi(_)) = &config.executor {
             let module = component.load_module(engine).await?;
-            Ok(EitherInstancePre::Module(
+            Ok(HttpInstancePre::Module(
                 engine.module_instantiate_pre(&module)?,
             ))
         } else {
             let comp = component.load_component(engine).await?;
-            Ok(EitherInstancePre::Component(engine.instantiate_pre(&comp)?))
+            Ok(HttpInstancePre::Component(engine.instantiate_pre(&comp)?))
+        }
+    }
+
+    async fn instantiate(&self, store: &mut Store) -> Result<HttpInstance> {
+        match self {
+            HttpInstancePre::Component(pre) => pre
+                .instantiate_async(store)
+                .await
+                .map(HttpInstance::Component),
+            HttpInstancePre::Module(pre) => {
+                pre.instantiate_async(store).await.map(HttpInstance::Module)
+            }
         }
     }
 }

--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -1,12 +1,13 @@
 use std::{io::Cursor, net::SocketAddr};
 
+use crate::HttpInstance;
 use anyhow::{anyhow, ensure, Context, Result};
 use async_trait::async_trait;
 use http_body_util::BodyExt;
 use hyper::{Request, Response};
 use spin_core::WasiVersion;
 use spin_http::{config::WagiTriggerConfig, routes::RoutePattern, wagi};
-use spin_trigger::{EitherInstance, TriggerAppEngine};
+use spin_trigger::TriggerAppEngine;
 use wasi_common_preview1::{pipe::WritePipe, I32Exit};
 
 use crate::{Body, HttpExecutor, HttpTrigger};
@@ -93,7 +94,7 @@ impl HttpExecutor for WagiHttpExecutor {
             .prepare_instance_with_store(component, store_builder)
             .await?;
 
-        let EitherInstance::Module(instance) = instance else {
+        let HttpInstance::Module(instance) = instance else {
             unreachable!()
         };
 

--- a/crates/trigger-redis/src/lib.rs
+++ b/crates/trigger-redis/src/lib.rs
@@ -7,7 +7,7 @@ use futures::{future::join_all, StreamExt};
 use redis::{Client, ConnectionLike};
 use serde::{de::IgnoredAny, Deserialize, Serialize};
 use spin_common::url::remove_credentials;
-use spin_core::async_trait;
+use spin_core::{async_trait, InstancePre};
 use spin_trigger::{cli::NoArgs, TriggerAppEngine, TriggerExecutor};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -53,6 +53,7 @@ impl TriggerExecutor for RedisTrigger {
     type RuntimeData = RuntimeData;
     type TriggerConfig = RedisTriggerConfig;
     type RunConfig = NoArgs;
+    type InstancePre = InstancePre<RuntimeData>;
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
         let default_address: String = engine

--- a/crates/trigger-redis/src/spin.rs
+++ b/crates/trigger-redis/src/spin.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use spin_core::Instance;
-use spin_trigger::{EitherInstance, TriggerAppEngine};
+use spin_trigger::TriggerAppEngine;
 use spin_world::v1::redis_types::{Error, Payload};
 
 use crate::{RedisExecutor, RedisTrigger, Store};
@@ -21,9 +21,6 @@ impl RedisExecutor for SpinRedisExecutor {
         tracing::trace!("Executing request using the Spin executor for component {component_id}");
 
         let (instance, store) = engine.prepare_instance(component_id).await?;
-        let EitherInstance::Component(instance) = instance else {
-            unreachable!()
-        };
 
         match Self::execute_impl(store, instance, channel, payload.to_vec()).await {
             Ok(()) => {

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -291,6 +291,7 @@ pub mod help {
         type RuntimeData = ();
         type TriggerConfig = ();
         type RunConfig = NoArgs;
+        type InstancePre = spin_core::InstancePre<Self::RuntimeData>;
         async fn new(_: crate::TriggerAppEngine<Self>) -> Result<Self> {
             Ok(Self)
         }


### PR DESCRIPTION
Moves the `EitherInstance*` logic into just the `spin-trigger-http` crate where the redis trigger, for example, only has to deal with components. The intention of this is to open up future customization of instances within a trigger that don't necessarily need to affect all other triggers.