### PR TITLE
Add some more documentation to factors

### DIFF
--- a/crates/factors-derive/src/lib.rs
+++ b/crates/factors-derive/src/lib.rs
@@ -118,7 +118,7 @@ fn expand_factors(input: &DeriveInput) -> syn::Result<TokenStream> {
                 Ok(#ConfiguredApp::new(app, app_state))
             }
 
-            fn build_store_data(
+            fn build_instance_state(
                 &self, configured_app: &#ConfiguredApp<Self>,
                 component_id: &str,
             ) -> #Result<Self::InstanceState> {

--- a/crates/factors/src/factor.rs
+++ b/crates/factors/src/factor.rs
@@ -6,15 +6,27 @@ use crate::{
     RuntimeFactors,
 };
 
+/// A contained (i.e., "factored") piece of runtime functionality.
 pub trait Factor: Any + Sized {
+    /// The particular runtime configuration relevant to this factor.
+    ///
+    /// Runtime configuration allows for user provided customization of the
+    /// factor's behavior on a per app basis.
     type RuntimeConfig: FactorRuntimeConfig;
 
+    /// The application state of this factor.
+    ///
+    /// This state *may* be cached by the runtime across multiple requests.
     type AppState;
 
+    /// The builder of instance state for this factor.
     type InstanceBuilder: FactorInstanceBuilder;
 
-    /// Initializes this Factor for a runtime. This will be called at most once,
-    /// before any call to [`FactorInstanceBuilder::new`]
+    /// Initializes this `Factor` for a runtime once at runtime startup.
+    ///
+    /// This will be called at most once, before any call to [`FactorInstanceBuilder::new`].
+    /// `InitContext` provides access to a wasmtime `Linker`, so this is where any bindgen
+    /// `add_to_linker` calls go.
     fn init<T: RuntimeFactors>(&mut self, mut ctx: InitContext<T, Self>) -> anyhow::Result<()> {
         // TODO: Should `ctx` always be immut? Rename this param/type?
         _ = &mut ctx;
@@ -24,18 +36,27 @@ pub trait Factor: Any + Sized {
     /// Performs factor-specific validation and configuration for the given
     /// [`App`].
     ///
+    /// `ConfigureAppContext` gives access to:
+    /// - The `spin_app::App`
+    /// - This factors's `RuntimeConfig`
+    /// - The `AppState` for any factors configured before this one
+    ///
     /// A runtime may - but is not required to - reuse the returned config
-    /// across multiple instances. Note that this may be called without any call
-    /// to `init` in cases where only validation is needed.
+    /// across multiple instances.
+    ///
+    /// This method may be called without any call to `init` or prepare in
+    /// cases where only validation is needed (e.g., `spin doctor`).
     fn configure_app<T: RuntimeFactors>(
         &self,
         ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState>;
 
-    /// Prepares an instance builder for this factor.
+    /// Creates a new `FactorInstanceBuilder`, which will later build per-instance
+    /// state for this factor.
     ///
     /// This method is given access to the app component being instantiated and
     /// to any other factors' instance builders that have already been prepared.
+    /// As such this is primary place for inter-factor dependencies.
     fn prepare<T: RuntimeFactors>(
         &self,
         ctx: PrepareContext<Self>,
@@ -75,14 +96,17 @@ impl<'a, T: RuntimeFactors, F: Factor> InitContext<'a, T, F> {
         Self { linker, get_data }
     }
 
+    /// Returns a mutable reference to the [`wasmtime::component::Linker`].
     pub fn linker(&mut self) -> &mut Linker<T> {
         self.linker
     }
 
+    /// Returns a function that can be used to get the instance state for this factor.
     pub fn get_data_fn(&self) -> GetDataFn<T, F> {
         self.get_data
     }
 
+    /// Convenience method to link a binding to the linker.
     pub fn link_bindings(
         &mut self,
         add_to_linker: impl Fn(
@@ -115,23 +139,28 @@ impl<'a, T: RuntimeFactors, F: Factor> ConfigureAppContext<'a, T, F> {
         })
     }
 
+    /// Get the [`App`] being configured.
     pub fn app(&self) -> &App {
         self.app
     }
 
+    /// Get the app state related to the given factor.
     pub fn app_state<U: Factor>(&self) -> crate::Result<&U::AppState> {
         T::app_state::<U>(self.app_state).ok_or(Error::no_such_factor::<U>())
     }
 
+    /// Get a reference to the runtime configuration for the given factor.
     pub fn runtime_config(&self) -> Option<&F::RuntimeConfig> {
         self.runtime_config.as_ref()
     }
 
+    /// Take ownership of the runtime configuration for the given factor.
     pub fn take_runtime_config(&mut self) -> Option<F::RuntimeConfig> {
         self.runtime_config.take()
     }
 }
 
+#[doc(hidden)]
 pub struct ConfiguredApp<T: RuntimeFactors> {
     app: App,
     app_state: T::AppState,
@@ -143,10 +172,12 @@ impl<T: RuntimeFactors> ConfiguredApp<T> {
         Self { app, app_state }
     }
 
+    /// Get the configured [`App`].
     pub fn app(&self) -> &App {
         &self.app
     }
 
+    /// Get the configured app's state related to the given factor.
     pub fn app_state<U: Factor>(&self) -> crate::Result<&U::AppState> {
         T::app_state::<U>(&self.app_state).ok_or(Error::no_such_factor::<U>())
     }

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::{
     runtime_factors::{GetFactorState, RuntimeFactors},
 };
 
+/// A [`wasmtime::component::Linker`] used for a [`RuntimeFactors`] collection.
 pub type Linker<T> = wasmtime::component::Linker<<T as RuntimeFactors>::InstanceState>;
 
 // Temporary wrappers while refactoring

--- a/crates/factors/src/runtime_factors.rs
+++ b/crates/factors/src/runtime_factors.rs
@@ -1,27 +1,65 @@
 use crate::{factor::FactorInstanceState, App, ConfiguredApp, Factor, Linker, RuntimeConfigSource};
 
-/// Implemented by `#[derive(RuntimeFactors)]`
+/// A collection of `Factor`s that are initialized and configured together.
+///
+/// Implemented by `#[derive(RuntimeFactors)]` and should not be implemented manually.
+///
+/// # Example
+///
+/// A typical usage of `RuntimeFactors` would look something like the following pseudo-code:
+///
+/// ```no_run
+/// #[derive(RuntimeFactors)]
+/// struct MyFactors {
+///  // ...
+/// }
+/// // Initialize the factors collection
+/// let factors = MyFactors { /* .. */ };
+/// // Initialize each factor with a linker
+/// factors.init(&mut linker)?;
+/// // Configure the factors with an app and runtime config
+/// let configured_app = factors.configure_app(app, runtime_config)?;
+/// // Build the instance state for the factors
+/// let data factors.build_instance_state(&configured_app, component.id())
+/// // Initialize a `wasmtime` store with the instance state
+/// let mut store = wasmtime::Store::new(&engine, data);
+/// // Instantiate the component
+/// let instance = linker.instantiate_async(&mut store, &component).await?;
+/// ```
 pub trait RuntimeFactors: Sized + 'static {
+    /// The per application state of all the factors.
     type AppState;
-    type InstanceBuilders;
+    /// The per instance state of the factors.
     type InstanceState: GetFactorState + Send + 'static;
+    /// The collection of all the `InstanceBuilder`s of the factors.
+    type InstanceBuilders;
 
+    /// Initialize the factors with a linker.
+    ///
+    /// Each factor's `init` is called in turn.
     fn init(&mut self, linker: &mut Linker<Self>) -> crate::Result<()>;
 
+    /// Configure the factors with an app and runtime config.
     fn configure_app(
         &self,
         app: App,
         runtime_config: impl RuntimeConfigSource,
     ) -> crate::Result<ConfiguredApp<Self>>;
 
-    fn build_store_data(
+    /// Build the instance state for the factors.
+    fn build_instance_state(
         &self,
         configured_app: &ConfiguredApp<Self>,
         component_id: &str,
     ) -> crate::Result<Self::InstanceState>;
 
+    /// Get the app state related to a particular factor.
     fn app_state<F: Factor>(app_state: &Self::AppState) -> Option<&F::AppState>;
 
+    /// Get the instance builder of a particular factor.
+    ///
+    /// The outer `Option` is `None` if the factor has not been registered with this `Factors` collection,
+    /// and the inner `Option` is `None` if the factor has not been prepared yet.
     fn instance_builder_mut<F: Factor>(
         builders: &mut Self::InstanceBuilders,
     ) -> Option<Option<&mut F::InstanceBuilder>>;

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -50,7 +50,7 @@ async fn smoke_test_works() -> anyhow::Result<()> {
     factors.init(&mut linker).unwrap();
 
     let configured_app = factors.configure_app(app, TestSource)?;
-    let data = factors.build_store_data(&configured_app, "smoke-app")?;
+    let data = factors.build_instance_state(&configured_app, "smoke-app")?;
 
     assert_eq!(
         data.variables


### PR DESCRIPTION
First pass just giving a bit more context on the various pieces of the factors system. I think this will mainly help for hovering over types in IDEs to remind users what things are. 

Besides documentation one code change is made: `RuntimeFactors::build_store_data` => `RuntimeFactors::build_instance_state`. I know that the value returned from this method is what gets passed to `wasmtime::Store::new` which refers to it as `data`, but given the rest of the factors framework refers to this as instance state (which is much more descriptive than wasmtime's nomenclature), I think this is a better name. 