### PR TITLE
chore(crates): address lint errs when rust is at 1.77+

### DIFF
--- a/crates/plugins/src/badger/store.rs
+++ b/crates/plugins/src/badger/store.rs
@@ -86,7 +86,7 @@ impl BadgerRecordManager {
         let new = BadgerRecord {
             name: name.to_owned(),
             badgered_from: from.clone(),
-            badgered_to: to.iter().map(|v| <semver::Version>::clone(v)).collect(),
+            badgered_to: to.iter().cloned().map(<semver::Version>::clone).collect(),
             when: chrono::Utc::now(),
         };
 

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -646,11 +646,14 @@ fn validate_v1_manifest(raw: &RawTemplateManifestV1) -> anyhow::Result<()> {
 mod test {
     use super::*;
 
-    struct TempFile(tempfile::TempDir, PathBuf);
+    struct TempFile {
+        _temp_dir: tempfile::TempDir,
+        path: PathBuf,
+    }
 
     impl TempFile {
         fn path(&self) -> PathBuf {
-            self.1.clone()
+            self.path.clone()
         }
     }
 
@@ -658,7 +661,10 @@ mod test {
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_file = temp_dir.path().join("spin.toml");
         std::fs::write(&temp_file, content).unwrap();
-        TempFile(temp_dir, temp_file)
+        TempFile {
+            _temp_dir: temp_dir,
+            path: temp_file,
+        }
     }
 
     #[test]


### PR DESCRIPTION
A few lint errors block successfully running the lint and test targets locally when on a more recent version of rust than is pinned in Spin/CI.  Hoping these updates are compatible with both scenarios...