### PR TITLE
Infer predefined annotations when pushing to registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7708,6 +7708,7 @@ dependencies = [
  "async-compression",
  "async-tar",
  "base64 0.21.7",
+ "chrono",
  "dirs 4.0.0",
  "dkregistry",
  "docker_credential",

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -10,6 +10,7 @@ async-compression = "0.4.3"
 # Fork with nested async-std dependency bumped to satisfy Windows build; branch/revision is protected
 async-tar = { git = "https://github.com/vdice/async-tar", rev = "71e037f9652971e7a55b412a8e47a37b06f9c29d" }
 base64 = "0.21"
+chrono = "0.4"
 # Fork with updated auth to support ACR login
 # Ref https://github.com/camallo/dkregistry-rs/pull/263
 dkregistry = { git = "https://github.com/fermyon/dkregistry-rs", rev = "161cf2b66996ed97c7abaf046e38244484814de3" }

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use spin_common::arg_parser::parse_kv;
-use spin_oci::Client;
+use spin_oci::{client::InferPredefinedAnnotations, Client};
 use std::{io::Read, path::PathBuf, time::Duration};
 
 /// Commands for working with OCI registries to distribute applications.
@@ -86,7 +86,14 @@ impl Push {
 
         let _spinner = create_dotted_spinner(2000, "Pushing app to the Registry".to_owned());
 
-        let digest = client.push(&app_file, &self.reference, annotations).await?;
+        let digest = client
+            .push(
+                &app_file,
+                &self.reference,
+                annotations,
+                InferPredefinedAnnotations::All,
+            )
+            .await?;
         match digest {
             Some(digest) => println!("Pushed with digest {digest}"),
             None => println!("Pushed; the registry did not return the digest"),


### PR DESCRIPTION
Fixes #2612 (or at least part of it).

I'm not sure the best way to test this in CI, but trying it locally it seems promising:

```
# Manifest for testing
ivan@hestia:~/testing$ cat v2vanillareallyv2/spin.toml
spin_manifest_version = 2

[application]
name = "v2vanillareallyv2"
version = "0.1.0"
authors = ["itowlson <ivan.towlson@fermyon.com>"]
description = ""
# moar TOML

# If the user doesn't set any of the predefined annotations
ivan@hestia:~/testing$ spin registry push localhost:5000/vanilla:v0.1 -f v2vanillareallyv2/ --insecure
Pushing app to the Registry..
Pushed with digest sha256:9110a84446a12c3479978316e2343e60bda6d5375ff39fb0ef0f77759d7d1011

# ...then they are inferred (formatting added for legibility)
ivan@hestia:~/testing$ docker buildx imagetools inspect localhost:5000/vanilla:v0.1 --raw
{"annotations":{
  "org.opencontainers.image.authors":"itowlson <ivan.towlson@fermyon.com>",
  "org.opencontainers.image.created":"2024-07-09T01:33:37.290049791+00:00",
  "org.opencontainers.image.title":"v2vanillareallyv2",
  "org.opencontainers.image.version":"0.1.0"
},
# moar JSON
}

# But if the user specifies, say, the `authors` annotation...
ivan@hestia:~/testing$ spin registry push localhost:5000/vanilla:v0.2 -f v2vanillareallyv2/ --insecure --annotation org.opencontainers.image.authors="THE GREAT OZ"
Pushing app to the Registry..
Pushed with digest sha256:63420c721dbb51261c0c3af18cded3b6ef81d8fc65c820be535500f27cb4285e

# ...then we do not infer it but respect the one we are given (formatting added for legibility)
ivan@hestia:~/testing$ docker buildx imagetools inspect localhost:5000/vanilla:v0.2 --raw
{"annotations":{
  "org.opencontainers.image.authors":"THE GREAT OZ",
  "org.opencontainers.image.created":"2024-07-09T01:36:01.402920121+00:00",
  "org.opencontainers.image.title":"v2vanillareallyv2",
  "org.opencontainers.image.version":"0.1.0"
},
# moar JSON
}
```

The OCI `authors` annotation is a string, whereas Spin allows an array: the PR comma-space-concatenates them, e.g. `"The Great Oz, Dorothy Gale"`.  OCI describes the field as a freeform string but if there's a common community convention then I can adopt that.

This PR does not provide a way for a user to suppress inference but the infrastructure is there in case we want to add an option, or for programmatic use (e.g. reproducibility).
