### PR TITLE
`spin templates install`: allow `--repo`

### DIFF
--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -62,6 +62,7 @@ pub struct Install {
     #[clap(
         name = INSTALL_FROM_GIT_OPT,
         long = "git",
+        alias = "repo",
         conflicts_with = INSTALL_FROM_DIR_OPT,
     )]
     pub git: Option<String>,


### PR DESCRIPTION
Fixes #2503 

The reason for choosing `--git` in `spin templates install` was to contrast with `--dir`.  However that didn't make sense with `upgrade` because in `upgrade` there was no contrast and it was more about filtering than about the protocol.  Which leads to an inconsistency between the two.  I still kinda think `--git` is nicer for `install` but having the same flag available in both places is good too.
