### PR TITLE
Better error if component from registry has regrettable version

### DIFF
--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -156,7 +156,7 @@ impl LocalLoader {
             .take();
 
         let source = self
-            .load_component_source(component.source.clone())
+            .load_component_source(id, component.source.clone())
             .await
             .with_context(|| format!("Failed to load Wasm source {}", component.source))?;
 
@@ -215,6 +215,7 @@ impl LocalLoader {
     // URL with an absolute path to the content.
     async fn load_component_source(
         &self,
+        component_id: &KebabId,
         source: v2::ComponentSource,
     ) -> Result<LockedComponentSource> {
         let content = match source {
@@ -227,6 +228,7 @@ impl LocalLoader {
                 package,
                 version,
             } => {
+                let version = semver::Version::parse(&version).with_context(|| format!("Component {component_id} specifies an invalid semantic version ({version:?}) for its package version"))?;
                 self.load_registry_source(registry.as_ref(), &package, &version)
                     .await?
             }

--- a/crates/manifest/src/schema/common.rs
+++ b/crates/manifest/src/schema/common.rs
@@ -39,7 +39,7 @@ pub enum ComponentSource {
         /// `package = "example:component"`
         package: PackageRef,
         /// `version = "1.2.3"`
-        version: semver::Version,
+        version: String,
     },
 }
 


### PR DESCRIPTION
If you have a component sourced from a registry, the version has to be semver.  The previous error message was bad.

Before:

```
ivan@hestia:~/testing/wkgtest$ spin up
Error: TOML parse error at line 15, column 10
   |
15 | source = { registry = "registrytest-vfztdiyy.fermyon.app", package = "component:ccspintest", version = "canary" }
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
data did not match any variant of untagged enum ComponentSource
```

After:

```
ivan@hestia:~/testing/wkgtest$ spin up
Error: Failed to load manifest from "spin.toml"

Caused by:
   0: Failed to load Spin app from "spin.toml"
   1: Failed to load component `wkgtest`
   2: Failed to load Wasm source "component:ccspintest@canary" from registry Registry(registrytest-vfztdiyy.fermyon.app)
   3: Component wkgtest specifies an invalid semantic version ("canary") for its package version
   4: unexpected character 'c' while parsing major version number
```
