### PR TITLE
Don't attempt to cancel workflow if lints fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,6 @@ jobs:
       - name: Run lints on examples
         run: BUILD_SPIN_EXAMPLES=0 make lint-rust-examples
 
-      - name: Cancel everything if linting fails
-        if: failure()
-        uses: andymckay/cancel-action@0.2
-
   ## This is separated out to remove full integration tests dependencies on windows/mac builds
   build-rust-ubuntu:
     name: Build Spin Ubuntu


### PR DESCRIPTION
We have a step in the PR CI workflow to "cancel everything if lints fail."  This step was added to save spending CI cycles on builds that were doomed to fail.

At the moment, this step doesn't actually do the cancel, I think because the permissions have drifted from when we originally added it.  However, some people (okay, I mean me) would actually prefer to have the run proceed, because it allows us to catch larger and more serious disasters in steps like integration testing without needing to do a full amend-resubmit-relint cycle.

I've checked in with the original author and they are comfortable with removing the step, so I don't think we're missing anything in terms of reasons it might need to be kept.

