### PR TITLE
Private endpoints

### DIFF
--- a/crates/http/src/config.rs
+++ b/crates/http/src/config.rs
@@ -7,10 +7,30 @@ pub struct HttpTriggerConfig {
     /// Component ID to invoke
     pub component: String,
     /// HTTP route the component will be invoked for
-    pub route: String,
+    pub route: HttpTriggerRouteConfig,
     /// The HTTP executor the component requires
     #[serde(default)]
     pub executor: Option<HttpExecutorType>,
+}
+
+/// An HTTP trigger route
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum HttpTriggerRouteConfig {
+    Route(String),
+    IsRoutable(bool),
+}
+
+impl Default for HttpTriggerRouteConfig {
+    fn default() -> Self {
+        Self::Route(Default::default())
+    }
+}
+
+impl<T: Into<String>> From<T> for HttpTriggerRouteConfig {
+    fn from(value: T) -> Self {
+        Self::Route(value.into())
+    }
 }
 
 /// The executor for the HTTP component.

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -16,7 +16,9 @@ use spin_app::{
     AppComponent, Loader,
 };
 use spin_core::{Component, StoreBuilder};
-use spin_http::config::{HttpExecutorType, HttpTriggerConfig, WagiTriggerConfig};
+use spin_http::config::{
+    HttpExecutorType, HttpTriggerConfig, HttpTriggerRouteConfig, WagiTriggerConfig,
+};
 use spin_trigger::{HostComponentInitData, RuntimeConfig, TriggerExecutor, TriggerExecutorBuilder};
 use tokio::fs;
 
@@ -68,7 +70,7 @@ impl HttpTestConfig {
         self.module_path(Path::new(TEST_PROGRAM_PATH).join(name))
     }
 
-    pub fn http_spin_trigger(&mut self, route: impl Into<String>) -> &mut Self {
+    pub fn http_spin_trigger(&mut self, route: impl Into<HttpTriggerRouteConfig>) -> &mut Self {
         self.http_trigger_config = HttpTriggerConfig {
             component: "test-component".to_string(),
             route: route.into(),
@@ -79,7 +81,7 @@ impl HttpTestConfig {
 
     pub fn http_wagi_trigger(
         &mut self,
-        route: impl Into<String>,
+        route: impl Into<HttpTriggerRouteConfig>,
         wagi_config: WagiTriggerConfig,
     ) -> &mut Self {
         self.http_trigger_config = HttpTriggerConfig {

--- a/tests/runtime-tests/tests/internal-http/spin.toml
+++ b/tests/runtime-tests/tests/internal-http/spin.toml
@@ -14,7 +14,7 @@ source = "%{source=internal-http-front}"
 allowed_outbound_hosts = ["http://middle.spin.internal"]
 
 [[trigger.http]]
-route = "/middle/..."
+route = false
 component = "middle"
 
 [component.middle]


### PR DESCRIPTION
The proposed syntax is that a private endpoint still requires a `[[trigger.http]]`, but has `route = false` instead of an actual route pattern.  (This creates the slight idiosyncrasy that `route = false` is allowed but `route = true` is not.  I can live with this!)

In addition to unit tests, the front-to-back service chaining test is modified to make the `middle` component a private endpoint.  Let me know if you think further tests are needed or if they should be reorganised to be more specific.
