### PR TITLE
ci(dispatch.yml): dispatch to fermyon/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,3 +358,17 @@ jobs:
         with:
           name: spin
           path: _dist/spin-${{ env.RELEASE_VERSION }}-static-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+
+  dispatch-homebrew-tap:
+    name: Dispatch spin-release event to fermyon/homebrew-tap
+    needs: create-gh-release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'fermyon' }} && ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEST_REPO_ACCESS_TOKEN }}
+          repository: fermyon/homebrew-tap
+          event-type: spin-release
+          client-payload: '{"version": "${{ github.ref_name }}"}'

--- a/docs/content/release-process.md
+++ b/docs/content/release-process.md
@@ -116,9 +116,8 @@ Otherwise, switch to the branch locally.
    `--certificate-identity` value should match this release, e.g.
    `https://github.com/fermyon/spin/.github/workflows/release.yml@refs/tags/v2.0.0`.
 
-1. Unless this is a release candidate, create a Pull Request into Fermyon's Hombrew tap
-   repository updating the [Spin formula](https://github.com/fermyon/homebrew-tap/blob/main/Formula/spin.rb).
-   In the formula, update the version, point to the latest release artifacts, and set their correct sha256 digests.
+1. Unless this is a release candidate, review and merge the bot-created Pull Request
+   in the [fermyon/homebrew-tap repository](https://github.com/fermyon/homebrew-tap/).
 
 The release is now complete!
 


### PR DESCRIPTION
- add a dispatch job after the GH release has been created to trigger homebrew formula update automation (ref https://github.com/fermyon/homebrew-tap/pull/34)