### PR TITLE
Fix broken TCP runtime tests.

### DIFF
--- a/tests/runtime-tests/tests/tcp-sockets-ip-range-variable-permission/spin.toml
+++ b/tests/runtime-tests/tests/tcp-sockets-ip-range-variable-permission/spin.toml
@@ -6,8 +6,8 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 version = "0.1.0"
 
 [variables]
-addr_prefix = { default = "127.0.0.0"}
-prefix_len = { default = "24"}
+addr_prefix = { default = "127.0.0.0" }
+prefix_len = { default = "24" }
 
 [[trigger.http]]
 route = "/"
@@ -15,5 +15,5 @@ component = "test"
 
 [component.test]
 source = "%{source=tcp-sockets}"
-environment = { ADDRESS = "127.0.0.1:%{port=5000}" }
-allowed_outbound_hosts = ["*://{{ addr_prefix }}/{{ prefix_len }}:%{port=5000}"]
+environment = { ADDRESS = "127.0.0.1:%{port=7}" }
+allowed_outbound_hosts = ["*://{{ addr_prefix }}/{{ prefix_len }}:%{port=7}"]

--- a/tests/runtime-tests/tests/tcp-sockets-ip-range/spin.toml
+++ b/tests/runtime-tests/tests/tcp-sockets-ip-range/spin.toml
@@ -11,5 +11,5 @@ component = "test"
 
 [component.test]
 source = "%{source=tcp-sockets}"
-environment = { ADDRESS = "127.0.0.1:%{port=5000}" }
-allowed_outbound_hosts = ["*://127.0.0.0/24:%{port=5000}"]
+environment = { ADDRESS = "127.0.0.1:%{port=7}" }
+allowed_outbound_hosts = ["*://127.0.0.0/24:%{port=7}"]

--- a/tests/runtime-tests/tests/tcp-sockets/spin.toml
+++ b/tests/runtime-tests/tests/tcp-sockets/spin.toml
@@ -11,5 +11,5 @@ component = "test"
 
 [component.test]
 source = "%{source=tcp-sockets}"
-environment = { ADDRESS = "127.0.0.1:%{port=5000}" }
-allowed_outbound_hosts = ["*://127.0.0.1:%{port=5000}"]
+environment = { ADDRESS = "127.0.0.1:%{port=7}" }
+allowed_outbound_hosts = ["*://127.0.0.1:%{port=7}"]


### PR DESCRIPTION
https://github.com/fermyon/conformance-tests/pull/16 changed the port for the TCP echo service that these tests use and we did not change the port in these spin.toml files.