### PR TITLE
feat(telemetry): Add a compatibility layer that emits app logs as tracing events.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6878,6 +6878,7 @@ dependencies = [
  "spin-sqlite",
  "spin-sqlite-inproc",
  "spin-sqlite-libsql",
+ "spin-telemetry",
  "spin-variables",
  "spin-world",
  "tempfile",

--- a/crates/telemetry/src/env.rs
+++ b/crates/telemetry/src/env.rs
@@ -8,6 +8,7 @@ use opentelemetry_otlp::{
 const OTEL_SDK_DISABLED: &str = "OTEL_SDK_DISABLED";
 const OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
 const OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
+const SPIN_DISABLE_LOG_TO_TRACING: &str = "SPIN_DISABLE_LOG_TO_TRACING";
 
 /// Returns a boolean indicating if the OTEL tracing layer should be enabled.
 ///
@@ -35,6 +36,15 @@ pub(crate) fn otel_metrics_enabled() -> bool {
         OTEL_EXPORTER_OTLP_ENDPOINT,
         OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     ]) && !otel_sdk_disabled()
+}
+
+/// Returns a boolean indicating if the compatibility layer that emits tracing events from
+/// applications logs should be disabled.
+///
+/// It is considered disabled if the environment variable `SPIN_DISABLED_LOG_TO_TRACING` is set and not
+/// empty. By default the features is enabled.
+pub(crate) fn spin_disable_log_to_tracing() -> bool {
+    any_vars_set(&[SPIN_DISABLE_LOG_TO_TRACING])
 }
 
 fn any_vars_set(enabling_vars: &[&str]) -> bool {

--- a/crates/telemetry/src/log.rs
+++ b/crates/telemetry/src/log.rs
@@ -1,0 +1,25 @@
+use std::{ascii::escape_default, sync::OnceLock};
+
+use crate::env;
+
+/// Takes a Spin application log and emits it as a tracing event.
+///
+/// This acts as a compatibility layer to easily get Spin app logs as events in our OTel traces.
+pub fn app_log_to_tracing_event(buf: &[u8]) {
+    static CELL: OnceLock<bool> = OnceLock::new();
+    if *CELL.get_or_init(env::spin_disable_log_to_tracing) {
+        return;
+    }
+
+    if let Ok(s) = std::str::from_utf8(buf) {
+        tracing::info!(app_log = s);
+    } else {
+        tracing::info!(
+            app_log_non_utf8 = buf
+                .iter()
+                .take(50)
+                .map(|&x| escape_default(x).to_string())
+                .collect::<String>()
+        );
+    }
+}

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -41,6 +41,7 @@ spin-world = { path = "../world" }
 spin-llm = { path = "../llm" }
 spin-llm-local = { path = "../llm-local", optional = true }
 spin-llm-remote-http = { path = "../llm-remote-http" }
+spin-telemetry = { path = "../telemetry" }
 sanitize-filename = "0.4"
 serde = "1.0.188"
 serde_json = "1.0"

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -4704,6 +4704,7 @@ dependencies = [
  "spin-sqlite",
  "spin-sqlite-inproc",
  "spin-sqlite-libsql",
+ "spin-telemetry",
  "spin-variables",
  "spin-world",
  "terminal",


### PR DESCRIPTION
## Problem being solved

Users want to be able to emit o11y from the guest itself, but WASI Observe is quite far away.

## Solution
If Spin app logs were emitted as events on the existing traces we could get users 80% of the way there.

## Notes
This required some jank in `stdio.rs`. @fibonacci1729 and I felt the cleanest way to handle the two cases in the writer was to represent it with an enum. We can't keep using the inherit functionality b/c we want to emit this tracing event either way. We also felt that using options throughout to avoid writing to the file in the inherit case wasn't very clean.