### PR TITLE
chore(trigger-http): bump tls-listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7075,16 +7075,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls-listener"
-version = "0.4.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8a215badde081a06ee0a7fbc9c9f0d580c022fbdc547065f62103aef71e178"
+checksum = "ce110c38c3c9b6e5cc4fe72e60feb5b327750388a10a276e3d5d7d431e3dc76c"
 dependencies = [
  "futures-util",
- "hyper 0.14.28",
  "pin-project-lite",
  "thiserror",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.25.0",
 ]
 
 [[package]]

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -31,11 +31,7 @@ spin-telemetry = { path = "../telemetry" }
 spin-trigger = { path = "../trigger" }
 spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
-tls-listener = { version = "0.4.0", features = [
-    "rustls",
-    "hyper-h1",
-    "hyper-h2",
-] }
+tls-listener = { version = "0.10.0", features = ["rustls"] }
 tokio = { version = "1.23", features = ["full"] }
 tokio-rustls = { version = "0.23.2" }
 url = "2.4.1"


### PR DESCRIPTION
- Bumps the tls-listener crate up to 0.10.0 per https://github.com/advisories/GHSA-2qph-qpvm-2qf7

It appears we only utilize the rust_tls feature of this crate and we don't invoke the `TlsListener::new()` method susceptible to the advisory, so open to discussion on if we want to take this opportunity to bump anyways -- or close this and mark the security warning as not applicable/won't fix.

Assuming we go ahead with the bump -- any special/additional testing we want to perform?