### PR TITLE
ci(build.yml): gate dependency review on PRs only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
   dependency-review:
     name: Review new dependencies for known vulnerabilities
     runs-on: "ubuntu-20.04"
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4


### PR DESCRIPTION
The job as written would need to be updated to run on merges to main (see https://github.com/fermyon/spin/actions/runs/8651743204/job/23723100234).  Glad to close this one if we'd rather update and also run on main - but I'm assuming its main utility is reviewing at PR time.