### PR TITLE
added local_addr() to listeners to display random port numbers

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -169,27 +169,12 @@ impl TriggerExecutor for HttpTrigger {
         let listen_addr = config.address;
         let tls = config.into_tls_config();
 
-        // Print startup messages
-        let scheme = if tls.is_some() { "https" } else { "http" };
-        let base_url = format!("{}://{:?}", scheme, listen_addr);
-        terminal::step!("\nServing", "{}", base_url);
-        log::info!("Serving {}", base_url);
-
-        println!("Available Routes:");
-        for (route, component_id) in self.router.routes() {
-            println!("  {}: {}{}", component_id, base_url, route);
-            if let Some(component) = self.engine.app().get_component(component_id) {
-                if let Some(description) = component.get_metadata(APP_DESCRIPTION_KEY)? {
-                    println!("    {}", description);
-                }
-            }
-        }
-
         if let Some(tls) = tls {
             self.serve_tls(listen_addr, tls).await?
         } else {
             self.serve(listen_addr).await?
         };
+
         Ok(())
     }
 
@@ -414,6 +399,22 @@ impl HttpTrigger {
             .await
             .with_context(|| format!("Unable to listen on {}", listen_addr))?;
 
+        // Print startup messages
+        let scheme = "http";
+        let base_url = format!("{}://{:?}", scheme, listener.local_addr()?);
+        terminal::step!("\nServing", "{}", base_url);
+        log::info!("Serving {}", base_url);
+
+        println!("Available Routes:");
+        for (route, component_id) in self_.router.routes() {
+            println!("  {}: {}{}", component_id, base_url, route);
+            if let Some(component) = self_.engine.app().get_component(component_id) {
+                if let Some(description) = component.get_metadata(APP_DESCRIPTION_KEY)? {
+                    println!("    {}", description);
+                }
+            }
+        }
+
         loop {
             let (stream, addr) = listener.accept().await?;
             Self::serve_connection(self_.clone(), stream, addr);
@@ -426,6 +427,22 @@ impl HttpTrigger {
         let listener = TcpListener::bind(listen_addr)
             .await
             .with_context(|| format!("Unable to listen on {}", listen_addr))?;
+
+        // Print startup messages
+        let scheme = "https";
+        let base_url = format!("{}://{:?}", scheme, listener.local_addr()?);
+        terminal::step!("\nServing", "{}", base_url);
+        log::info!("Serving {}", base_url);
+
+        println!("Available Routes:");
+        for (route, component_id) in self_.router.routes() {
+            println!("  {}: {}{}", component_id, base_url, route);
+            if let Some(component) = self_.engine.app().get_component(component_id) {
+                if let Some(description) = component.get_metadata(APP_DESCRIPTION_KEY)? {
+                    println!("    {}", description);
+                }
+            }
+        }
 
         let acceptor = tls.server_config()?;
 

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -169,10 +169,15 @@ impl TriggerExecutor for HttpTrigger {
         let listen_addr = config.address;
         let tls = config.into_tls_config();
 
+        let listener = TcpListener::bind(listen_addr)
+            .await
+            .with_context(|| format!("Unable to listen on {}", listen_addr))?;
+
+        let self_ = Arc::new(self);
         if let Some(tls) = tls {
-            self.serve_tls(listen_addr, tls).await?
+            self_.serve_tls(listener, tls).await?
         } else {
-            self.serve(listen_addr).await?
+            self_.serve(listener).await?
         };
 
         Ok(())
@@ -350,7 +355,7 @@ impl HttpTrigger {
     }
 
     fn serve_connection<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
-        self_: Arc<Self>,
+        self: Arc<Self>,
         stream: S,
         addr: SocketAddr,
     ) {
@@ -359,7 +364,7 @@ impl HttpTrigger {
                 .keep_alive(true)
                 .serve_connection(
                     TokioIo::new(stream),
-                    service_fn(move |request| self_.clone().instrumented_service_fn(addr, request)),
+                    service_fn(move |request| self.clone().instrumented_service_fn(addr, request)),
                 )
                 .await
             {
@@ -392,67 +397,43 @@ impl HttpTrigger {
         .await
     }
 
-    async fn serve(self, listen_addr: SocketAddr) -> Result<()> {
-        let self_ = Arc::new(self);
-
-        let listener = TcpListener::bind(listen_addr)
-            .await
-            .with_context(|| format!("Unable to listen on {}", listen_addr))?;
-
-        // Print startup messages
-        let scheme = "http";
-        let base_url = format!("{}://{:?}", scheme, listener.local_addr()?);
-        terminal::step!("\nServing", "{}", base_url);
-        log::info!("Serving {}", base_url);
-
-        println!("Available Routes:");
-        for (route, component_id) in self_.router.routes() {
-            println!("  {}: {}{}", component_id, base_url, route);
-            if let Some(component) = self_.engine.app().get_component(component_id) {
-                if let Some(description) = component.get_metadata(APP_DESCRIPTION_KEY)? {
-                    println!("    {}", description);
-                }
-            }
-        }
-
+    async fn serve(self: Arc<Self>, listener: TcpListener) -> Result<()> {
+        self.print_startup_msgs("http", &listener)?;
         loop {
             let (stream, addr) = listener.accept().await?;
-            Self::serve_connection(self_.clone(), stream, addr);
+            Self::serve_connection(self.clone(), stream, addr);
         }
     }
 
-    async fn serve_tls(self, listen_addr: SocketAddr, tls: TlsConfig) -> Result<()> {
-        let self_ = Arc::new(self);
-
-        let listener = TcpListener::bind(listen_addr)
-            .await
-            .with_context(|| format!("Unable to listen on {}", listen_addr))?;
-
-        // Print startup messages
-        let scheme = "https";
-        let base_url = format!("{}://{:?}", scheme, listener.local_addr()?);
-        terminal::step!("\nServing", "{}", base_url);
-        log::info!("Serving {}", base_url);
-
-        println!("Available Routes:");
-        for (route, component_id) in self_.router.routes() {
-            println!("  {}: {}{}", component_id, base_url, route);
-            if let Some(component) = self_.engine.app().get_component(component_id) {
-                if let Some(description) = component.get_metadata(APP_DESCRIPTION_KEY)? {
-                    println!("    {}", description);
-                }
-            }
-        }
-
+    async fn serve_tls(self: Arc<Self>, listener: TcpListener, tls: TlsConfig) -> Result<()> {
         let acceptor = tls.server_config()?;
+        self.print_startup_msgs("https", &listener)?;
 
         loop {
             let (stream, addr) = listener.accept().await?;
             match acceptor.accept(stream).await {
-                Ok(stream) => Self::serve_connection(self_.clone(), stream, addr),
+                Ok(stream) => self.clone().serve_connection(stream, addr),
                 Err(err) => tracing::error!(?err, "Failed to start TLS session"),
             }
         }
+    }
+
+    fn print_startup_msgs(&self, scheme: &str, listener: &TcpListener) -> Result<()> {
+        let local_addr = listener.local_addr()?;
+        let base_url = format!("{scheme}://{local_addr:?}");
+        terminal::step!("\nServing", "{}", base_url);
+        log::info!("Serving {}", base_url);
+
+        println!("Available Routes:");
+        for (route, component_id) in self.router.routes() {
+            println!("  {}: {}{}", component_id, base_url, route);
+            if let Some(component) = self.engine.app().get_component(component_id) {
+                if let Some(description) = component.get_metadata(APP_DESCRIPTION_KEY)? {
+                    println!("    {}", description);
+                }
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Also had to move some logging info out of run and into serve and serve_tls functions since the thread is blocking. An alternative would be to spawn a new thread but this seemed to work and is the most straightforward approach.

I feel like it'd be good to add tests but I'm not exactly sure the best way to go about that. If anyone has guidance there or feedback for potential issues with this modification please let me know.

Closes #2471 

<img width="1432" alt="Screenshot 2024-04-25 at 12 06 43 PM" src="https://github.com/fermyon/spin/assets/111464359/d99b990a-bbe5-4cb7-b594-93fba156756e">
