### PR TITLE
fix `StoreBuilder::inherit_limited_network`

### DIFF
--- a/crates/trigger/src/network.rs
+++ b/crates/trigger/src/network.rs
@@ -29,15 +29,13 @@ impl TriggerHooks for Network {
         let allowed_hosts =
             spin_outbound_networking::AllowedHostsConfig::parse(&hosts, &self.resolver)?;
         match allowed_hosts {
-            spin_outbound_networking::AllowedHostsConfig::All => {
-                store_builder.inherit_limited_network()
-            }
+            spin_outbound_networking::AllowedHostsConfig::All => store_builder.inherit_network(),
             spin_outbound_networking::AllowedHostsConfig::SpecificHosts(configs) => {
                 for config in configs {
                     if config.scheme().allows_any() {
                         match config.host() {
                             spin_outbound_networking::HostConfig::Any => {
-                                store_builder.inherit_limited_network()
+                                store_builder.inherit_network()
                             }
                             spin_outbound_networking::HostConfig::AnySubdomain(_) => continue,
                             spin_outbound_networking::HostConfig::ToSelf => {}


### PR DESCRIPTION
Previously, this called `WasiCtxBuilder::inherit_network`, but that had no effect since `StoreBuilder::build_with_data` later overwrites that setting by calling `WasiCtxBuilder::socket_addr_check` with a lambda that uses `StoreBuilder::net_pool` to check addresses.  In this case, `StoreBuilder::net_pool` has not had any subnets added to it, so it denies everything, which is the opposite of what we intended.

The solution is to have `StoreBuilder::inherit_limited_network` update `net_pool` to allow all IPv4 and IPv6 networks.