### PR TITLE
ci(release): fix dispatch conditional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,7 +363,7 @@ jobs:
     name: Dispatch spin-release event to fermyon/homebrew-tap
     needs: create-gh-release
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'fermyon' }} && ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: github.repository_owner == 'fermyon' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
Apparently `${{ startsWith(github.ref, 'refs/tags/v') }}` always resolves to true, presumably because when wrapped in expression brackets the result is a string rather than a boolean.  Removing the expression brackets to fix... probably.