### PR TITLE
factors: Add spin-factors-test crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7562,7 +7562,9 @@ dependencies = [
  "serde 1.0.197",
  "spin-expressions",
  "spin-factors",
+ "spin-factors-test",
  "spin-world",
+ "tokio",
  "toml 0.8.14",
 ]
 
@@ -7610,6 +7612,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
+]
+
+[[package]]
+name = "spin-factors-test"
+version = "2.7.0-pre0"
+dependencies = [
+ "spin-app",
+ "spin-factors",
+ "spin-loader",
+ "tempfile",
+ "toml 0.8.14",
 ]
 
 [[package]]

--- a/crates/factor-variables/Cargo.toml
+++ b/crates/factor-variables/Cargo.toml
@@ -11,5 +11,9 @@ spin-factors = { path = "../factors" }
 spin-world = { path = "../world" }
 toml = "0.8"
 
+[dev-dependencies]
+spin-factors-test = { path = "../factors-test" }
+tokio = { version = "1", features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/crates/factor-variables/tests/factor.rs
+++ b/crates/factor-variables/tests/factor.rs
@@ -1,0 +1,44 @@
+use spin_factor_variables::{StaticVariables, VariablesFactor};
+use spin_factors::{anyhow, RuntimeFactors};
+use spin_factors_test::{toml, TestEnvironment};
+
+#[derive(RuntimeFactors)]
+struct TestFactors {
+    variables: VariablesFactor,
+}
+
+#[tokio::test]
+async fn static_provider_works() -> anyhow::Result<()> {
+    let mut factors = TestFactors {
+        variables: VariablesFactor::default(),
+    };
+    factors.variables.add_provider_type(StaticVariables)?;
+
+    let mut env = TestEnvironment {
+        manifest: toml! {
+            spin_manifest_version = 2
+            application.name = "test-app"
+            [[trigger.test]]
+
+            [variables]
+            foo = { required = true }
+
+            [component.test-component]
+            source = "does-not-exist.wasm"
+            variables = { baz = "<{{ foo }}>" }
+        },
+        runtime_config: toml! {
+            [[variable_provider]]
+            type = "static"
+            values = { foo = "bar" }
+        },
+    };
+    let state = env.build_instance_state(factors).await?;
+    let val = state
+        .variables
+        .resolver()
+        .resolve("test-component", "baz".try_into().unwrap())
+        .await?;
+    assert_eq!(val, "<bar>");
+    Ok(())
+}

--- a/crates/factors-test/Cargo.toml
+++ b/crates/factors-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spin-factors-test"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+spin-app = { path = "../app" }
+spin-factors = { path = "../factors" }
+spin-loader = { path = "../loader" }
+tempfile = "3.10.1"
+toml = "0.8.14"
+
+[lints]
+workspace = true

--- a/crates/factors-test/src/lib.rs
+++ b/crates/factors-test/src/lib.rs
@@ -1,0 +1,69 @@
+use spin_app::locked::LockedApp;
+use spin_factors::{
+    anyhow::{self, Context},
+    serde::de::DeserializeOwned,
+    wasmtime::{Config, Engine},
+    App, Linker, RuntimeConfigSource, RuntimeFactors,
+};
+use spin_loader::FilesMountStrategy;
+
+pub use toml::toml;
+
+#[derive(Default)]
+pub struct TestEnvironment {
+    pub manifest: toml::Table,
+    pub runtime_config: toml::Table,
+}
+
+impl TestEnvironment {
+    /// Starting from a new _uninitialized_ [`RuntimeFactors`], run through the
+    /// [`Factor`]s' lifecycle(s) to build a [`RuntimeFactors::InstanceState`].
+    pub async fn build_instance_state<T: RuntimeFactors>(
+        &mut self,
+        mut factors: T,
+    ) -> anyhow::Result<T::InstanceState> {
+        let mut linker = Self::new_linker::<T>();
+        factors.init(&mut linker)?;
+
+        let locked_app = self.build_locked_app().await?;
+        let app = App::inert(locked_app);
+        let runtime_config = TomlRuntimeConfig(&self.runtime_config);
+        let configured_app = factors.configure_app(app, runtime_config)?;
+
+        let component = configured_app
+            .app()
+            .components()
+            .next()
+            .context("no components")?;
+        factors.build_store_data(&configured_app, component.id())
+    }
+
+    pub fn new_linker<T: RuntimeFactors>() -> Linker<T> {
+        let engine = Engine::new(Config::new().async_support(true)).expect("engine");
+        Linker::<T>::new(&engine)
+    }
+
+    pub async fn build_locked_app(&self) -> anyhow::Result<LockedApp> {
+        let toml_str = toml::to_string(&self.manifest).context("failed serializing manifest")?;
+        let dir = tempfile::tempdir().context("failed creating tempdir")?;
+        let path = dir.path().join("spin.toml");
+        std::fs::write(&path, toml_str).context("failed writing manifest")?;
+        spin_loader::from_file(&path, FilesMountStrategy::Direct, None).await
+    }
+}
+
+pub struct TomlRuntimeConfig<'a>(&'a toml::Table);
+
+impl RuntimeConfigSource for TomlRuntimeConfig<'_> {
+    fn factor_config_keys(&self) -> impl IntoIterator<Item = &str> {
+        self.0.keys().map(|key| key.as_str())
+    }
+
+    fn get_factor_config<T: DeserializeOwned>(&self, key: &str) -> anyhow::Result<Option<T>> {
+        let Some(val) = self.0.get(key) else {
+            return Ok(None);
+        };
+        let config = val.clone().try_into()?;
+        Ok(Some(config))
+    }
+}

