### PR TITLE
Revert "use ubuntu 20.04 for PR workflow to make it consistent with release workflow"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   lint-rust:
     name: Lint Rust
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     permissions:
       ## Allow this job to potentially cancel the running workflow (on failure)
       actions: write
@@ -53,7 +53,7 @@ jobs:
   ## This is separated out to remove full integration tests dependencies on windows/mac builds
   build-rust-ubuntu:
     name: Build Spin Ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -77,7 +77,7 @@ jobs:
 
   build-spin-static:
     name: Build Spin static
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         config:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,7 @@ jobs:
   ## statically linked spin binaries
   build-spin-static:
     name: Build Spin static
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       # cosign uses the GitHub OIDC token
       id-token: write


### PR DESCRIPTION
Reverts fermyon/spin#2378

I foolishly overrode the CI check because I didn't see how it was possibly caused by the PR. I'm currently debugging and _still_ don't understand how it failed but we'll revert for now to prevent further PR breakage.