### PR TITLE
feat: Add Azure Key Vault Variable Provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
+dependencies = [
+ "async-channel 2.2.0",
+ "async-io 2.3.2",
+ "async-lock 3.3.0",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.3.0",
+ "futures-lite 2.3.0",
+ "rustix 0.38.32",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +376,7 @@ dependencies = [
  "async-global-executor",
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "async-process",
+ "async-process 1.8.1",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -526,13 +546,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.12",
+ "http-types",
+ "once_cell",
+ "paste",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.3",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "azure_data_cosmos"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73dede39a91e205b2050f250f6e31ed7c4c72be7ee694930c155c4d7636fe8e1"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.11.0",
  "bytes",
  "futures",
  "hmac",
@@ -544,6 +591,41 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c97790480791ec1ee9b76f5c6499b1d0aac0d4cd1e62010bfc19bb545544c5"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-process 2.2.2",
+ "async-trait",
+ "azure_core 0.20.0",
+ "futures",
+ "oauth2",
+ "pin-project",
+ "serde",
+ "time",
+ "tracing",
+ "tz-rs",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_security_keyvault"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338cac645bda0555f59189873be0cccaf420c26791f009b2207b62474cebbab8"
+dependencies = [
+ "async-trait",
+ "azure_core 0.20.0",
+ "futures",
+ "serde",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -1276,6 +1358,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "constant_time_eq"
@@ -4218,6 +4306,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.12",
+ "http 0.2.12",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,6 +5975,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6843,6 +6960,9 @@ version = "2.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "azure_core 0.20.0",
+ "azure_identity",
+ "azure_security_keyvault",
  "dotenvy",
  "once_cell",
  "serde",
@@ -7210,6 +7330,7 @@ checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -7734,6 +7855,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/crates/trigger/src/runtime_config/variables_provider.rs
+++ b/crates/trigger/src/runtime_config/variables_provider.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use spin_variables::provider::{
-    azkv::{AzureAuthorityHost, AzureKeyVaultProvider},
+    azure_key_vault::{AzureAuthorityHost, AzureKeyVaultProvider},
     env::EnvProvider,
     vault::VaultProvider,
 };

--- a/crates/variables/Cargo.toml
+++ b/crates/variables/Cargo.toml
@@ -18,6 +18,9 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 vaultrs = "0.6.2"
 serde = "1.0.188"
 tracing = { workspace = true }
+azure_security_keyvault = "0.20.0"
+azure_core = "0.20.0"
+azure_identity = "0.20.0"
 
 [dev-dependencies]
 toml = "0.5"

--- a/crates/variables/src/provider.rs
+++ b/crates/variables/src/provider.rs
@@ -1,3 +1,3 @@
-pub mod azkv;
+pub mod azure_key_vault;
 pub mod env;
 pub mod vault;

--- a/crates/variables/src/provider.rs
+++ b/crates/variables/src/provider.rs
@@ -1,2 +1,3 @@
+pub mod azkv;
 pub mod env;
 pub mod vault;

--- a/crates/variables/src/provider/azkv.rs
+++ b/crates/variables/src/provider/azkv.rs
@@ -1,0 +1,99 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use azure_core::Url;
+use azure_security_keyvault::SecretClient;
+use serde::Deserialize;
+use spin_expressions::{Key, Provider};
+use tracing::{instrument, Level};
+
+#[derive(Debug)]
+pub struct AzureKeyVaultProvider {
+    client_id: String,
+    client_secret: String,
+    tenant_id: String,
+    vault_url: String,
+    authority_host: AzureAuthorityHost,
+}
+
+impl AzureKeyVaultProvider {
+    pub fn new(
+        client_id: impl Into<String>,
+        client_secret: impl Into<String>,
+        tenant_id: impl Into<String>,
+        vault_url: impl Into<String>,
+        authority_host: impl Into<AzureAuthorityHost>,
+    ) -> Self {
+        Self {
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            tenant_id: tenant_id.into(),
+            vault_url: vault_url.into(),
+            authority_host: authority_host.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for AzureKeyVaultProvider {
+    #[instrument(name = "spin_variables.get_from_azure_key_vault", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
+    async fn get(&self, key: &Key) -> Result<Option<String>> {
+        let http_client = azure_core::new_http_client();
+        let credential = azure_identity::ClientSecretCredential::new(
+            http_client,
+            self.authority_host.into(),
+            self.tenant_id.to_string(),
+            self.client_id.to_string(),
+            self.client_secret.to_string(),
+        );
+
+        let secret_client = SecretClient::new(&self.vault_url, Arc::new(credential))?;
+        match secret_client.get(key.as_str()).await {
+            Ok(secret) => Ok(Some(secret.value)),
+            Err(err) => return Err(err).context("Failed to read variable from Azure Key Vault"),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Deserialize)]
+pub enum AzureAuthorityHost {
+    AzurePublicCloud,
+    AzureChina,
+    AzureGermany,
+    AzureGovernment,
+}
+
+impl Default for AzureAuthorityHost {
+    fn default() -> Self {
+        Self::AzurePublicCloud
+    }
+}
+
+impl From<AzureAuthorityHost> for Url {
+    fn from(value: AzureAuthorityHost) -> Self {
+        let url = match value {
+            AzureAuthorityHost::AzureChina => "https://login.chinacloudapi.cn/",
+            AzureAuthorityHost::AzureGovernment => "https://login.microsoftonline.us/",
+            AzureAuthorityHost::AzureGermany => "https://login.microsoftonline.de/",
+            _ => "https://login.microsoftonline.com/",
+        };
+        Url::parse(url).unwrap()
+    }
+}
+impl From<&str> for AzureAuthorityHost {
+    fn from(value: &str) -> Self {
+        match value.to_lowercase().as_str() {
+            "azurechina" | "china" => AzureAuthorityHost::AzureChina,
+            "azuregermany" | "germany" => AzureAuthorityHost::AzureGermany,
+            "AzureGovernment" | "gov" => AzureAuthorityHost::AzureGovernment,
+            _ => AzureAuthorityHost::AzurePublicCloud,
+        }
+    }
+}
+
+impl From<String> for AzureAuthorityHost {
+    fn from(value: String) -> Self {
+        AzureAuthorityHost::from(value.as_str())
+    }
+}

--- a/crates/variables/src/provider/azure_key_vault.rs
+++ b/crates/variables/src/provider/azure_key_vault.rs
@@ -1,6 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use azure_core::Url;
 use azure_security_keyvault::SecretClient;
@@ -80,26 +80,5 @@ impl From<AzureAuthorityHost> for Url {
             AzureAuthorityHost::AzurePublicCloud => "https://login.microsoftonline.com/",
         };
         Url::parse(url).unwrap()
-    }
-}
-impl FromStr for AzureAuthorityHost {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> std::prelude::v1::Result<Self, Self::Err> {
-        Ok(match s.to_lowercase().as_str() {
-            "azurechina" | "china" => AzureAuthorityHost::AzureChina,
-            "azuregermany" | "germany" => AzureAuthorityHost::AzureGermany,
-            "azuregovernment" | "gov" => AzureAuthorityHost::AzureGovernment,
-            "azureublic" | "azurepubliccloud" | "public" | "publiccloud" => {
-                AzureAuthorityHost::AzurePublicCloud
-            }
-            _ => bail!("Unsupported value provided for AzureAuthorityHost"),
-        })
-    }
-}
-
-impl From<String> for AzureAuthorityHost {
-    fn from(value: String) -> Self {
-        value.as_str().parse().unwrap()
     }
 }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,8 +110,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 5.3.0",
+ "event-listener-strategy 0.5.2",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -119,6 +138,74 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "parking",
+ "polling",
+ "rustix 0.38.31",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
+dependencies = [
+ "async-channel 2.2.1",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.3.0",
+ "futures-lite 2.3.0",
+ "rustix 0.38.31",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.31",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -144,6 +231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +246,12 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -233,11 +332,38 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.24",
  "rustc_version",
  "serde",
  "serde_json",
  "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.12",
+ "http-types",
+ "once_cell",
+ "paste",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.4",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -249,7 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73dede39a91e205b2050f250f6e31ed7c4c72be7ee694930c155c4d7636fe8e1"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.11.0",
  "bytes",
  "futures",
  "hmac",
@@ -261,6 +387,41 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c97790480791ec1ee9b76f5c6499b1d0aac0d4cd1e62010bfc19bb545544c5"
+dependencies = [
+ "async-lock",
+ "async-process",
+ "async-trait",
+ "azure_core 0.20.0",
+ "futures",
+ "oauth2",
+ "pin-project",
+ "serde",
+ "time",
+ "tracing",
+ "tz-rs",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_security_keyvault"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338cac645bda0555f59189873be0cccaf420c26791f009b2207b62474cebbab8"
+dependencies = [
+ "async-trait",
+ "azure_core 0.20.0",
+ "futures",
+ "serde",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -289,6 +450,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -344,6 +511,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
+dependencies = [
+ "async-channel 2.2.1",
+ "async-lock",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "piper",
 ]
 
 [[package]]
@@ -421,7 +602,7 @@ dependencies = [
  "indicatif",
  "log",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.24",
  "serde",
  "serde_json",
  "sha2",
@@ -534,6 +715,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +832,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "constant_time_eq"
@@ -1134,6 +1336,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener 5.3.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1572,19 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1637,9 +1894,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
- "async-channel",
+ "async-channel 1.9.0",
  "base64 0.13.1",
- "futures-lite",
+ "futures-lite 1.13.0",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -1761,6 +2018,42 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2576,6 +2869,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.12",
+ "http 0.2.11",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,7 +2996,7 @@ dependencies = [
  "bytes",
  "http 0.2.11",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.11.24",
 ]
 
 [[package]]
@@ -2702,7 +3014,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.11.24",
  "thiserror",
  "tokio",
  "tonic",
@@ -2800,7 +3112,7 @@ version = "2.5.0-pre0"
 dependencies = [
  "anyhow",
  "http 0.2.11",
- "reqwest",
+ "reqwest 0.11.24",
  "spin-app",
  "spin-core",
  "spin-expressions",
@@ -3058,10 +3370,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+
+[[package]]
+name = "polling"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.31",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "postgres-native-tls"
@@ -3428,7 +3765,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -3455,7 +3792,48 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.1",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util 0.7.10",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3536,7 +3914,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 0.2.11",
- "reqwest",
+ "reqwest 0.11.24",
  "rustify_derive",
  "serde",
  "serde_json",
@@ -3802,6 +4180,16 @@ checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -4120,7 +4508,7 @@ dependencies = [
  "anyhow",
  "http 0.2.11",
  "llm",
- "reqwest",
+ "reqwest 0.11.24",
  "serde",
  "serde_json",
  "spin-core",
@@ -4147,7 +4535,7 @@ dependencies = [
  "outbound-http",
  "path-absolutize",
  "regex",
- "reqwest",
+ "reqwest 0.11.24",
  "semver",
  "serde",
  "serde_json",
@@ -4334,6 +4722,9 @@ version = "2.5.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "azure_core 0.20.0",
+ "azure_identity",
+ "azure_security_keyvault",
  "dotenvy",
  "once_cell",
  "serde",
@@ -4598,6 +4989,7 @@ checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -4662,7 +5054,7 @@ dependencies = [
  "rayon-cond",
  "regex",
  "regex-syntax 0.7.5",
- "reqwest",
+ "reqwest 0.11.24",
  "serde",
  "serde_json",
  "spm_precompiled",
@@ -5066,6 +5458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5186,7 +5587,7 @@ dependencies = [
  "bytes",
  "derive_builder 0.11.2",
  "http 0.2.11",
- "reqwest",
+ "reqwest 0.11.24",
  "rustify",
  "rustify_derive",
  "serde",
@@ -6088,6 +6489,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",


### PR DESCRIPTION
This PR adds Azure Key Vault as Variable provider. 

Users can provide a runtime config using necessary information for Client Credential Flow:

```toml
[[config_provider]]
type = "azure_key_vault"
vault_url = "https://some.vault.azure.net/"
client_id = "11111111-1111-1111-1111-111111111111"
client_secret = "11111111-1111-1111-1111-111111111111"
tenant_id = "11111111-1111-1111-1111-111111111111"
# authority_host = "AzurePublicCloud"
```

If not specified, `authority_host` will default to `AzurePublicCloud`.


Unfortunately, I wasn't able to run `make lint` and `make test` on my machine. Both commands ran into errors shown below. 

Am I missing something on my machine? 

### Output from `make lint`

```bash
    Checking spin-expressions v2.5.0-pre0 (/Users/thorsten/dev/thorstenhans/spin/crates/expressions)
error: you are explicitly cloning with `.map()`
  --> crates/plugins/src/badger/store.rs:89:26
   |
89 |             badgered_to: to.iter().map(|v| <semver::Version>::clone(v)).collect(),
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `to.iter().cloned()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
   = note: `-D clippy::map-clone` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::map_clone)]`

    Checking spin-outbound-networking v2.5.0-pre0 (/Users/thorsten/dev/thorstenhans/spin/crates/outbound-networking)
    Checking spin-doctor v2.5.0-pre0 (/Users/thorsten/dev/thorstenhans/spin/crates/doctor)
    Checking spin-build v2.5.0-pre0 (/Users/thorsten/dev/thorstenhans/spin/crates/build)
    Checking spin-templates v2.5.0-pre0 (/Users/thorsten/dev/thorstenhans/spin/crates/templates)
error: could not compile `spin-plugins` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `spin-plugins` (lib test) due to 1 previous error
make: *** [lint] Error 101
```


### Output from `make test`

```bash
Checking spin-key-value v2.5.0-pre0 (/Users/thorsten/dev/thorstenhans/spin/crates/key-value)
error: you are explicitly cloning with `.map()`
  --> crates/plugins/src/badger/store.rs:89:26
   |
89 |             badgered_to: to.iter().map(|v| <semver::Version>::clone(v)).collect(),
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `to.iter().cloned()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
   = note: `-D clippy::map-clone` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::map_clone)]`

    Checking outbound-http v2.5.0-pre0 (/Users/thorsten/dev/thorstenhans/spin/crates/outbound-http)
error: could not compile `spin-plugins` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `spin-plugins` (lib test) due to 1 previous error
error: field `0` is never read
   --> crates/templates/src/template.rs:649:21
    |
649 |     struct TempFile(tempfile::TempDir, PathBuf);
    |            -------- ^^^^^^^^^^^^^^^^^
    |            |
    |            field in this struct
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
649 |     struct TempFile((), PathBuf);
    |                     ~~

error: could not compile `spin-templates` (lib test) due to 1 previous error
make: *** [lint] Error 101
```