### PR TITLE
Allow modular manifest files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5951,6 +5951,7 @@ version = "2.4.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
+ "indexmap 1.9.3",
  "serde",
  "spin-common",
  "spin-manifest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6327,6 +6327,7 @@ dependencies = [
  "indexmap 1.9.3",
  "serde",
  "serde_json",
+ "spin-common",
  "spin-serde",
  "terminal",
  "thiserror",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0.57"
 futures = "0.3.21"
+indexmap = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -138,4 +138,17 @@ mod tests {
         let bad_trigger_file = test_data_root().join("bad_trigger.toml");
         build(&bad_trigger_file, &[]).await.unwrap();
     }
+
+    #[tokio::test]
+    async fn can_load_inline_components() -> anyhow::Result<()> {
+        let inline_comp_file = test_data_root().join("inline.toml");
+        let build_configs = component_build_configs(&inline_comp_file).await?;
+        assert_eq!(1, build_configs.len());
+        assert!(build_configs[0].build.is_some());
+        assert_eq!(
+            "echo done",
+            build_configs[0].build.as_ref().unwrap().command
+        );
+        Ok(())
+    }
 }

--- a/crates/build/src/manifest.rs
+++ b/crates/build/src/manifest.rs
@@ -97,7 +97,7 @@ impl TryFrom<toml::Value> for ComponentSpec {
             Some(s) => match s.strip_prefix('@') {
                 Some(path) => Ok(ComponentSpec::External(std::path::PathBuf::from(path))),
                 None => Ok(ComponentSpec::Reference(s.to_string())),
-            }
+            },
             None => Ok(ComponentSpec::Inline(Box::new(
                 ComponentBuildInfo::deserialize(value)?,
             ))),
