### PR TITLE
Check for illegal file name when copying single file

### DIFF
--- a/crates/loader/tests/file-errors/bad.toml
+++ b/crates/loader/tests/file-errors/bad.toml
@@ -1,0 +1,12 @@
+spin_manifest_version = 2
+
+[application]
+name = "file-errors"
+
+[[trigger.http]]
+route = "/..."
+component = "bad"
+
+[component.bad]
+source = "dummy.wasm.txt"
+files = [{ source = "host.txt", destination = "/" }]

--- a/crates/loader/tests/file-errors/dummy.wasm.txt
+++ b/crates/loader/tests/file-errors/dummy.wasm.txt
@@ -1,0 +1,1 @@
+This file needs to exist for manifests to validate, but is never used.

--- a/crates/loader/tests/file-errors/host.txt
+++ b/crates/loader/tests/file-errors/host.txt
@@ -1,0 +1,1 @@
+Super excited for being copied from the host to the working directory!


### PR DESCRIPTION
Fixes #2361.

Example output:

```
$ spin up -f ./crates/loader/tests/file-errors/bad.toml 
Error: Failed to load manifest from "./crates/loader/tests/file-errors/bad.toml"

Caused by:
   0: Failed to load Spin app from "./crates/loader/tests/file-errors/bad.toml"
   1: Failed to load component `bad`
   2: Failed to copy "/home/ivan/github/spin/crates/loader/tests/file-errors/host.txt" to working path "/tmp/spinup-x8yn3O/assets/bad/": "/" is not a valid destination file name
```