--- a/crates/factors/src/factor.rs
+++ b/crates/factors/src/factor.rs
@@ -15,7 +15,7 @@ pub trait Factor: Any + Sized {
     type InstanceBuilder: FactorInstanceBuilder;
 
     /// Initializes this Factor for a runtime. This will be called at most once,
-    /// before any call to [`FactorInstancePreparer::new`]
+    /// before any call to [`FactorInstanceBuilder::new`]
     fn init<T: RuntimeFactors>(&mut self, mut ctx: InitContext<T, Self>) -> anyhow::Result<()> {
         // TODO: Should `ctx` always be immut? Rename this param/type?
         _ = &mut ctx;

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -4,6 +4,7 @@ mod runtime_config;
 mod runtime_factors;
 
 pub use anyhow;
+pub use serde;
 pub use wasmtime;
 
 pub use spin_factors_derive::RuntimeFactors;

--- a/crates/factors/src/runtime_factors.rs
+++ b/crates/factors/src/runtime_factors.rs
@@ -1,10 +1,24 @@
-use crate::{factor::FactorInstanceState, Factor};
+use crate::{factor::FactorInstanceState, App, ConfiguredApp, Factor, Linker, RuntimeConfigSource};
 
 /// Implemented by `#[derive(RuntimeFactors)]`
 pub trait RuntimeFactors: Sized + 'static {
     type AppState;
     type InstanceBuilders;
     type InstanceState: GetFactorState + Send + 'static;
+
+    fn init(&mut self, linker: &mut Linker<Self>) -> anyhow::Result<()>;
+
+    fn configure_app(
+        &self,
+        app: App,
+        runtime_config: impl RuntimeConfigSource,
+    ) -> anyhow::Result<ConfiguredApp<Self>>;
+
+    fn build_store_data(
+        &self,
+        configured_app: &ConfiguredApp<Self>,
+        component_id: &str,
+    ) -> anyhow::Result<Self::InstanceState>;
 
     fn app_state<F: Factor>(app_state: &Self::AppState) -> Option<&F::AppState>;
 


### PR DESCRIPTION
This provides a TestEnvironment type to aid factor authors in writing tests.

In order to enable TestEnvironment, move all of the generated RuntimeFactors methcods into the trait.

Exercise TestEnvironment in a spin-factor-variables test.