### PR TITLE
Don't print plugin prerelease warning in middle of help

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -351,6 +351,7 @@ impl UpCommand {
 
             cmd.kill_on_drop(true);
         } else {
+            cmd.env("SPIN_PLUGINS_SUPPRESS_COMPATIBILITY_WARNINGS", "1");
             cmd.arg("--help-args-only");
         }
 


### PR DESCRIPTION
Fixes #2218 