### PR TITLE
ci: Include os-release in cache key

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -104,10 +104,16 @@ runs:
       if: ${{ inputs.rust-cross == 'true' }}
       shell: bash
 
+    # hashFiles only works on files in the workspace
+    - name: "Copy os-release for cache key"
+      run: cp /etc/os-release .
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+
     - uses: Swatinem/rust-cache@v2
       if: ${{ inputs.rust-cache == 'true' }}
       with:
-        shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+        shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock', './os-release') }}"
 
     ## Install nomad
     - name: Install nomad


### PR DESCRIPTION
This will hopefully prevent the cache from sharing across incompatible e.g. glibc versions.