### PR TITLE
nit: fix label on openssl setup

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -78,8 +78,8 @@ inputs:
     default: 'false'
     type: bool
 
-  vcpkg:
-    description: 'setup vcpkg'
+  openssl-windows:
+    description: 'setup openssl on windows'
     required: false
     default: 'false'
     type: bool
@@ -136,10 +136,10 @@ runs:
       with:
         version: ${{ inputs.tinygo-version }}
 
-    ## Install vcpgk
-    - name: "Install vcpkg"
+    ## Install openssl
+    - name: "Install openssl on windows"
       run: |
         echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
         vcpkg install openssl:x64-windows-static-md
       shell: pwsh
-      if: ${{ inputs.vcpkg == 'true' }}
+      if: ${{ inputs.openssl-windows == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           rust: true
           rust-wasm: true
           rust-cache: true
-          vcpkg: "${{ matrix.os == 'windows-latest' }}"
+          openssl-windows: "${{ matrix.os == 'windows-latest' }}"
 
       - name: Cargo Build
         run: cargo build --workspace --release --all-targets
@@ -280,8 +280,7 @@ jobs:
       - name: setup dependencies
         uses: ./.github/actions/spin-ci-dependencies
         with:
-          vcpkg: "${{ matrix.os == 'windows-latest' }}"
-          openssl-mac: "${{ matrix.os == 'macos-latest' }}"
+          openssl-windows: "${{ matrix.os == 'windows-latest' }}"
 
       - name: build release
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       - name: setup dependencies
         uses: ./.github/actions/spin-ci-dependencies
         with:
-          vcpkg: "${{ matrix.os == 'windows-latest' }}"
+          openssl-windows: "${{ matrix.os == 'windows-latest' }}"
 
       - name: build release
         shell: bash


### PR DESCRIPTION
This PR changes the label for composite action to reflect that we are setting up `openssl for windows using vcpkg` (as opposed to saying `installing vcpkg`)