### PR TITLE
Make yes the default for generating new project in non-emtpy directory

### DIFF
--- a/crates/templates/src/interaction.rs
+++ b/crates/templates/src/interaction.rs
@@ -102,7 +102,7 @@ impl InteractionStrategy for Silent {
 }
 
 pub(crate) fn confirm(text: &str) -> std::io::Result<bool> {
-    Confirm::new().with_prompt(text).interact()
+    Confirm::new().with_prompt(text).default(true).interact()
 }
 
 pub(crate) fn prompt_parameter(parameter: &TemplateParameter) -> Option<String> {

--- a/crates/templates/src/run.rs
+++ b/crates/templates/src/run.rs
@@ -93,12 +93,14 @@ impl Run {
         // TODO: rationalise `path` and `dir`
         let to = self.generation_target_dir();
 
-        match interaction.allow_generate_into(&to) {
-            Cancellable::Cancelled => return Ok(None),
-            Cancellable::Ok(_) => (),
-            Cancellable::Err(e) => return Err(e),
-        };
-
+        // If the user isn't accepting default, asking for permission to generate into a non-empty directory
+        if !self.options.accept_defaults {
+            match interaction.allow_generate_into(&to) {
+                Cancellable::Cancelled => return Ok(None),
+                Cancellable::Ok(_) => (),
+                Cancellable::Err(e) => return Err(e),
+            };
+        }
         self.validate_provided_values()?;
 
         let files = match self.template.content_dir() {


### PR DESCRIPTION
If the --accept-defaults is passed then the user won't be prompted.

I discovered this when investigating the issue with https://github.com/fermyon/spin/pull/2615 which was failing because we could not create a project in a non-empty directory. I was very surprised to see that `--accept-defaults` did nothing. 