### PR TITLE
factors: Add Error type

### DIFF
--- a/crates/factors-test/src/lib.rs
+++ b/crates/factors-test/src/lib.rs
@@ -64,7 +64,7 @@ impl TestEnvironment {
             .components()
             .next()
             .context("no components")?;
-        factors.build_store_data(&configured_app, component.id())
+        Ok(factors.build_store_data(&configured_app, component.id())?)
     }
 
     pub fn new_linker<T: RuntimeFactors>() -> Linker<T> {

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -22,10 +22,55 @@ pub type Linker<T> = wasmtime::component::Linker<<T as RuntimeFactors>::Instance
 pub type App = spin_app::App<'static, spin_app::InertLoader>;
 pub type AppComponent<'a> = spin_app::AppComponent<'a, spin_app::InertLoader>;
 
-// TODO: Add a real Error type
-pub type Result<T> = wasmtime::Result<T>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("factor dependency ordering error: {0}")]
+    DependencyOrderingError(String),
+    #[error("no such factor: {0}")]
+    NoSuchFactor(&'static str),
+    #[error("{factor} requested already-consumed key {key:?}")]
+    RuntimeConfigReusedKey { factor: &'static str, key: String },
+    #[error("runtime config error: {0}")]
+    RuntimeConfigSource(#[source] anyhow::Error),
+    #[error("unused runtime config key(s): {}", keys.join(", "))]
+    RuntimeConfigUnusedKeys { keys: Vec<String> },
+    #[error("{factor} {method} failed: {source}")]
+    RuntimeFactorError {
+        factor: &'static str,
+        method: &'static str,
+        source: anyhow::Error,
+    },
+    #[error("unknown component: {0}")]
+    UnknownComponent(String),
+}
+
+impl Error {
+    fn no_such_factor<T: Factor>() -> Self {
+        Self::NoSuchFactor(std::any::type_name::<T>())
+    }
+
+    fn runtime_config_reused_key<T: Factor>(key: impl Into<String>) -> Self {
+        Self::RuntimeConfigReusedKey {
+            factor: std::any::type_name::<T>(),
+            key: key.into(),
+        }
+    }
+}
 
 #[doc(hidden)]
 pub mod __internal {
     pub use crate::runtime_config::RuntimeConfigTracker;
+
+    pub fn runtime_factor_error<T: crate::Factor>(
+        method: &'static str,
+        source: anyhow::Error,
+    ) -> crate::Error {
+        crate::Error::RuntimeFactorError {
+            factor: std::any::type_name::<T>(),
+            method,
+            source,
+        }
+    }
 }

--- a/crates/factors/src/runtime_factors.rs
+++ b/crates/factors/src/runtime_factors.rs
@@ -6,19 +6,19 @@ pub trait RuntimeFactors: Sized + 'static {
     type InstanceBuilders;
     type InstanceState: GetFactorState + Send + 'static;
 
-    fn init(&mut self, linker: &mut Linker<Self>) -> anyhow::Result<()>;
+    fn init(&mut self, linker: &mut Linker<Self>) -> crate::Result<()>;
 
     fn configure_app(
         &self,
         app: App,
         runtime_config: impl RuntimeConfigSource,
-    ) -> anyhow::Result<ConfiguredApp<Self>>;
+    ) -> crate::Result<ConfiguredApp<Self>>;
 
     fn build_store_data(
         &self,
         configured_app: &ConfiguredApp<Self>,
         component_id: &str,
-    ) -> anyhow::Result<Self::InstanceState>;
+    ) -> crate::Result<Self::InstanceState>;
 
     fn app_state<F: Factor>(app_state: &Self::AppState) -> Option<&F::AppState>;
 


### PR DESCRIPTION
Adds a custom `Error` enum.

One effect here is more-helpful errors when inter-factor dependencies aren't met:

```

Error: spin_factor_outbound_http::OutboundHttpFactor prepare failed: no such factor: spin_factor_outbound_networking::OutboundNetworkingFactor
