### PR TITLE
Add support for workload identity in the Azure CosmosDB Key/Value impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,32 +570,6 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32568c56fda7f2f1173430298bddeb507ed44e99bd989ba1156a25534bff5d98"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "dyn-clone",
- "futures",
- "getrandom 0.2.12",
- "http-types",
- "log",
- "paste",
- "pin-project",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "rustc_version",
- "serde 1.0.197",
- "serde_json",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_core"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
@@ -622,22 +596,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "azure_data_cosmos"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73dede39a91e205b2050f250f6e31ed7c4c72be7ee694930c155c4d7636fe8e1"
+name = "azure_core"
+version = "0.20.0"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
- "azure_core 0.11.0",
+ "base64 0.22.0",
  "bytes",
+ "dyn-clone",
  "futures",
+ "getrandom 0.2.12",
  "hmac",
- "log",
+ "http-types",
+ "once_cell",
+ "paste",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.4",
+ "rustc_version",
  "serde 1.0.197",
  "serde_json",
  "sha2",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_data_cosmos"
+version = "0.20.0"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
+dependencies = [
+ "async-trait",
+ "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "bytes",
+ "futures",
+ "serde 1.0.197",
+ "serde_json",
  "thiserror",
  "time",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -651,7 +650,27 @@ dependencies = [
  "async-lock 3.3.0",
  "async-process 2.2.2",
  "async-trait",
- "azure_core 0.20.0",
+ "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "oauth2",
+ "pin-project",
+ "serde 1.0.197",
+ "time",
+ "tracing",
+ "tz-rs",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.20.0"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-process 2.2.2",
+ "async-trait",
+ "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
  "futures",
  "oauth2",
  "pin-project",
@@ -670,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338cac645bda0555f59189873be0cccaf420c26791f009b2207b62474cebbab8"
 dependencies = [
  "async-trait",
- "azure_core 0.20.0",
+ "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "serde 1.0.197",
  "serde_json",
@@ -7538,6 +7557,7 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
+ "azure_identity 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
  "futures",
  "serde 1.0.197",
  "spin-core",
@@ -8020,8 +8040,8 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "azure_core 0.20.0",
- "azure_identity",
+ "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_identity 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_security_keyvault",
  "dotenvy",
  "once_cell",

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -6,7 +6,8 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = "1"
-azure_data_cosmos = "0.11.0"
+azure_data_cosmos = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
+azure_identity = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
 futures = "0.3.28"
 serde = { version = "1.0", features = ["derive"] }
 spin-key-value = { path = "../key-value" }

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -1141,15 +1141,13 @@ mod test {
                 .expect("should have version annotation")
         );
         assert!(
-            annotations
-                .get(oci_distribution::annotations::ORG_OPENCONTAINERS_IMAGE_DESCRIPTION)
-                .is_none(),
+            !annotations
+                .contains_key(oci_distribution::annotations::ORG_OPENCONTAINERS_IMAGE_DESCRIPTION),
             "empty description should not have generated annotation"
         );
         assert!(
             annotations
-                .get(oci_distribution::annotations::ORG_OPENCONTAINERS_IMAGE_CREATED)
-                .is_some(),
+                .contains_key(oci_distribution::annotations::ORG_OPENCONTAINERS_IMAGE_CREATED),
             "creation annotation should have been generated"
         );
     }

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -442,7 +442,7 @@ impl<Executor: TriggerExecutor> TriggerAppEngine<Executor> {
         &self,
         component_id: &str,
     ) -> Option<HashMap<Authority, ParsedClientTlsOpts>> {
-        self.client_tls_opts.get(&component_id.to_string()).cloned()
+        self.client_tls_opts.get(component_id).cloned()
     }
 
     pub fn resolve_template(

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -472,32 +472,6 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32568c56fda7f2f1173430298bddeb507ed44e99bd989ba1156a25534bff5d98"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "dyn-clone",
- "futures",
- "getrandom 0.2.12",
- "http-types",
- "log",
- "paste",
- "pin-project",
- "rand 0.8.5",
- "reqwest 0.11.24",
- "rustc_version",
- "serde 1.0.203",
- "serde_json",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_core"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
@@ -524,22 +498,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "azure_data_cosmos"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73dede39a91e205b2050f250f6e31ed7c4c72be7ee694930c155c4d7636fe8e1"
+name = "azure_core"
+version = "0.20.0"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
- "azure_core 0.11.0",
+ "base64 0.22.0",
  "bytes",
+ "dyn-clone",
  "futures",
+ "getrandom 0.2.12",
  "hmac",
- "log",
+ "http-types",
+ "once_cell",
+ "paste",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.4",
+ "rustc_version",
  "serde 1.0.203",
  "serde_json",
  "sha2",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_data_cosmos"
+version = "0.20.0"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
+dependencies = [
+ "async-trait",
+ "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "bytes",
+ "futures",
+ "serde 1.0.203",
+ "serde_json",
  "thiserror",
  "time",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -553,7 +552,27 @@ dependencies = [
  "async-lock 3.3.0",
  "async-process 2.2.2",
  "async-trait",
- "azure_core 0.20.0",
+ "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "oauth2",
+ "pin-project",
+ "serde 1.0.203",
+ "time",
+ "tracing",
+ "tz-rs",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.20.0"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-process 2.2.2",
+ "async-trait",
+ "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
  "futures",
  "oauth2",
  "pin-project",
@@ -572,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338cac645bda0555f59189873be0cccaf420c26791f009b2207b62474cebbab8"
 dependencies = [
  "async-trait",
- "azure_core 0.20.0",
+ "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "serde 1.0.203",
  "serde_json",
@@ -4897,7 +4916,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg 0.50.0",
@@ -5764,6 +5782,7 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
+ "azure_identity 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
  "futures",
  "serde 1.0.203",
  "spin-core",
@@ -6043,8 +6062,8 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "azure_core 0.20.0",
- "azure_identity",
+ "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_identity 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_security_keyvault",
  "dotenvy",
  "once_cell",


### PR DESCRIPTION
This PR adds the ability for the Azure CosmosDB KV store implementation to use ambient authentication (managed identity, workflow identity, azure cli). The PR should not break existing users of the `key` authentication mechanism; it should only be additive. For more information about the Azure Rust SDK identity flows, check out: https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/identity/README.md.

Here is the associated infrastructure and sample application to demo this identity flow: https://github.com/devigned/spin-workload-id.

I'm opening this now to start getting feedback. I (or the identity SDK) also likely have a bug related to the authentication scope being passed to Entra (previously Azure Active Directory). I will sort that issue out and notify via the PR.

This work is related to https://github.com/spinkube/spin-operator/issues/252.

If you have Azure CLI installed, you can test this locally doing the following:
```bash
# Create an Azure CosmosDB
az cosmosdb create -n cosmosdb-spin-test -g test --locations regionName=southcentralus
# Create a database in our account
az cosmosdb database create -a cosmosdb-spin-test -g test -n spin
# Create a container (table) in our database
az cosmosdb container create -a cosmosdb-spin-test -g test -n  -d spin -p "/id"
# Get your subscription ID
SUB_ID=$(az account show --query "id" -o tsv)
# Get your user principal ID
ID=$(az ad user show --id your_user@your_domain.com --query "id" -o tsv)
# Add the role assignment to enable data mutations for your user
az cosmosdb sql role assignment create -a cosmosdb-spin-test -g test \
  --role-definition-name "00000000-0000-0000-0000-000000000002" \
  -s "/subscriptions/${SUB_ID}/resourceGroups/test/providers/Microsoft.DocumentDB/databaseAccounts/cosmosdb-spin-test" \
  -p ${ID}
```

Your corresponding runtime config should look like the following. Note there is no `key` used.
```
[key_value_store.default]
type = "azure_cosmos"
account = "cosmosdb-spin-test"
database = "spin"
container = "keys-and-values"
```