### PR TITLE
ref(*): Standardize on using tracing::* instead of tracing::log::*

### DIFF
--- a/crates/http/src/wagi/mod.rs
+++ b/crates/http/src/wagi/mod.rs
@@ -263,7 +263,7 @@ pub fn compose_response(stdout: &[u8]) -> Result<Response<Body>, Error> {
                     match status_code.parse::<StatusCode>() {
                         Ok(code) => *res.status_mut() = code,
                         Err(e) => {
-                            tracing::log::warn!("Failed to parse code: {}", e);
+                            tracing::warn!("Failed to parse code: {}", e);
                             *res.status_mut() = StatusCode::BAD_GATEWAY;
                         }
                     }

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -490,7 +490,7 @@ impl Client {
 
     /// Create a new wasm layer based on a file.
     async fn wasm_layer(file: &Path) -> Result<ImageLayer> {
-        tracing::log::trace!("Reading wasm module from {:?}", file);
+        tracing::trace!("Reading wasm module from {:?}", file);
         Ok(ImageLayer::new(
             fs::read(file).await.context("cannot read wasm module")?,
             WASM_LAYER_MEDIA_TYPE.to_string(),
@@ -500,7 +500,7 @@ impl Client {
 
     /// Create a new data layer based on a file.
     async fn data_layer(file: &Path, media_type: String) -> Result<ImageLayer> {
-        tracing::log::trace!("Reading data file from {:?}", file);
+        tracing::trace!("Reading data file from {:?}", file);
         Ok(ImageLayer::new(fs::read(&file).await?, media_type, None))
     }
 

--- a/crates/outbound-http/src/host_impl.rs
+++ b/crates/outbound-http/src/host_impl.rs
@@ -60,12 +60,12 @@ impl outbound_http::Host for OutboundHttp {
             }
         }
 
-        tracing::log::trace!("Attempting to send outbound HTTP request to {}", req.uri);
+        tracing::trace!("Attempting to send outbound HTTP request to {}", req.uri);
         if !self
             .is_allowed(&req.uri)
             .map_err(|_| HttpError::RuntimeError)?
         {
-            tracing::log::info!("Destination not allowed: {}", req.uri);
+            tracing::info!("Destination not allowed: {}", req.uri);
             if let Some((scheme, host_and_port)) = scheme_host_and_port(&req.uri) {
                 terminal::warn!("A component tried to make a HTTP request to non-allowed host '{host_and_port}'.");
                 eprintln!("To allow requests, add 'allowed_outbound_hosts = [\"{scheme}://{host_and_port}\"]' to the manifest component section.");
@@ -88,7 +88,7 @@ impl outbound_http::Host for OutboundHttp {
         let body = req.body.unwrap_or_default().to_vec();
 
         if !req.params.is_empty() {
-            tracing::log::warn!("HTTP params field is deprecated");
+            tracing::warn!("HTTP params field is deprecated");
         }
 
         // Allow reuse of Client's internal connection pool for multiple requests
@@ -102,7 +102,7 @@ impl outbound_http::Host for OutboundHttp {
             .send()
             .await
             .map_err(log_reqwest_error)?;
-        tracing::log::trace!("Returning response from outbound request to {}", req.uri);
+        tracing::trace!("Returning response from outbound request to {}", req.uri);
         current_span.record("http.response.status_code", resp.status().as_u16());
         response_from_reqwest(resp).await
     }

--- a/crates/outbound-mysql/src/lib.rs
+++ b/crates/outbound-mysql/src/lib.rs
@@ -348,7 +348,7 @@ fn convert_value(value: mysql_async::Value, column: &Column) -> Result<DbValue, 
 }
 
 async fn build_conn(address: &str) -> Result<mysql_async::Conn, mysql_async::Error> {
-    tracing::log::debug!("Build new connection: {}", address);
+    tracing::debug!("Build new connection: {}", address);
 
     let opts = build_opts(address)?;
 

--- a/crates/plugins/src/lookup.rs
+++ b/crates/plugins/src/lookup.rs
@@ -4,7 +4,6 @@ use std::{
     fs::File,
     path::{Path, PathBuf},
 };
-use tracing::log;
 use url::Url;
 
 // Name of directory that contains the cloned centralized Spin plugins
@@ -62,7 +61,7 @@ impl PluginLookup {
         plugins_dir: &Path,
     ) -> PluginLookupResult<PluginManifest> {
         let url = plugins_repo_url()?;
-        log::info!("Pulling manifest for plugin {} from {url}", self.name);
+        tracing::info!("Pulling manifest for plugin {} from {url}", self.name);
         fetch_plugins_repo(&url, plugins_dir, false)
             .await
             .map_err(|e| {

--- a/crates/plugins/src/manager.rs
+++ b/crates/plugins/src/manager.rs
@@ -16,7 +16,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use tempfile::{tempdir, TempDir};
-use tracing::log;
 use url::Url;
 
 // Url scheme prefix of a plugin that is installed from a local source
@@ -189,7 +188,7 @@ impl PluginManager {
     ) -> PluginLookupResult<PluginManifest> {
         let plugin_manifest = match manifest_location {
             ManifestLocation::Remote(url) => {
-                log::info!("Pulling manifest for plugin from {url}");
+                tracing::info!("Pulling manifest for plugin from {url}");
                 reqwest::get(url.as_ref())
                     .await
                     .map_err(|e| {
@@ -216,7 +215,7 @@ impl PluginManager {
                     })?
             }
             ManifestLocation::Local(path) => {
-                log::info!("Pulling manifest for plugin from {}", path.display());
+                tracing::info!("Pulling manifest for plugin from {}", path.display());
                 let file = File::open(path).map_err(|e| {
                     Error::NotFound(NotFoundError::new(
                         None,
@@ -336,7 +335,7 @@ pub fn get_package(plugin_manifest: &PluginManifest) -> Result<&PluginPackage> {
 }
 
 async fn download_plugin(name: &str, temp_dir: &TempDir, target_url: &str) -> Result<PathBuf> {
-    log::trace!("Trying to get tar file for plugin '{name}' from {target_url}");
+    tracing::trace!("Trying to get tar file for plugin '{name}' from {target_url}");
     let plugin_bin = reqwest::get(target_url).await?;
     if !plugin_bin.status().is_success() {
         match plugin_bin.status() {
@@ -358,7 +357,7 @@ fn verify_checksum(plugin_file: &Path, expected_sha256: &str) -> Result<()> {
     let actual_sha256 = sha256::hex_digest_from_file(plugin_file)
         .with_context(|| format!("Cannot get digest for {}", plugin_file.display()))?;
     if actual_sha256 == expected_sha256 {
-        log::info!("Package checksum verified successfully");
+        tracing::info!("Package checksum verified successfully");
         Ok(())
     } else {
         Err(anyhow!("Checksum did not match, aborting installation."))

--- a/crates/plugins/src/store.rs
+++ b/crates/plugins/src/store.rs
@@ -7,7 +7,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use tar::Archive;
-use tracing::log;
 
 use crate::{error::*, manifest::PluginManifest};
 
@@ -131,7 +130,7 @@ impl PluginStore {
     /// Looks up and parses the JSON plugin manifest file into object form.
     pub fn read_plugin_manifest(&self, plugin_name: &str) -> PluginLookupResult<PluginManifest> {
         let manifest_path = self.installed_manifest_path(plugin_name);
-        log::info!("Reading plugin manifest from {}", manifest_path.display());
+        tracing::info!("Reading plugin manifest from {}", manifest_path.display());
         let manifest_file = File::open(manifest_path.clone()).map_err(|e| {
             Error::NotFound(NotFoundError::new(
                 Some(plugin_name.to_string()),
@@ -156,7 +155,7 @@ impl PluginStore {
             &File::create(self.installed_manifest_path(&plugin_manifest.name()))?,
             plugin_manifest,
         )?;
-        log::trace!("Added manifest for {}", &plugin_manifest.name());
+        tracing::trace!("Added manifest for {}", &plugin_manifest.name());
         Ok(())
     }
 

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -692,7 +692,7 @@ impl OutboundWasiHttpHandler for HttpRuntimeData {
                 .allowed_hosts
                 .allows(&OutboundUrl::parse(uri_string, "https")?);
         if unallowed_relative || unallowed_absolute {
-            tracing::log::error!("Destination not allowed: {}", request.request.uri());
+            tracing::error!("Destination not allowed: {}", request.request.uri());
             let host = if unallowed_absolute {
                 // Safe to unwrap because absolute urls have a host by definition.
                 let host = uri.authority().map(|a| a.host()).unwrap();

--- a/crates/trigger/src/runtime_config/llm.rs
+++ b/crates/trigger/src/runtime_config/llm.rs
@@ -26,7 +26,7 @@ pub(crate) async fn build_component(
             spin_llm::LlmComponent::new(move || Box::new(noop::NoopLlmEngine.clone()))
         }
         LlmComputeOpts::RemoteHttp(config) => {
-            tracing::log::info!("Using remote compute for LLMs");
+            tracing::info!("Using remote compute for LLMs");
             let engine =
                 RemoteHttpLlmEngine::new(config.url.to_owned(), config.auth_token.to_owned());
             spin_llm::LlmComponent::new(move || Box::new(engine.clone()))

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -10,7 +10,6 @@ use spin_plugins::{
 use std::io::{stderr, IsTerminal};
 use std::{collections::HashMap, env, process};
 use tokio::process::Command;
-use tracing::log;
 
 const BADGER_GRACE_PERIOD_MILLIS: u64 = 50;
 
@@ -83,12 +82,12 @@ pub async fn execute_external_subcommand(
 
     let badger = BadgerChecker::start(&plugin_name, plugin_version, SPIN_VERSION);
 
-    log::info!("Executing command {:?}", command);
+    tracing::info!("Executing command {:?}", command);
     // Allow user to interact with stdio/stdout of child process
     let mut child = command.spawn()?;
     set_kill_on_ctrl_c(&child);
     let status = child.wait().await?;
-    log::info!("Exiting process with {}", status);
+    tracing::info!("Exiting process with {}", status);
 
     report_badger_result(badger).await;
 

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -11,7 +11,6 @@ use spin_plugins::{
     manifest::{PluginManifest, PluginPackage},
 };
 use std::path::{Path, PathBuf};
-use tracing::log;
 use url::Url;
 
 use crate::build_info::*;
@@ -366,7 +365,7 @@ impl Upgrade {
                 .await
             {
                 Err(Error::NotFound(e)) => {
-                    log::info!("Could not upgrade plugin '{name}': {e:?}");
+                    tracing::info!("Could not upgrade plugin '{name}': {e:?}");
                     continue;
                 }
                 Err(e) => return Err(e.into()),


### PR DESCRIPTION
This decreases our dependency on the Rust tracing-log compatibility layer to enable future work of integrating o11y work into SpinKube.