### PR TITLE
Run a Wasm file as an application without a manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7600,6 +7600,7 @@ dependencies = [
  "dunce",
  "futures",
  "glob",
+ "indexmap 1.9.3",
  "itertools 0.10.5",
  "lazy_static 1.4.0",
  "mime_guess",

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -12,6 +12,7 @@ dirs = "4.0"
 dunce = "1.0"
 futures = "0.3.17"
 glob = "0.3.0"
+indexmap = { version = "1" }
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 mime_guess = { version = "2.0" }

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -67,7 +67,7 @@ impl LocalLoader {
     }
 
     // Load the given manifest into a LockedApp, ready for execution.
-    async fn load_manifest(&self, mut manifest: AppManifest) -> Result<LockedApp> {
+    pub(crate) async fn load_manifest(&self, mut manifest: AppManifest) -> Result<LockedApp> {
         spin_manifest::normalize::normalize_manifest(&mut manifest);
 
         let AppManifest {

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -118,10 +118,10 @@ pub struct Component {
     pub exclude_files: Vec<String>,
     /// `allowed_http_hosts = ["example.com"]`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub(crate) allowed_http_hosts: Vec<String>,
+    pub allowed_http_hosts: Vec<String>,
     /// `allowed_outbound_hosts = ["redis://myredishost.com:6379"]`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub(crate) allowed_outbound_hosts: Vec<String>,
+    pub allowed_outbound_hosts: Vec<String>,
     /// `key_value_stores = ["default", "my-store"]`
     #[serde(
         default,

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -5847,6 +5847,7 @@ dependencies = [
  "dunce",
  "futures",
  "glob",
+ "indexmap 1.9.3",
  "itertools 0.10.5",
  "lazy_static 1.4.0",
  "mime_guess",

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -435,6 +435,9 @@ impl UpCommand {
                     .await?;
                 ResolvedAppSource::OciRegistry { locked_app }
             }
+            AppSource::BareWasm(path) => ResolvedAppSource::BareWasm {
+                wasm_path: path.clone(),
+            },
             AppSource::Unresolvable(err) => bail!("{err}"),
             AppSource::None => bail!("Internal error - should have shown help"),
         })
@@ -463,6 +466,11 @@ impl UpCommand {
                     })
             }
             ResolvedAppSource::OciRegistry { locked_app } => Ok(locked_app),
+            ResolvedAppSource::BareWasm { wasm_path } => spin_loader::from_wasm_file(&wasm_path)
+                .await
+                .with_context(|| {
+                    format!("Failed to load component from {}", quoted_path(&wasm_path))
+                }),
         }
     }
 


### PR DESCRIPTION
Fixes #2477.  Or at least it explores what a solution might look like - there are definitely other paths to consider.

For example, this goes the route of constructing an in-memory `spin.toml`, because the route from `spin.toml` to locked app to trigger is well-exercised.  But we could bypass that and construct a lockfile directly - a lot of `spin.toml` concerns are not (yet) relevant to manifestless applications.

Or we could start planning more extensively for Future Things - this POC doesn't really provide any support in terms of the OCI proposal.

One thing we discussed internally was whether to put this on `spin up` or on a new command such as `spin serve` (by analogy with `wasmtime serve`).  For the sake of this POC I put it on `spin up` and inferred "bare file or manifest" based on the file extension.  This is not intended as a proposal, just a thing to dangle the actual loader code off.

Anyway hopefully provides us with something to argue about _grin_
