### PR TITLE
Don't prompt to install templates if not interactive

### DIFF
--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{io::IsTerminal, path::Path};
 
 use anyhow::Context;
 
@@ -90,10 +90,11 @@ pub struct ListResults {
 }
 
 impl ListResults {
-    /// Returns true if no templates were found or skipped indicating that
-    /// templates may not be installed.
+    /// Returns true if no templates were found or skipped, and the UI should prompt to
+    /// install templates. This is specifically for interactive use and returns false
+    /// if not connected to a terminal.
     pub fn needs_install(&self) -> bool {
-        self.templates.is_empty() && self.skipped.is_empty()
+        self.templates.is_empty() && self.skipped.is_empty() && std::io::stderr().is_terminal()
     }
 }
 


### PR DESCRIPTION
Fixes an issue where you can't test the output of `spin templates list` to programmatically determine if templates are installed or not, because if not it would put up a prompt.
