### PR TITLE
Update Rust templates and bump Spin SDK version from 2.2.0 to 3.0.1

### DIFF
--- a/templates/http-rust/content/Cargo.toml
+++ b/templates/http-rust/content/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-spin-sdk = "2.2.0"
+spin-sdk = "3.0.1"
 
 [workspace]

--- a/templates/redis-rust/content/Cargo.toml
+++ b/templates/redis-rust/content/Cargo.toml
@@ -14,6 +14,6 @@ anyhow = "1"
 # Crate to simplify working with bytes.
 bytes = "1"
 # The Spin SDK.
-spin-sdk = "2.2.0"
+spin-sdk = "3.0.1"
 
 [workspace]


### PR DESCRIPTION
With this PR, Rust templates will use latest Spin SDK version (`3.0.1`)