### PR TITLE
Restore cursor if dialoguer Ctrl+C-ed

### DIFF
--- a/crates/templates/src/interaction.rs
+++ b/crates/templates/src/interaction.rs
@@ -123,6 +123,7 @@ pub(crate) fn prompt_parameter(parameter: &TemplateParameter) -> Option<String> 
             },
             Err(e) => {
                 println!("Invalid value: {}", e);
+                return None;
             }
         }
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -25,6 +25,11 @@ pub struct DoctorCommand {
 
 impl DoctorCommand {
     pub async fn run(self) -> Result<()> {
+        // This may use dialoguer so we work around https://github.com/console-rs/dialoguer/issues/294
+        _ = ctrlc::set_handler(|| {
+            _ = dialoguer::console::Term::stderr().show_cursor();
+        });
+
         let manifest_file = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
 
         println!("{icon}The Spin Doctor is in.", icon = Emoji("📟 ", ""));

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -56,6 +56,11 @@ pub async fn execute_external_subcommand(
     cmd: Vec<String>,
     app: clap::App<'_>,
 ) -> anyhow::Result<()> {
+    // This may use dialoguer so we work around https://github.com/console-rs/dialoguer/issues/294
+    _ = ctrlc::set_handler(|| {
+        _ = dialoguer::console::Term::stderr().show_cursor();
+    });
+
     let (plugin_name, args, override_compatibility_check) = parse_subcommand(cmd)?;
     let plugin_store = PluginStore::try_default()?;
     let plugin_version = ensure_plugin_available(

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -125,6 +125,11 @@ impl AddCommand {
 
 impl TemplateNewCommandCore {
     pub async fn run(&self, variant: TemplateVariantInfo) -> Result<()> {
+        // work around https://github.com/console-rs/dialoguer/issues/294
+        _ = ctrlc::set_handler(|| {
+            _ = dialoguer::console::Term::stderr().show_cursor();
+        });
+
         let template_manager = TemplateManager::try_default()
             .context("Failed to construct template directory path")?;
 

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -108,6 +108,11 @@ pub struct Install {
 
 impl Install {
     pub async fn run(&self) -> Result<()> {
+        // This may use dialoguer so we work around https://github.com/console-rs/dialoguer/issues/294
+        _ = ctrlc::set_handler(|| {
+            _ = dialoguer::console::Term::stderr().show_cursor();
+        });
+
         let manifest_location = match (&self.local_manifest_src, &self.remote_manifest_src, &self.name) {
             (Some(path), None, None) => ManifestLocation::Local(path.to_path_buf()),
             (None, Some(url), None) => ManifestLocation::Remote(url.clone()),
@@ -231,6 +236,11 @@ impl Upgrade {
     /// Also, by default, Spin displays the list of installed plugins that are in
     /// the catalogue and prompts user to choose which ones to upgrade.
     pub async fn run(self) -> Result<()> {
+        // This may use dialoguer so we work around https://github.com/console-rs/dialoguer/issues/294
+        _ = ctrlc::set_handler(|| {
+            _ = dialoguer::console::Term::stderr().show_cursor();
+        });
+
         let manager = PluginManager::try_default()?;
         let manifests_dir = manager.store().installed_manifests_directory();
 

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -117,6 +117,11 @@ pub struct Uninstall {
 
 impl Install {
     pub async fn run(self) -> Result<()> {
+        // This may use dialoguer so we work around https://github.com/console-rs/dialoguer/issues/294
+        _ = ctrlc::set_handler(|| {
+            _ = dialoguer::console::Term::stderr().show_cursor();
+        });
+
         let template_manager = TemplateManager::try_default()
             .context("Failed to construct template directory path")?;
         let source = match (&self.git, &self.dir) {
@@ -198,6 +203,11 @@ fn infer_github(raw: &str) -> String {
 
 impl Upgrade {
     pub async fn run(&self) -> Result<()> {
+        // This may use dialoguer so we work around https://github.com/console-rs/dialoguer/issues/294
+        _ = ctrlc::set_handler(|| {
+            _ = dialoguer::console::Term::stderr().show_cursor();
+        });
+
         if self.git.is_some() {
             // This is equivalent to `install --update`
             let install = Install {
@@ -478,6 +488,11 @@ pub enum ListFormat {
 
 impl List {
     pub async fn run(self) -> Result<()> {
+        // This may use dialoguer so we work around https://github.com/console-rs/dialoguer/issues/294
+        _ = ctrlc::set_handler(|| {
+            _ = dialoguer::console::Term::stderr().show_cursor();
+        });
+
         let template_manager = TemplateManager::try_default()
             .context("Failed to construct template directory path")?;
 


### PR DESCRIPTION
Fixes #2557.

At the moment, this prints `Error: read interrupted` after the Ctrl+C.  I've tried some of the suggested fixes and they have either had the same quirk, or not fixed the problem, or both.  So for now I'm accepting that ugliness as a compromise.  Better offers eagerly accepted!

This PR sets the Ctrl+C handler up at the entry to every command that uses `dialoguer` hidden-cursor functions.  This is safer than putting it near the point of use, because you can only set a Ctrl+C handler once per process; and we cannot put it at the top of the whole program because some commands need different/extra Ctrl+C processing (e.g. `spin up` tearing down triggers).  This can result in setting up a handler that might never be needed (and it's not 100% clear if that could have unexpected side effects).

There is code duplication here: we could move it into `common` or `terminal` but that would introduce new dependencies into those crates, which are used quite widely.  But maybe it's worth it.
