### PR TITLE
feat(oci): set token expiration for oci client

### DIFF
--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -48,6 +48,12 @@ const MAX_LAYER_COUNT: usize = 500;
 /// rather than pushing as a separate layer
 const DEFAULT_CONTENT_REF_INLINE_MAX_SIZE: usize = 128;
 
+/// Default token expiration when pushing/pulling an image to/from a registry.
+/// This value is used by the underyling OCI client when the token expiration
+/// is unspecified on a claim.
+/// This essentially equates to a timeout for push/pull.
+const DEFAULT_TOKEN_EXPIRATION_SECS: usize = 300;
+
 /// Mode of assembly of a Spin application into an OCI image
 enum AssemblyMode {
     /// Assemble the application as one layer per component and one layer for
@@ -643,6 +649,7 @@ impl Client {
 
         oci_distribution::client::ClientConfig {
             protocol,
+            default_token_expiration_secs: DEFAULT_TOKEN_EXPIRATION_SECS,
             ..Default::default()
         }
     }


### PR DESCRIPTION
feat/fix: set default token expiration for oci push/pull

This unblocks some Spin app publishing/deployment cases.  The [upstream default token expiration is 60 seconds](https://github.com/krustlet/oci-distribution/blob/dfe6d40b15d80b5534e0db9a225b711b230f54bf/src/client.rs#L56).  However, we've seen cases where more time is needed to finish pushing all layers for an app -- for example, apps with large numbers of layers (eg static websites with many and/or larger-sized assets).