### PR TITLE
fix(templates/../spin.toml): skewer spin application name like a kebab

### DIFF
--- a/templates/http-c/content/spin.toml
+++ b/templates/http-c/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/http-empty/content/spin.toml
+++ b/templates/http-empty/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/http-go/content/spin.toml
+++ b/templates/http-go/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/http-grain/content/spin.toml
+++ b/templates/http-grain/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/http-php/content/spin.toml
+++ b/templates/http-php/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/http-rust/content/spin.toml
+++ b/templates/http-rust/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/http-swift/content/spin.toml
+++ b/templates/http-swift/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/http-zig/content/spin.toml
+++ b/templates/http-zig/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/redirect/content/spin.toml
+++ b/templates/redirect/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/redis-go/content/spin.toml
+++ b/templates/redis-go/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/redis-rust/content/spin.toml
+++ b/templates/redis-rust/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"

--- a/templates/static-fileserver/content/spin.toml
+++ b/templates/static-fileserver/content/spin.toml
@@ -1,7 +1,7 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name}}"
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 description = "{{project-description}}"


### PR DESCRIPTION
TLDR: Kebab skewers are great  🍡

---

With my Master's thesis handed in where I built a Temu/Wish knockoff of your products, I finally have time to try out your products proper. Howver, I encountered a bug while naively naming my spin project.

I'm not sure if omitting the kebab skewer from the generated spin.toml file was intentional or not, but I was met with this nifty error while trying to deploy the app I named with whitespaces:

**`Error: App name 'is it wednesday yet my dudes' contains characters that are not allowed. It may contain only letters, numbers, dashes and underscores`**

The error disappeared when I updated the name in my spin.toml to include the skewer, and I was able to deploy as expected.

I noticed that the `Cargo.toml` and folder name replaced the whitespace correctly, but not `spin.toml.application.name`. No one would be stupid enough to name their project with whitespace, eh? (Hi, it's a me! 👋 👨‍💼)

After digging through the source code that I'm now more suited for understanding after building [Nebula](https://github.com/brehen/nebula) (self-plug), I noticed that the kebab_case piping were missing in all the spin.toml templates. You're skewering the other other instances of project-name in here though, so I figured it might have been a mishap?

I'm able to build and deploy to Fermyon Cloud after installing the templates from the local git repository where I've update the templates.

My LSP complained about some of the .toml templates missing a newline between [component.name] and [component.name.build]. Let me know if I should revert these newlines.