### PR TITLE
feat(*): Add tracing to some more host components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6504,6 +6504,7 @@ dependencies = [
  "spin-world",
  "table",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6518,6 +6519,7 @@ dependencies = [
  "spin-sqlite",
  "spin-world",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6532,6 +6534,7 @@ dependencies = [
  "spin-world",
  "sqlparser",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6263,6 +6263,7 @@ dependencies = [
  "spin-core",
  "spin-key-value",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -6276,6 +6277,7 @@ dependencies = [
  "spin-key-value",
  "spin-world",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -6290,6 +6292,7 @@ dependencies = [
  "spin-key-value",
  "spin-world",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6735,6 +6735,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.5.11",
+ "tracing",
  "vaultrs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,10 @@ wasmtime-wasi-http = "18.0.1"
 
 spin-componentize = { path = "crates/componentize" }
 
+[workspace.lints.clippy]
+# TODO: Remove this once https://github.com/rust-lang/rust-clippy/issues/12281 is resolved
+blocks_in_conditions = "allow"
+
 [[bin]]
 name = "spin"
 path = "src/bin/spin.rs"

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -13,3 +13,7 @@ spin-key-value = { path = "../key-value" }
 spin-core = { path = "../core" }
 tokio = "1"
 url = "2"
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/key-value-azure/src/lib.rs
+++ b/crates/key-value-azure/src/lib.rs
@@ -9,6 +9,7 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use spin_core::async_trait;
 use spin_key_value::{log_error, Error, Store, StoreManager};
+use tracing::{instrument, Level};
 
 pub struct KeyValueAzureCosmos {
     client: CollectionClient,
@@ -46,11 +47,13 @@ struct AzureCosmosStore {
 
 #[async_trait]
 impl Store for AzureCosmosStore {
+    #[instrument(name = "spin_key_value_azure.get", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
         let pair = self.get_pair(key).await?;
         Ok(pair.map(|p| p.value))
     }
 
+    #[instrument(name = "spin_key_value_azure.set", skip(self, value), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn set(&self, key: &str, value: &[u8]) -> Result<(), Error> {
         let pair = Pair {
             id: key.to_string(),
@@ -64,6 +67,7 @@ impl Store for AzureCosmosStore {
         Ok(())
     }
 
+    #[instrument(name = "spin_key_value_azure.delete", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn delete(&self, key: &str) -> Result<(), Error> {
         if self.exists(key).await? {
             let document_client = self.client.document_client(key, &key).map_err(log_error)?;
@@ -72,10 +76,12 @@ impl Store for AzureCosmosStore {
         Ok(())
     }
 
+    #[instrument(name = "spin_key_value_azure.exists", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn exists(&self, key: &str) -> Result<bool, Error> {
         Ok(self.get_pair(key).await?.is_some())
     }
 
+    #[instrument(name = "spin_key_value_azure.get_keys", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get_keys(&self) -> Result<Vec<String>, Error> {
         self.get_keys().await
     }

--- a/crates/key-value-redis/Cargo.toml
+++ b/crates/key-value-redis/Cargo.toml
@@ -12,3 +12,7 @@ spin-core = { path = "../core" }
 spin-world = { path = "../world" }
 tokio = "1"
 url = "2"
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/key-value-redis/src/lib.rs
+++ b/crates/key-value-redis/src/lib.rs
@@ -4,6 +4,7 @@ use spin_core::async_trait;
 use spin_key_value::{log_error, Error, Store, StoreManager};
 use std::sync::Arc;
 use tokio::sync::{Mutex, OnceCell};
+use tracing::{instrument, Level};
 use url::Url;
 
 pub struct KeyValueRedis {
@@ -24,6 +25,7 @@ impl KeyValueRedis {
 
 #[async_trait]
 impl StoreManager for KeyValueRedis {
+    #[instrument(name = "spin_key_value_redis.get_store", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(&self, _name: &str) -> Result<Arc<dyn Store>, Error> {
         let connection = self
             .connection
@@ -53,11 +55,13 @@ struct RedisStore {
 
 #[async_trait]
 impl Store for RedisStore {
+    #[instrument(name = "spin_key_value_redis.get", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
         let mut conn = self.connection.lock().await;
         conn.get(key).await.map_err(log_error)
     }
 
+    #[instrument(name = "spin_key_value_redis.set", skip(self, value), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn set(&self, key: &str, value: &[u8]) -> Result<(), Error> {
         self.connection
             .lock()
@@ -67,6 +71,7 @@ impl Store for RedisStore {
             .map_err(log_error)
     }
 
+    #[instrument(name = "spin_key_value_redis.delete", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn delete(&self, key: &str) -> Result<(), Error> {
         self.connection
             .lock()
@@ -76,6 +81,7 @@ impl Store for RedisStore {
             .map_err(log_error)
     }
 
+    #[instrument(name = "spin_key_value_redis.exists", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn exists(&self, key: &str) -> Result<bool, Error> {
         self.connection
             .lock()
@@ -85,6 +91,7 @@ impl Store for RedisStore {
             .map_err(log_error)
     }
 
+    #[instrument(name = "spin_key_value_redis.get_keys", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get_keys(&self) -> Result<Vec<String>, Error> {
         self.connection
             .lock()

--- a/crates/key-value-sqlite/Cargo.toml
+++ b/crates/key-value-sqlite/Cargo.toml
@@ -12,3 +12,7 @@ tokio = "1"
 spin-key-value = { path = "../key-value" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/key-value-sqlite/src/lib.rs
+++ b/crates/key-value-sqlite/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tokio::task;
+use tracing::{instrument, Level};
 
 pub enum DatabaseLocation {
     InMemory,
@@ -30,6 +31,7 @@ impl KeyValueSqlite {
 
 #[async_trait]
 impl StoreManager for KeyValueSqlite {
+    #[instrument(name = "spin_key_value_sqlite.get_store", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(&self, name: &str) -> Result<Arc<dyn Store>, Error> {
         let connection = task::block_in_place(|| {
             self.connection.get_or_try_init(|| {
@@ -74,6 +76,7 @@ struct SqliteStore {
 
 #[async_trait]
 impl Store for SqliteStore {
+    #[instrument(name = "spin_key_value_sqlite.get", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
         task::block_in_place(|| {
             self.connection
@@ -89,6 +92,7 @@ impl Store for SqliteStore {
         })
     }
 
+    #[instrument(name = "spin_key_value_sqlite.set", skip(self, value), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn set(&self, key: &str, value: &[u8]) -> Result<(), Error> {
         task::block_in_place(|| {
             self.connection
@@ -105,6 +109,7 @@ impl Store for SqliteStore {
         })
     }
 
+    #[instrument(name = "spin_key_value_sqlite.delete", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn delete(&self, key: &str) -> Result<(), Error> {
         task::block_in_place(|| {
             self.connection
@@ -118,10 +123,12 @@ impl Store for SqliteStore {
         })
     }
 
+    #[instrument(name = "spin_key_value_sqlite.exists", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn exists(&self, key: &str) -> Result<bool, Error> {
         Ok(self.get(key).await?.is_some())
     }
 
+    #[instrument(name = "spin_key_value_sqlite.get_keys", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get_keys(&self) -> Result<Vec<String>, Error> {
         task::block_in_place(|| {
             self.connection

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -31,3 +31,6 @@ tracing = { workspace = true }
 default = []
 metal = ["llm/metal"]
 cublas = ["llm/cublas"]
+
+[lints]
+workspace = true

--- a/crates/llm-local/src/lib.rs
+++ b/crates/llm-local/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tokenizers::PaddingParams;
-use tracing::instrument;
+use tracing::{instrument, Level};
 
 #[derive(Clone)]
 pub struct LocalLlmEngine {
@@ -33,7 +33,7 @@ pub struct LocalLlmEngine {
 
 #[async_trait]
 impl LlmEngine for LocalLlmEngine {
-    #[instrument(name = "llm_generate_local_inference", skip(self, prompt))]
+    #[instrument(name = "generate_inference_local_llm", skip(self, prompt), err(level = Level::INFO))]
     async fn infer(
         &mut self,
         model: wasi_llm::InferencingModel,
@@ -93,7 +93,7 @@ impl LlmEngine for LocalLlmEngine {
         Ok(response)
     }
 
-    #[instrument(name = "llm_generate_local_embeddings", skip(self, data))]
+    #[instrument(name = "generate_embeddings_local_llm", skip(self, data), err(level = Level::INFO))]
     async fn generate_embeddings(
         &mut self,
         model: wasi_llm::EmbeddingModel,

--- a/crates/llm-local/src/lib.rs
+++ b/crates/llm-local/src/lib.rs
@@ -33,7 +33,7 @@ pub struct LocalLlmEngine {
 
 #[async_trait]
 impl LlmEngine for LocalLlmEngine {
-    #[instrument(name = "generate_inference_local_llm", skip(self, prompt), err(level = Level::INFO))]
+    #[instrument(name = "spin_llm_local.infer", skip(self, prompt), err(level = Level::INFO))]
     async fn infer(
         &mut self,
         model: wasi_llm::InferencingModel,
@@ -93,7 +93,7 @@ impl LlmEngine for LocalLlmEngine {
         Ok(response)
     }
 
-    #[instrument(name = "generate_embeddings_local_llm", skip(self, data), err(level = Level::INFO))]
+    #[instrument(name = "spin_llm_local.generate_embeddings", skip(self, data), err(level = Level::INFO))]
     async fn generate_embeddings(
         &mut self,
         model: wasi_llm::EmbeddingModel,

--- a/crates/llm-remote-http/Cargo.toml
+++ b/crates/llm-remote-http/Cargo.toml
@@ -16,3 +16,6 @@ spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
 reqwest = { version = "0.11", features = ["gzip", "json"] }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/llm-remote-http/src/lib.rs
+++ b/crates/llm-remote-http/src/lib.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use spin_core::async_trait;
 use spin_llm::LlmEngine;
 use spin_world::v2::llm::{self as wasi_llm};
-use tracing::instrument;
+use tracing::{instrument, Level};
 
 #[derive(Clone)]
 pub struct RemoteHttpLlmEngine {
@@ -55,7 +55,7 @@ struct EmbeddingResponseBody {
 
 #[async_trait]
 impl LlmEngine for RemoteHttpLlmEngine {
-    #[instrument(name = "llm_generate_remote_inference", skip(self, prompt), fields(otel.kind = "client"))]
+    #[instrument(name = "generate_inference_remote_llm", skip(self, prompt), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn infer(
         &mut self,
         model: wasi_llm::InferencingModel,
@@ -118,7 +118,7 @@ impl LlmEngine for RemoteHttpLlmEngine {
         }
     }
 
-    #[instrument(name = "llm_generate_remote_embeddings", skip(self, data), fields(otel.kind = "client"))]
+    #[instrument(name = "generate_embeddings_remote_llm", skip(self, data), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn generate_embeddings(
         &mut self,
         model: wasi_llm::EmbeddingModel,

--- a/crates/llm-remote-http/src/lib.rs
+++ b/crates/llm-remote-http/src/lib.rs
@@ -55,7 +55,7 @@ struct EmbeddingResponseBody {
 
 #[async_trait]
 impl LlmEngine for RemoteHttpLlmEngine {
-    #[instrument(name = "generate_inference_remote_llm", skip(self, prompt), err(level = Level::INFO), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_llm_remote_http.infer", skip(self, prompt), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn infer(
         &mut self,
         model: wasi_llm::InferencingModel,
@@ -118,7 +118,7 @@ impl LlmEngine for RemoteHttpLlmEngine {
         }
     }
 
-    #[instrument(name = "generate_embeddings_remote_llm", skip(self, data), err(level = Level::INFO), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_llm_remote_http.generate_embeddings", skip(self, data), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn generate_embeddings(
         &mut self,
         model: wasi_llm::EmbeddingModel,

--- a/crates/outbound-redis/Cargo.toml
+++ b/crates/outbound-redis/Cargo.toml
@@ -18,3 +18,6 @@ spin-outbound-networking = { path = "../outbound-networking" }
 table = { path = "../table" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -9,6 +9,7 @@ use spin_world::v2::redis::{
 };
 
 pub use host_component::OutboundRedisComponent;
+use tracing::{instrument, Level};
 
 struct RedisResults(Vec<RedisResult>);
 
@@ -70,8 +71,12 @@ impl OutboundRedis {
 
 impl v2::Host for OutboundRedis {}
 
+// TODO: #[instrument(err)] is only reporting the outer error (if the guest traps), we want to mark
+// the span as failed if the inner result is an error too.
+
 #[async_trait]
 impl v2::HostConnection for OutboundRedis {
+    #[instrument(name = "spin_outbound_redis.open_connection", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis"))]
     async fn open(&mut self, address: String) -> Result<Result<Resource<RedisConnection>, Error>> {
         if !self.is_address_allowed(&address) {
             return Ok(Err(Error::InvalidAddress));
@@ -80,6 +85,7 @@ impl v2::HostConnection for OutboundRedis {
         self.establish_connection(address).await
     }
 
+    #[instrument(name = "spin_outbound_redis.publish", skip(self, connection, payload), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("PUBLISH {}", channel)))]
     async fn publish(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -96,6 +102,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.get", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("GET {}", key)))]
     async fn get(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -109,6 +116,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.set", skip(self, connection, value), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SET {}", key)))]
     async fn set(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -123,6 +131,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.incr", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("INCRBY {} 1", key)))]
     async fn incr(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -136,6 +145,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.del", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("DEL {}", keys.join(" "))))]
     async fn del(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -149,6 +159,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.sadd", skip(self, connection, values), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SADD {} {}", key, values.join(" "))))]
     async fn sadd(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -169,6 +180,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.smembers", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SMEMBERS {}", key)))]
     async fn smembers(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -182,6 +194,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.srem", skip(self, connection, values), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SREM {} {}", key, values.join(" "))))]
     async fn srem(
         &mut self,
         connection: Resource<RedisConnection>,
@@ -196,6 +209,7 @@ impl v2::HostConnection for OutboundRedis {
         .await)
     }
 
+    #[instrument(name = "spin_outbound_redis.execute", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("{}", command)))]
     async fn execute(
         &mut self,
         connection: Resource<RedisConnection>,

--- a/crates/outbound-redis/src/lib.rs
+++ b/crates/outbound-redis/src/lib.rs
@@ -71,8 +71,8 @@ impl OutboundRedis {
 
 impl v2::Host for OutboundRedis {}
 
-// TODO: #[instrument(err)] is only reporting the outer error (if the guest traps), we want to mark
-// the span as failed if the inner result is an error too.
+// TODO: #[instrument(err)] is only reporting the outer error, we want to mark the span as failed
+// if the inner result is an error too.
 
 #[async_trait]
 impl v2::HostConnection for OutboundRedis {

--- a/crates/sqlite-inproc/Cargo.toml
+++ b/crates/sqlite-inproc/Cargo.toml
@@ -13,3 +13,7 @@ rusqlite = { version = "0.29.0", features = [ "bundled" ] }
 rand = "0.8"
 once_cell = "1"
 tokio = "1"
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sqlite-inproc/src/lib.rs
+++ b/crates/sqlite-inproc/src/lib.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use once_cell::sync::OnceCell;
 use spin_sqlite::Connection;
 use spin_world::v2::sqlite;
+use tracing::{instrument, Level};
 
 #[derive(Debug, Clone)]
 pub enum InProcDatabaseLocation {
@@ -46,6 +47,7 @@ impl InProcConnection {
 
 #[async_trait]
 impl Connection for InProcConnection {
+    #[instrument(name = "spin_sqlite_inproc.query", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query))]
     async fn query(
         &self,
         query: &str,
@@ -60,6 +62,7 @@ impl Connection for InProcConnection {
             .map_err(|e| sqlite::Error::Io(e.to_string()))?
     }
 
+    #[instrument(name = "spin_sqlite_inproc.execute_batch", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", db.statements = statements))]
     async fn execute_batch(&self, statements: &str) -> anyhow::Result<()> {
         let connection = self.db_connection()?;
         let statements = statements.to_owned();

--- a/crates/sqlite-libsql/Cargo.toml
+++ b/crates/sqlite-libsql/Cargo.toml
@@ -15,3 +15,7 @@ spin-world = { path = "../world" }
 sqlparser = "0.34"
 libsql = { version = "0.3.2", features = ["remote"], default-features = false }
 tokio = { version = "1", features = ["full"] }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sqlite-libsql/src/lib.rs
+++ b/crates/sqlite-libsql/src/lib.rs
@@ -1,4 +1,5 @@
 use spin_world::v2::sqlite::{self, RowResult};
+use tracing::{instrument, Level};
 
 #[derive(Clone)]
 pub struct LibsqlClient {
@@ -6,6 +7,7 @@ pub struct LibsqlClient {
 }
 
 impl LibsqlClient {
+    #[instrument(name = "spin_sqlite_libsql.create_connection", skip(token), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite"))]
     pub async fn create(url: String, token: String) -> anyhow::Result<Self> {
         let db = libsql::Builder::new_remote(url, token).build().await?;
         let inner = db.connect()?;
@@ -15,6 +17,7 @@ impl LibsqlClient {
 
 #[async_trait::async_trait]
 impl spin_sqlite::Connection for LibsqlClient {
+    #[instrument(name = "spin_sqlite_libsql.query", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query))]
     async fn query(
         &self,
         query: &str,
@@ -34,6 +37,7 @@ impl spin_sqlite::Connection for LibsqlClient {
         })
     }
 
+    #[instrument(name = "spin_sqlite_libsql.execute_batch", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", db.statements = statements))]
     async fn execute_batch(&self, statements: &str) -> anyhow::Result<()> {
         self.inner.execute_batch(statements).await?;
 

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -12,3 +12,4 @@ spin-app = { path = "../app" }
 spin-world = { path = "../world" }
 table = { path = "../table" }
 tokio = "1"
+tracing = { workspace = true }

--- a/crates/variables/Cargo.toml
+++ b/crates/variables/Cargo.toml
@@ -17,6 +17,10 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 vaultrs = "0.6.2"
 serde = "1.0.188"
+tracing = { workspace = true }
 
 [dev-dependencies]
 toml = "0.5"
+
+[lints]
+workspace = true

--- a/crates/variables/src/provider/env.rs
+++ b/crates/variables/src/provider/env.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 
 use spin_expressions::{Key, Provider};
+use tracing::{instrument, Level};
 
 const DEFAULT_ENV_PREFIX: &str = "SPIN_VARIABLE";
 const LEGACY_ENV_PREFIX: &str = "SPIN_CONFIG";
@@ -84,6 +85,7 @@ impl EnvProvider {
 
 #[async_trait]
 impl Provider for EnvProvider {
+    #[instrument(name = "spin_variables.get_from_env", skip(self), err(level = Level::INFO))]
     async fn get(&self, key: &Key) -> Result<Option<String>> {
         tokio::task::block_in_place(|| self.get_sync(key))
     }

--- a/crates/variables/src/provider/vault.rs
+++ b/crates/variables/src/provider/vault.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use tracing::{instrument, Level};
 use vaultrs::{
     client::{VaultClient, VaultClientSettingsBuilder},
     error::ClientError,
@@ -41,6 +42,7 @@ struct Secret {
 
 #[async_trait]
 impl Provider for VaultProvider {
+    #[instrument(name = "spin_variables.get_from_vault", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(&self, key: &Key) -> Result<Option<String>> {
         let client = VaultClient::new(
             VaultClientSettingsBuilder::default()

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -3997,6 +3997,7 @@ dependencies = [
  "spin-core",
  "spin-key-value",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -4010,6 +4011,7 @@ dependencies = [
  "spin-key-value",
  "spin-world",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -4024,6 +4026,7 @@ dependencies = [
  "spin-key-value",
  "spin-world",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4152,6 +4155,7 @@ dependencies = [
  "spin-world",
  "table",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4166,6 +4170,7 @@ dependencies = [
  "spin-sqlite",
  "spin-world",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4180,6 +4185,7 @@ dependencies = [
  "spin-world",
  "sqlparser",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4264,6 +4270,7 @@ dependencies = [
  "spin-world",
  "thiserror",
  "tokio",
+ "tracing",
  "vaultrs",
 ]
 


### PR DESCRIPTION
#2348 introduced basic observability support to Spin via the OpenTelemetry standard. It had only basic support for the [tracing signal](https://opentelemetry.io/docs/concepts/signals/) and so the logical next step was to extend the tracing to cover more Spin surface area (host components, triggers, etc.). This PR is my attempt to "trace all the things". The complexity of choosing good span names and deciding what to trace has waylaid my efforts though. This PR is no longer a comprehensive attempt to trace all of Spin. Rather it has become a first crack in the glass — an exploratory attempt to try and build consensus around how we want to trace Spin.

In my digging I've identified the following crates that we want to trace. A * after a crate means it was initially traced in #2348. Bolded crates I have added tracing to in this PR.

- `core` * (lots of questions here about whether we should trace all the WASI stuff or not)
- **`key-value-{azure, redis, sqlite}`**
- **`llm-{local, remote}`** *
- `outbound-{http, mqtt, mysql, networking, pg}`
- **`outbound-redis`**
- **`sqlite-{inproc, libsql}`**
- `trigger-http` *
- `trigger-redis`
- **`variables`**

As I was going through the exercise of tracing a subset of these crates I ran into the issue of how to name the spans. As @rylev suggested I wanted to have a consistent scheme that I used for all the span names across Spin. I ended up opting for a name scheme along the lines of `verb_{optional adjective}_noun` e.g. `execute_query_in_process_sqlite_db`.

**Problem 1**: Very quickly this naming scheme started to fray around the edges. For example with `set_add_values_redis` should `set` actually be part of the noun i.e. `add_values_redis_set`. Sure, but than that conflicts with the clean `redis` noun. Not only is this naming scheme not very consistent, but it also isn't particularly user-friendly to read in a trace.

**Problem 2**: Lots of our host components have a base implementation that calls out to an underlying provider e.g. `llm` and `llm-local`. It wasn't clear to me whether I should trace both of these function calls or not. On the one hand it is nice information to be able to see the stack trace and know which implementation you're using. On the other hand it isn't very beginner friendly and makes the trace look cluttered for little extra information.

Enter more complexity stage left: [OTEL semantic conventions](https://opentelemetry.io/docs/specs/semconv/). It turns out that OTEL has pretty detailed conventions for how to trace certain things like database calls or messaging systems. For example let's look at the `outbound-redis` crate. OTEL has [conventions](https://opentelemetry.io/docs/specs/semconv/database/redis/) for exactly this use case of interacting with Redis. It turns out the span names they recommend are low cardinality versions of the Redis query e.g. `GET key`. This is very different then the pattern of `get_value_redis` that I created above.

**Problem 3**: I'm not sure what to do with these OTEL conventions. It seems pretty obvious that we should use them in a lot of places. But, I also see a lot of problems with following the conventions:

- Some of our host components don't map cleanly to a convention e.g. `llm`. What do we do there?
- By following the OTEL conventions we lose the kind of consistency in span names from Spin that we might want e.g. one span is going to be `SELECT * FROM users` while another is going to be`shop.orders process`. Another example: if we were to follow the convention to the letter the `redis-trigger` would become something like `mychannel deliver` instead of something like `handle_redis_message`. Likewise `handle_http_request` becomes `GET /my/route/*`. I can imagine it becoming confusing to a user of Spin who is just trying to understand when their Spin app is triggered.
- If we follow the convention what level of a host component do we trace at. For example with KV there is `kv`, `cached_kv`, and `sqlite_kv`. Do we still emit a span at each level of that stack? Do we just do it at the root underlying implementation? I don't know.

---

Well that was a whole lot of confusion and uncertainty that I just spewed out. My hope is that the discussion in this PR can help me wade through this uncertainty. If you're looking for concrete points to address I would recommend responding to problems 1 through 3.

As a final note here is a strawman that I would advocate and that we can all argue and diff against: We don't try to have any internal sense of consistent Spin spans. Instead we completely follow the upstream semantic conventions where appropriate. Where conventions don't exist we just wing it.