@@ -107,7 +107,7 @@ impl TryFrom<toml::Value> for ComponentSpec {
 
 fn load_cbi_from(path: &Path, app_root: &Path) -> anyhow::Result<ComponentBuildInfo> {
     // moar duplication, we hates it precious
-    let abs_path = app_root.join(&path);
+    let abs_path = app_root.join(path);
     let (abs_path, containing_dir) = if abs_path.is_file() {
         (abs_path, path.parent().unwrap().to_owned())
     } else if abs_path.is_dir() {
@@ -115,15 +115,22 @@ fn load_cbi_from(path: &Path, app_root: &Path) -> anyhow::Result<ComponentBuildI
         if inferred.is_file() {
             (inferred, path.to_owned())
         } else {
-            anyhow::bail!("{} does not contain a spin-component.toml file", quoted_path(&abs_path));
+            anyhow::bail!(
+                "{} does not contain a spin-component.toml file",
+                quoted_path(&abs_path)
+            );
         }
     } else {
         anyhow::bail!("{} does not exist", quoted_path(abs_path));
     };
 
     let toml_text = std::fs::read_to_string(&abs_path)?;
-    let mut component: ComponentBuildInfo = toml::from_str(&toml_text)
-        .with_context(|| format!("{} is not a valid component manifest", quoted_path(&abs_path)))?;
+    let mut component: ComponentBuildInfo = toml::from_str(&toml_text).with_context(|| {
+        format!(
+            "{} is not a valid component manifest",
+            quoted_path(&abs_path)
+        )
+    })?;
 
     if let Some(build) = &mut component.build {
         let workdir = match &build.workdir {

--- a/crates/build/src/manifest.rs
+++ b/crates/build/src/manifest.rs
@@ -17,18 +17,87 @@ pub async fn component_build_configs(
         }
         ManifestVersion::V2 => {
             let v2: ManifestV2BuildInfo = toml::from_str(&manifest_text)?;
+            let inlines = v2.triggers.values().flat_map(|triggers| {
+                triggers
+                    .iter()
+                    .flat_map(|tr| tr.component_specs())
+                    .filter_map(|spec| spec.buildinfo())
+            });
             v2.components
                 .into_iter()
                 .map(|(id, mut c)| {
                     c.id = id;
                     c
                 })
+                .chain(inlines)
                 .collect()
         }
     })
 }
 
 #[derive(Deserialize)]
+pub struct TriggerBuildInfo {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub id: String,
+    /// `component = ...`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component: Option<ComponentSpec>,
+    /// `components = { ... }`
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub components: indexmap::IndexMap<String, OneOrManyComponentSpecs>,
+}
+
+impl TriggerBuildInfo {
+    fn component_specs(&self) -> Vec<&ComponentSpec> {
+        match &self.component {
+            Some(spec) => vec![spec],
+            None => self
+                .components
+                .values()
+                .flat_map(|specs| &specs.0)
+                .collect(),
+        }
+    }
+}
+
+/// One or many `ComponentSpec`(s)
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub struct OneOrManyComponentSpecs(#[serde(with = "one_or_many")] pub Vec<ComponentSpec>);
+
+/// Component reference or inline definition
+#[derive(Deserialize)]
+#[serde(untagged, try_from = "toml::Value")]
+pub enum ComponentSpec {
+    /// `"component-id"`
+    Reference(String),
+    /// `{ ... }`
+    Inline(Box<ComponentBuildInfo>),
+}
+
+impl ComponentSpec {
+    fn buildinfo(&self) -> Option<ComponentBuildInfo> {
+        match self {
+            Self::Reference(_) => None, // Will be picked up from `components` section
+            Self::Inline(cbi) => Some(*cbi.clone()),
+        }
+    }
+}
+
+impl TryFrom<toml::Value> for ComponentSpec {
+    type Error = toml::de::Error;
+
+    fn try_from(value: toml::Value) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            Some(s) => Ok(ComponentSpec::Reference(s.to_string())),
+            None => Ok(ComponentSpec::Inline(Box::new(
+                ComponentBuildInfo::deserialize(value)?,
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, Deserialize)]
 pub struct ComponentBuildInfo {
     #[serde(default)]
     pub id: String,
@@ -43,6 +112,25 @@ struct ManifestV1BuildInfo {
 
 #[derive(Deserialize)]
 struct ManifestV2BuildInfo {
-    #[serde(rename = "component")]
+    #[serde(rename = "trigger")]
+    pub triggers: indexmap::IndexMap<String, Vec<TriggerBuildInfo>>,
+    #[serde(default, rename = "component")]
     components: BTreeMap<String, ComponentBuildInfo>,
+}
+
+mod one_or_many {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+    where
+        T: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        let value = toml::Value::deserialize(deserializer)?;
+        if let Ok(val) = T::deserialize(value.clone()) {
+            Ok(vec![val])
+        } else {
+            Vec::deserialize(value).map_err(serde::de::Error::custom)
+        }
+    }
 }

--- a/crates/build/src/manifest.rs
+++ b/crates/build/src/manifest.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Deserialize;
+use spin_common::ui::quoted_path;
 use std::{collections::BTreeMap, path::Path};
 
 use spin_manifest::{schema::v2, ManifestVersion};
@@ -9,11 +10,12 @@ use spin_manifest::{schema::v2, ManifestVersion};
 pub async fn component_build_configs(
     manifest_file: impl AsRef<Path>,
 ) -> Result<Vec<ComponentBuildInfo>> {
-    let manifest_text = tokio::fs::read_to_string(manifest_file).await?;
-    Ok(match ManifestVersion::detect(&manifest_text)? {
+    let app_root = manifest_file.as_ref().parent().unwrap();
+    let manifest_text = tokio::fs::read_to_string(manifest_file.as_ref()).await?;
+    match ManifestVersion::detect(&manifest_text)? {
         ManifestVersion::V1 => {
             let v1: ManifestV1BuildInfo = toml::from_str(&manifest_text)?;
-            v1.components
+            Ok(v1.components)
         }
         ManifestVersion::V2 => {
             let v2: ManifestV2BuildInfo = toml::from_str(&manifest_text)?;
@@ -21,18 +23,18 @@ pub async fn component_build_configs(
                 triggers
                     .iter()
                     .flat_map(|tr| tr.component_specs())
-                    .filter_map(|spec| spec.buildinfo())
+                    .filter_map(|spec| spec.buildinfo(app_root))
             });
             v2.components
                 .into_iter()
                 .map(|(id, mut c)| {
                     c.id = id;
-                    c
+                    Ok(c)
                 })
                 .chain(inlines)
                 .collect()
         }
-    })
+    }
 }
 
 #[derive(Deserialize)]
@@ -73,13 +75,16 @@ pub enum ComponentSpec {
     Reference(String),
     /// `{ ... }`
     Inline(Box<ComponentBuildInfo>),
+    /// `"@my-component/spin-component.toml"`
+    External(std::path::PathBuf),
 }
 
 impl ComponentSpec {
-    fn buildinfo(&self) -> Option<ComponentBuildInfo> {
+    fn buildinfo(&self, app_root: &Path) -> Option<anyhow::Result<ComponentBuildInfo>> {
         match self {
             Self::Reference(_) => None, // Will be picked up from `components` section
-            Self::Inline(cbi) => Some(*cbi.clone()),
+            Self::Inline(cbi) => Some(Ok(*cbi.clone())),
+            Self::External(path) => Some(load_cbi_from(path, app_root)),
         }
     }
 }
@@ -89,12 +94,46 @@ impl TryFrom<toml::Value> for ComponentSpec {
 
     fn try_from(value: toml::Value) -> Result<Self, Self::Error> {
         match value.as_str() {
-            Some(s) => Ok(ComponentSpec::Reference(s.to_string())),
+            Some(s) => match s.strip_prefix('@') {
+                Some(path) => Ok(ComponentSpec::External(std::path::PathBuf::from(path))),
+                None => Ok(ComponentSpec::Reference(s.to_string())),
+            }
             None => Ok(ComponentSpec::Inline(Box::new(
                 ComponentBuildInfo::deserialize(value)?,
             ))),
         }
     }
+}
+
+fn load_cbi_from(path: &Path, app_root: &Path) -> anyhow::Result<ComponentBuildInfo> {
+    // moar duplication, we hates it precious
+    let abs_path = app_root.join(&path);
+    let (abs_path, containing_dir) = if abs_path.is_file() {
+        (abs_path, path.parent().unwrap().to_owned())
+    } else if abs_path.is_dir() {
+        let inferred = abs_path.join("spin-component.toml");
+        if inferred.is_file() {
+            (inferred, path.to_owned())
+        } else {
+            anyhow::bail!("{} does not contain a spin-component.toml file", quoted_path(&abs_path));
+        }
+    } else {
+        anyhow::bail!("{} does not exist", quoted_path(abs_path));
+    };
+
+    let toml_text = std::fs::read_to_string(&abs_path)?;
+    let mut component: ComponentBuildInfo = toml::from_str(&toml_text)
+        .with_context(|| format!("{} is not a valid component manifest", quoted_path(&abs_path)))?;
+
+    if let Some(build) = &mut component.build {
+        let workdir = match &build.workdir {
+            Some(w) => containing_dir.join(w).to_string_lossy().to_string(),
+            None => containing_dir.to_string_lossy().to_string(),
+        };
+        build.workdir = Some(workdir);
+    }
+
+    Ok(component)
 }
 
 #[derive(Clone, Deserialize)]

--- a/crates/build/tests/inline.toml
+++ b/crates/build/tests/inline.toml
@@ -1,0 +1,8 @@
+spin_manifest_version = 2
+
+[application]
+name = "inline"
+
+[[trigger.http]]
+route = "/..."
+component = { source = "test.wasm", build = { command = "echo done" } }

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -68,7 +68,7 @@ impl LocalLoader {
 
     // Load the given manifest into a LockedApp, ready for execution.
     async fn load_manifest(&self, mut manifest: AppManifest) -> Result<LockedApp> {
-        spin_manifest::normalize::normalize_manifest(&mut manifest);
+        spin_manifest::normalize::normalize_manifest(&mut manifest, &self.app_root)?;
 
         let AppManifest {
             spin_manifest_version: _,

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 anyhow = "1.0.75"
 indexmap = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+spin-common = { path = "../common" }
 spin-serde = { path = "../serde" }
 thiserror = "1"
 terminal = { path = "../terminal" }

--- a/crates/manifest/src/normalize.rs
+++ b/crates/manifest/src/normalize.rs
@@ -2,15 +2,129 @@
 
 use std::collections::HashSet;
 
+use anyhow::Context;
+use spin_common::ui::quoted_path;
+
 use crate::schema::v2::{AppManifest, ComponentSpec, KebabId};
 
 /// Normalizes some optional [`AppManifest`] features into a canonical form:
 /// - Inline components in trigger configs are moved into top-level
 ///   components and replaced with a reference.
 /// - Any triggers without an ID are assigned a generated ID.
-pub fn normalize_manifest(manifest: &mut AppManifest) {
+pub fn normalize_manifest(manifest: &mut AppManifest, app_root: &std::path::Path) -> anyhow::Result<()> {
     normalize_trigger_ids(manifest);
+    normalize_external_references(manifest, app_root)?;
     normalize_inline_components(manifest);
+    Ok(())
+}
+
+fn normalize_external_references(manifest: &mut AppManifest, app_root: &std::path::Path) -> anyhow::Result<()> {
+    // let components = &manifest.components;
+
+    for trigger in manifest.triggers.values_mut().flatten() {
+        // let trigger_id = &trigger.id;
+
+        let component_specs = trigger
+            .component
+            .iter_mut()
+            .chain(
+                trigger
+                    .components
+                    .values_mut()
+                    .flat_map(|specs| specs.0.iter_mut()),
+            )
+            .collect::<Vec<_>>();
+        // let multiple_components = component_specs.len() > 1;
+
+        // let mut counter = 1;
+        for spec in component_specs {
+            let ComponentSpec::External(path) = spec else {
+                continue;
+            };
+
+            let abs_path = app_root.join(&path);
+            let (abs_path, containing_dir) = if abs_path.is_file() {
+                (abs_path, path.parent().unwrap().to_owned())
+            } else if abs_path.is_dir() {
+                let inferred = abs_path.join("spin-component.toml");
+                if inferred.is_file() {
+                    (inferred, path.to_owned())
+                } else {
+                    anyhow::bail!("{} does not contain a spin-component.toml file", quoted_path(&abs_path));
+                }
+            } else {
+                anyhow::bail!("{} does not exist", quoted_path(abs_path));
+            };
+
+            let toml_text = std::fs::read_to_string(&abs_path)?;
+            let mut component: crate::schema::v2::Component = toml::from_str(&toml_text)
+                .with_context(|| format!("{} is not a valid component manifest", quoted_path(&abs_path)))?;
+
+            relativise_paths(&mut component, &containing_dir);
+
+            // let inline_id = {
+            //     // Try a "natural" component ID...
+            //     let mut id = KebabId::try_from(format!("{trigger_id}-component"));
+            //     // ...falling back to a counter-based component ID
+            //     if multiple_components
+            //         || id.is_err()
+            //         || components.contains_key(id.as_ref().unwrap())
+            //     {
+            //         id = Ok(loop {
+            //             let id = KebabId::try_from(format!("inline-component{counter}")).unwrap();
+            //             if !components.contains_key(&id) {
+            //                 break id;
+            //             }
+            //             counter += 1;
+            //         });
+            //     }
+            //     id.unwrap()
+            // };
+
+            // Replace the inline component with a reference...
+            _ = std::mem::replace(spec, ComponentSpec::Inline(Box::new(component)));
+        }
+    }
+
+    Ok(())
+}
+
+fn relativise_paths(component: &mut crate::schema::v2::Component, relative_to: &std::path::Path) {
+    // Empty string means a relative path with no directory component
+    if relative_to == std::path::PathBuf::from("") {
+        return;
+    }
+
+    if let crate::schema::common::ComponentSource::Local(path) = &component.source {
+        let adjusted_path = relative_to.join(path);
+        component.source = crate::schema::common::ComponentSource::Local(adjusted_path.to_string_lossy().to_string());
+    }
+
+    component.files.iter_mut().for_each(|f| relativise_mount(f, relative_to));
+    component.exclude_files.iter_mut().for_each(|f| *f = relative_to.join(&f).to_string_lossy().to_string());
+
+    if let Some(build) = &mut component.build {
+        let workdir = match &build.workdir {
+            Some(w) => relative_to.join(w).to_string_lossy().to_string(),
+            None => relative_to.to_string_lossy().to_string(),
+        };
+        build.workdir = Some(workdir);
+    }
+
+    // We can't do anything about `tool` entries.  Idea is to inject a `spin:meta` pseudo-tool that
+    // consumers of this section can look at to detect that the component they are looking at originated
+    // in a subdir.
+    let mut tool_meta_map = toml::map::Map::new();
+    tool_meta_map.insert("component-manifest-path-base".to_owned(), toml::Value::String(relative_to.to_string_lossy().to_string()));
+    component.tool.insert("spin:meta".to_owned(), tool_meta_map);
+}
+
+fn relativise_mount(mount: &mut crate::schema::v2::WasiFilesMount, relative_to: &std::path::Path) {
+    let adjusted_mount = match mount {
+        crate::schema::common::WasiFilesMount::Pattern(f) => crate::schema::common::WasiFilesMount::Pattern(relative_to.join(f).to_string_lossy().to_string()),
+        crate::schema::common::WasiFilesMount::Placement { source, destination } => crate::schema::common::WasiFilesMount::Placement { source: relative_to.join(source).to_string_lossy().to_string(), destination: destination.to_string() },
+    };
+    *mount = adjusted_mount;
 }
 
 fn normalize_inline_components(manifest: &mut AppManifest) {

--- a/crates/manifest/src/normalize.rs
+++ b/crates/manifest/src/normalize.rs
@@ -11,19 +11,22 @@ use crate::schema::v2::{AppManifest, ComponentSpec, KebabId};
 /// - Inline components in trigger configs are moved into top-level
 ///   components and replaced with a reference.
 /// - Any triggers without an ID are assigned a generated ID.
-pub fn normalize_manifest(manifest: &mut AppManifest, app_root: &std::path::Path) -> anyhow::Result<()> {
+pub fn normalize_manifest(
+    manifest: &mut AppManifest,
+    app_root: &std::path::Path,
+) -> anyhow::Result<()> {
+    // Order is important here!
     normalize_trigger_ids(manifest);
     normalize_external_references(manifest, app_root)?;
     normalize_inline_components(manifest);
     Ok(())
 }
 
-fn normalize_external_references(manifest: &mut AppManifest, app_root: &std::path::Path) -> anyhow::Result<()> {
-    // let components = &manifest.components;
-
+fn normalize_external_references(
+    manifest: &mut AppManifest,
+    app_root: &std::path::Path,
+) -> anyhow::Result<()> {
     for trigger in manifest.triggers.values_mut().flatten() {
-        // let trigger_id = &trigger.id;
-
         let component_specs = trigger
             .component
             .iter_mut()
@@ -34,9 +37,7 @@ fn normalize_external_references(manifest: &mut AppManifest, app_root: &std::pat
                     .flat_map(|specs| specs.0.iter_mut()),
             )
             .collect::<Vec<_>>();
-        // let multiple_components = component_specs.len() > 1;
 
-        // let mut counter = 1;
         for spec in component_specs {
             let ComponentSpec::External(path) = spec else {
                 continue;
@@ -50,7 +51,10 @@ fn normalize_external_references(manifest: &mut AppManifest, app_root: &std::pat
                 if inferred.is_file() {
                     (inferred, path.to_owned())
                 } else {
-                    anyhow::bail!("{} does not contain a spin-component.toml file", quoted_path(&abs_path));
+                    anyhow::bail!(
+                        "{} does not contain a spin-component.toml file",
+                        quoted_path(&abs_path)
+                    );
                 }
             } else {
                 anyhow::bail!("{} does not exist", quoted_path(abs_path));
@@ -58,30 +62,17 @@ fn normalize_external_references(manifest: &mut AppManifest, app_root: &std::pat
 
             let toml_text = std::fs::read_to_string(&abs_path)?;
             let mut component: crate::schema::v2::Component = toml::from_str(&toml_text)
-                .with_context(|| format!("{} is not a valid component manifest", quoted_path(&abs_path)))?;
+                .with_context(|| {
+                    format!(
+                        "{} is not a valid component manifest",
+                        quoted_path(&abs_path)
+                    )
+                })?;
 
             relativise_paths(&mut component, &containing_dir);
 
-            // let inline_id = {
-            //     // Try a "natural" component ID...
-            //     let mut id = KebabId::try_from(format!("{trigger_id}-component"));
-            //     // ...falling back to a counter-based component ID
-            //     if multiple_components
-            //         || id.is_err()
-            //         || components.contains_key(id.as_ref().unwrap())
-            //     {
-            //         id = Ok(loop {
-            //             let id = KebabId::try_from(format!("inline-component{counter}")).unwrap();
-            //             if !components.contains_key(&id) {
-            //                 break id;
-            //             }
-            //             counter += 1;
-            //         });
-            //     }
-            //     id.unwrap()
-            // };
-
-            // Replace the inline component with a reference...
+            // Replace the external component with an inline, which will be normalised
+            // in the next pass.
             _ = std::mem::replace(spec, ComponentSpec::Inline(Box::new(component)));
         }
     }
@@ -97,11 +88,19 @@ fn relativise_paths(component: &mut crate::schema::v2::Component, relative_to: &
 
     if let crate::schema::common::ComponentSource::Local(path) = &component.source {
         let adjusted_path = relative_to.join(path);
-        component.source = crate::schema::common::ComponentSource::Local(adjusted_path.to_string_lossy().to_string());
+        component.source = crate::schema::common::ComponentSource::Local(
+            adjusted_path.to_string_lossy().to_string(),
+        );
     }
 
-    component.files.iter_mut().for_each(|f| relativise_mount(f, relative_to));
-    component.exclude_files.iter_mut().for_each(|f| *f = relative_to.join(&f).to_string_lossy().to_string());
+    component
+        .files
+        .iter_mut()
+        .for_each(|f| relativise_mount(f, relative_to));
+    component
+        .exclude_files
+        .iter_mut()
+        .for_each(|f| *f = relative_to.join(&f).to_string_lossy().to_string());
 
     if let Some(build) = &mut component.build {
         let workdir = match &build.workdir {
@@ -115,14 +114,27 @@ fn relativise_paths(component: &mut crate::schema::v2::Component, relative_to: &
     // consumers of this section can look at to detect that the component they are looking at originated
     // in a subdir.
     let mut tool_meta_map = toml::map::Map::new();
-    tool_meta_map.insert("component-manifest-path-base".to_owned(), toml::Value::String(relative_to.to_string_lossy().to_string()));
+    tool_meta_map.insert(
+        "component-manifest-path-base".to_owned(),
+        toml::Value::String(relative_to.to_string_lossy().to_string()),
+    );
     component.tool.insert("spin:meta".to_owned(), tool_meta_map);
 }
 
 fn relativise_mount(mount: &mut crate::schema::v2::WasiFilesMount, relative_to: &std::path::Path) {
     let adjusted_mount = match mount {
-        crate::schema::common::WasiFilesMount::Pattern(f) => crate::schema::common::WasiFilesMount::Pattern(relative_to.join(f).to_string_lossy().to_string()),
-        crate::schema::common::WasiFilesMount::Placement { source, destination } => crate::schema::common::WasiFilesMount::Placement { source: relative_to.join(source).to_string_lossy().to_string(), destination: destination.to_string() },
+        crate::schema::common::WasiFilesMount::Pattern(f) => {
+            crate::schema::common::WasiFilesMount::Pattern(
+                relative_to.join(f).to_string_lossy().to_string(),
+            )
+        }
+        crate::schema::common::WasiFilesMount::Placement {
+            source,
+            destination,
+        } => crate::schema::common::WasiFilesMount::Placement {
+            source: relative_to.join(source).to_string_lossy().to_string(),
+            destination: destination.to_string(),
+        },
     };
     *mount = adjusted_mount;
 }

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -91,10 +91,10 @@ impl TryFrom<toml::Value> for ComponentSpec {
             Some(s) => match s.strip_prefix('@') {
                 Some(path) => Ok(ComponentSpec::External(std::path::PathBuf::from(path))),
                 None => Ok(ComponentSpec::Reference(KebabId::deserialize(value)?)),
-            }
+            },
             None => Ok(ComponentSpec::Inline(Box::new(Component::deserialize(
                 value,
-            )?)))
+            )?))),
         }
     }
 }

--- a/crates/manifest/tests/ui.rs
+++ b/crates/manifest/tests/ui.rs
@@ -44,7 +44,7 @@ fn run_v1_to_v2_test(input: &Path) -> Result<String, Failed> {
 }
 
 fn run_normalization_test(input: impl AsRef<Path>) -> Result<String, Failed> {
-    let mut manifest = spin_manifest::manifest_from_file(input)?;
-    normalize_manifest(&mut manifest);
+    let mut manifest = spin_manifest::manifest_from_file(input.as_ref())?;
+    normalize_manifest(&mut manifest, input.as_ref().parent().unwrap())?;
     Ok(toml::to_string(&manifest).expect("serialization should work"))
 }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -4072,6 +4072,7 @@ dependencies = [
  "anyhow",
  "indexmap 1.9.3",
  "serde",
+ "spin-common",
  "spin-serde",
  "terminal",
  "thiserror",


### PR DESCRIPTION
Fixes #1759.

This is WIP for discussion and pondering.

The proposed UX for the modular feature is to overload the `trigger.component` field to allow it to reference a file (or directory containing a well-known file).  I considered an embedded table for this (`[[trigger.http]] component = { path = "example.toml" }`) but it felt wordy, so the current draft instead proposes an `@filename` syntax similar to what we use for the `--sqlite` flag (`[[trigger.http]] component = "@example.toml"`).  I kind of like it, but suspect it will be divisive!

There are also a couple of serious structural considerations:

1. The duplication of manifest resolution into the `build` loader, mentioned in #2393, increases yet more, which is extremely not good.  I don't have a good solution for this - I'm toying with some ideas that could defer the full parse in cases where it's not needed, but nothing looks super easy.

2. This implementation fails on the requirement of tracing errors back to the source file path.  Core manifest validation will get the file path, but if, for example, the Wasm file mentioned in the child file doesn't exist, it gives you no clue as to which file the error lies in.  We do carry some application origin info into the trigger: I'm wondering if we could attach an optional origin field to each component, but we'd not want that going into the lockfile because the lockfile also serves as the OCI thing.

Also, no, there are (almost) no tests yet.
