### PR TITLE
More forgiving caching

### DIFF
--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -222,6 +222,7 @@ impl LocalLoader {
         } else {
             let _loading_permit = self.file_loading_permits.acquire().await?;
 
+            self.cache.ensure_dirs().await?;
             let dest = self.cache.wasm_path(digest);
             verified_download(url, digest, &dest)
                 .await

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -57,6 +57,10 @@ pub struct Push {
     /// This is a string whose format is defined by the registry standard, and generally consists of <registry>/<username>/<application-name>:<version>. E.g. ghcr.io/ogghead/spin-test-app:0.1.0
     #[clap()]
     pub reference: String,
+
+    /// Cache directory for downloaded registry data.
+    #[clap(long)]
+    pub cache_dir: Option<PathBuf>,
 }
 
 impl Push {
@@ -66,7 +70,8 @@ impl Push {
             spin_build::build(&app_file, &[]).await?;
         }
 
-        let mut client = spin_oci::Client::new(self.insecure, None).await?;
+        let mut client =
+            spin_oci::Client::new(self.insecure, self.cache_dir.clone()).await?;
 
         let _spinner = create_dotted_spinner(2000, "Pushing app to the Registry".to_owned());
 
@@ -95,12 +100,17 @@ pub struct Pull {
     /// This is a string whose format is defined by the registry standard, and generally consists of <registry>/<username>/<application-name>:<version>. E.g. ghcr.io/ogghead/spin-test-app:0.1.0
     #[clap()]
     pub reference: String,
+
+    /// Cache directory for downloaded registry data.
+    #[clap(long)]
+    pub cache_dir: Option<PathBuf>,
 }
 
 impl Pull {
     /// Pull a Spin application from an OCI registry
     pub async fn run(self) -> Result<()> {
-        let mut client = spin_oci::Client::new(self.insecure, None).await?;
+        let mut client =
+            spin_oci::Client::new(self.insecure, self.cache_dir.clone()).await?;
 
         let _spinner = create_dotted_spinner(2000, "Pulling app from the Registry".to_owned());
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -70,8 +70,7 @@ impl Push {
             spin_build::build(&app_file, &[]).await?;
         }
 
-        let mut client =
-            spin_oci::Client::new(self.insecure, self.cache_dir.clone()).await?;
+        let mut client = spin_oci::Client::new(self.insecure, self.cache_dir.clone()).await?;
 
         let _spinner = create_dotted_spinner(2000, "Pushing app to the Registry".to_owned());
 
@@ -109,8 +108,7 @@ pub struct Pull {
 impl Pull {
     /// Pull a Spin application from an OCI registry
     pub async fn run(self) -> Result<()> {
-        let mut client =
-            spin_oci::Client::new(self.insecure, self.cache_dir.clone()).await?;
+        let mut client = spin_oci::Client::new(self.insecure, self.cache_dir.clone()).await?;
 
         let _spinner = create_dotted_spinner(2000, "Pulling app from the Registry".to_owned());
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -95,6 +95,10 @@ pub struct UpCommand {
     #[clap(long = "temp", alias = "tmp")]
     pub tmp: Option<PathBuf>,
 
+    /// Cache directory for downloaded components and assets.
+    #[clap(long)]
+    pub cache_dir: Option<PathBuf>,
+
     /// For local apps with directory mounts and no excluded files, mount them directly instead of using a temporary
     /// directory.
     ///
@@ -421,7 +425,7 @@ impl UpCommand {
             // TODO: We could make the `--help` experience a little faster if
             // we could fetch just the locked app JSON at this stage.
             AppSource::OciRegistry(reference) => {
-                let mut client = spin_oci::Client::new(self.insecure, None)
+                let mut client = spin_oci::Client::new(self.insecure, self.cache_dir.clone())
                     .await
                     .context("cannot create registry client")?;
 
@@ -448,7 +452,7 @@ impl UpCommand {
                 } else {
                     FilesMountStrategy::Copy(working_dir.join("assets"))
                 };
-                spin_loader::from_file(&manifest_path, files_mount_strategy, None)
+                spin_loader::from_file(&manifest_path, files_mount_strategy, self.cache_dir.clone())
                     .await
                     .with_context(|| {
                         format!(


### PR DESCRIPTION
Fixes #2339.

This provides an option to override the registry/download cache directory.  (I've called it download because it's used for more than registry stuff, although that might feel a bit weird on `spin registry push`.  Open to feedback!)

This also creates the cache directory only on demand.  If a problem occurs, the user still finds out about it during startup; but if the cache is never needed, there is no need for the user to cajole Spin into using a better directory.  Note that only the write methods trigger directory creation; "xxx_file" methods already return an error if the path/file doesn't exist, and "xxx_path" methods make it clear that the caller should not assume the path exists.  Still this is an area where reviewer persnicketiness is advised.

The two chunks are separate commits in case we want to take only one of them.
