### PR TITLE
Allow `spin-expressions` and `spin-outbound-networking` to compile to wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6134,11 +6134,10 @@ dependencies = [
  "dotenvy",
  "once_cell",
  "serde",
- "spin-app",
+ "spin-locked-app",
  "thiserror",
  "tokio",
  "toml 0.5.11",
- "vaultrs",
 ]
 
 [[package]]

--- a/crates/expressions/Cargo.toml
+++ b/crates/expressions/Cargo.toml
@@ -9,11 +9,10 @@ anyhow = "1.0"
 async-trait = "0.1"
 dotenvy = "0.15"
 once_cell = "1"
-spin-app = { path = "../app" }
+spin-locked-app = { path = "../locked-app" }
 thiserror = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-vaultrs = "0.6.2"
 serde = "1.0.188"
 
 [dev-dependencies]
 toml = "0.5"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/expressions/src/lib.rs
+++ b/crates/expressions/src/lib.rs
@@ -3,7 +3,7 @@ mod template;
 
 use std::{borrow::Cow, collections::HashMap, fmt::Debug};
 
-use spin_app::Variable;
+use spin_locked_app::Variable;
 
 pub use provider::Provider;
 use template::Part;

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -3928,10 +3928,8 @@ dependencies = [
  "dotenvy",
  "once_cell",
  "serde",
- "spin-app",
+ "spin-locked-app",
  "thiserror",
- "tokio",
- "vaultrs",
 ]
 
 [[package]]


### PR DESCRIPTION
This is needed for my work on testing Spin apps where the outbound networking check will run inside of wasm. 