### PR TITLE
Provide a way for lockfile consumers to see the actual downlevel version

### DIFF
--- a/crates/locked-app/src/locked.rs
+++ b/crates/locked-app/src/locked.rs
@@ -314,6 +314,7 @@ mod test {
 
         let reloaded = LockedApp::from_json(&json).unwrap();
 
+        assert_eq!(0, reloaded.spin_lock_version.actual());
         assert_eq!(1, Into::<usize>::into(reloaded.spin_lock_version));
     }
 
@@ -339,6 +340,7 @@ mod test {
 
         let reloaded = LockedApp::from_json(&json).unwrap();
 
+        assert_eq!(1, reloaded.spin_lock_version.actual());
         assert_eq!(1, Into::<usize>::into(reloaded.spin_lock_version));
         assert_eq!(1, reloaded.must_understand.len());
         assert_eq!(1, reloaded.host_requirements.len());

--- a/crates/serde/src/version.rs
+++ b/crates/serde/src/version.rs
@@ -24,9 +24,17 @@ impl<const V: usize> TryFrom<usize> for FixedVersion<V> {
 
 /// FixedVersion represents a version integer field with a const value,
 /// but accepts lower versions during deserialisation.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(into = "usize", try_from = "usize")]
-pub struct FixedVersionBackwardCompatible<const V: usize>;
+pub struct FixedVersionBackwardCompatible<const V: usize> {
+    actual: usize,
+}
+
+impl<const V: usize> Default for FixedVersionBackwardCompatible<V> {
+    fn default() -> Self {
+        Self { actual: V }
+    }
+}
 
 impl<const V: usize> From<FixedVersionBackwardCompatible<V>> for usize {
     fn from(_: FixedVersionBackwardCompatible<V>) -> usize {
@@ -41,7 +49,14 @@ impl<const V: usize> TryFrom<usize> for FixedVersionBackwardCompatible<V> {
         if value > V {
             return Err(format!("invalid version {} > {}", value, V));
         }
-        Ok(Self)
+        Ok(Self { actual: value })
+    }
+}
+
+impl<const V: usize> FixedVersionBackwardCompatible<V> {
+    /// The underlying (downlevel, deserialised) version.
+    pub fn actual(&self) -> usize {
+        self.actual
     }
 }
 


### PR DESCRIPTION
New Spin always reports lockfiles as v1, but for transitional purposes can serialise as v0 when the app is downlevel compatible.  However, there is no current way for tools that are passing an app to a consumer to determine if the app is downlevel compatible (other than by using a downlevel version of the Spin crate to try to load it).  An example is the cloud plugin needing to validate an application because Cloud does not yet accept v1 lockfiles.  This PR provides a workaround.