### PR TITLE
Add implementations to the test environment for the Spin containerd shim

### DIFF
--- a/tests/testing-framework/src/runtimes/mod.rs
+++ b/tests/testing-framework/src/runtimes/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod in_process_spin;
 pub mod spin_cli;
+pub mod spin_containerd_shim;
 
 /// The type of app Spin is running
 pub enum SpinAppType {


### PR DESCRIPTION
`TestEnvironment` implementations for conformance testing in the shim https://github.com/spinkube/containerd-shim-spin/pull/134

This is very draft -- pushing up in a state that "gets things running".