### PR TITLE
Fix incorrect base passed in service chaining

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -582,6 +582,7 @@ impl HttpRuntimeData {
         let engine = chained_handler.engine;
         let handler = chained_handler.executor;
 
+        let base = "/";
         let route_match = RouteMatch::synthetic(&component_id, request.request.uri().path());
 
         let client_addr = std::net::SocketAddr::from_str("0.0.0.0:0")?;
@@ -595,13 +596,7 @@ impl HttpRuntimeData {
 
         let resp_fut = async move {
             match handler
-                .execute(
-                    engine.clone(),
-                    &component_id,
-                    &route_match,
-                    req,
-                    client_addr,
-                )
+                .execute(engine.clone(), base, &route_match, req, client_addr)
                 .await
             {
                 Ok(resp) => Ok(Ok(IncomingResponseInternal {

--- a/tests/test-components/components/internal-http-middle/src/lib.rs
+++ b/tests/test-components/components/internal-http-middle/src/lib.rs
@@ -16,6 +16,11 @@ async fn handle_middle_impl(req: Request) -> Result<impl IntoResponse, String> {
         .header("spin-path-info")
         .and_then(|v| v.as_str());
     let inbound_rel_path = ensure_some!(inbound_rel_path);
+    let inbound_base = req
+        .header("spin-base-path")
+        .and_then(|v| v.as_str());
+    ensure_eq!("/", ensure_some!(inbound_base));
+    
     let out_req = spin_sdk::http::Request::builder()
         .uri("https://back.spin.internal/hello/from/middle")
         .method(spin_sdk::http::Method::Post)


### PR DESCRIPTION
The granular route matching work changed the signature of `HttpExecutor::execute()` to take a `RouteMatch` instead of a `component_id` and `raw_route`.

Unfortunately, when updating the call to `execute()` in service chaining, I incorrectly removed the `base` parameter instead of `component_id`.  The compiler didn't catch this because both are strings, and our tests didn't catch it because `base` is unused in service chaining (because it's not routed).  However, this would have let to some rather strange looking routing headers (which would have been meaningless anyway, but still), plus it's a category error to pass the component id as a base path even if it we did get away with it in practice.

Anyway this fixes it except for the lengthy self-lecture on primitive obsession.
