### PR TITLE
Try to load manifest during `spin build`

### DIFF
--- a/crates/build/src/manifest.rs
+++ b/crates/build/src/manifest.rs
@@ -5,8 +5,35 @@ use std::{collections::BTreeMap, path::Path};
 use spin_manifest::{schema::v2, ManifestVersion};
 
 /// Returns a map of component IDs to [`v2::ComponentBuildConfig`]s for the
-/// given (v1 or v2) manifest path.
+/// given (v1 or v2) manifest path. If the manifest cannot be loaded, the
+/// function attempts fallback: if fallback succeeds, result is Ok but the load error
+/// is also returned via the second part of the return value tuple.
 pub async fn component_build_configs(
+    manifest_file: impl AsRef<Path>,
+) -> Result<(Vec<ComponentBuildInfo>, Option<spin_manifest::Error>)> {
+    let manifest = spin_manifest::manifest_from_file(&manifest_file);
+    match manifest {
+        Ok(manifest) => Ok((build_configs_from_manifest(manifest), None)),
+        Err(e) => fallback_load_build_configs(&manifest_file)
+            .await
+            .map(|bc| (bc, Some(e))),
+    }
+}
+
+fn build_configs_from_manifest(
+    manifest: spin_manifest::schema::v2::AppManifest,
+) -> Vec<ComponentBuildInfo> {
+    manifest
+        .components
+        .into_iter()
+        .map(|(id, c)| ComponentBuildInfo {
+            id: id.to_string(),
+            build: c.build,
+        })
+        .collect()
+}
+
+async fn fallback_load_build_configs(
     manifest_file: impl AsRef<Path>,
 ) -> Result<Vec<ComponentBuildInfo>> {
     let manifest_text = tokio::fs::read_to_string(manifest_file).await?;


### PR DESCRIPTION
This partly, but only partly, addresses #2520.

With this change, `spin build` attempts to load the full manifest, falling back to the subset only if that fails, and emitting a warning for the non-build-related validation failure.  This will catch schema errors such as `allowed_outbound_hsots = ...`:

```
$ spin build
Building component self-req-test with `cargo build --target wasm32-wasi --release`
    Finished `release` profile [optimized] target(s) in 0.03s
Finished building all Spin components
Warning: The manifest has errors not related to the Wasm component build. Error details:
TOML parse error at line 18, column 1
   |
18 | allowed_outbound_hsots = []
   | ^^^^^^^^^^^^^^^^^^^^^^
unknown field `allowed_outbound_hsots`, expected one of `source`, `description`, `variables`, `environment`, `files`, `exclude_files`, `allowed_http_hosts`, `allowed_outbound_hosts`, `key_value_stores`, `sqlite_databases`, `ai_models`, `build`, `tool`
```

HOWEVER.

The problem in #2520 relates to variable name validation, and that does _not_ happen at manifest load, or even lockfile creation, but _in the trigger_ when it tries to resolve the variables.  Checking that in the loader would require additional validation logic in the loader, similar to how we validate kebab-ids.  Nothing stops us adding that validation logic, but it's not there now, and _for this PR_ I didn't want to extend load-time validation (with who knows what consequences) but only run the existing load-time validation at build time.  If we decide to add variable name validation at load time then `spin build` with this PR will inherit it.
