### PR TITLE
fix(gh-backport.sh): add worktrees path

### DIFF
--- a/.github/gh-backport.sh
+++ b/.github/gh-backport.sh
@@ -22,7 +22,7 @@ git fetch -q origin "refs/pull/${pr}/head"
 git fetch -q origin "refs/heads/${branch}"
 branch_head="$(git rev-parse FETCH_HEAD)"
 
-work_tree="$(git rev-parse --git-dir)/backport-worktree"
+work_tree="$(git rev-parse --git-dir)/worktrees/backport-worktree"
 [[ -e "${work_tree}" ]] || git worktree add -f "${work_tree}" "${branch_head}"
 cd "${work_tree}"
 


### PR DESCRIPTION
I ran into the following error when running the gh-backport.sh script:

```
fatal: not a git repository: /Users/vdice/go/src/github.com/fermyon/spin/.git/worktrees/backport-worktree
```

Adding `worktrees` to the `work_tree` path fixed it for me.  I have `git version 2.39.3 (Apple Git-146)`