### PR TITLE
Improve non-interactive behaviour of `spin new`

### DIFF
--- a/crates/templates/src/run.rs
+++ b/crates/templates/src/run.rs
@@ -40,6 +40,9 @@ pub struct RunOptions {
     pub accept_defaults: bool,
     /// If true, do not create a .gitignore file
     pub no_vcs: bool,
+    /// Skip the overwrite prompt if the output directory already contains files
+    /// (or, if silent, allow overwrite instead of erroring).
+    pub allow_overwrite: bool,
 }
 
 impl Run {
@@ -93,11 +96,13 @@ impl Run {
         // TODO: rationalise `path` and `dir`
         let to = self.generation_target_dir();
 
-        match interaction.allow_generate_into(&to) {
-            Cancellable::Cancelled => return Ok(None),
-            Cancellable::Ok(_) => (),
-            Cancellable::Err(e) => return Err(e),
-        };
+        if !self.options.allow_overwrite {
+            match interaction.allow_generate_into(&to) {
+                Cancellable::Cancelled => return Ok(None),
+                Cancellable::Ok(_) => (),
+                Cancellable::Err(e) => return Err(e),
+            };
+        }
 
         self.validate_provided_values()?;
 

--- a/crates/templates/src/test_built_ins/mod.rs
+++ b/crates/templates/src/test_built_ins/mod.rs
@@ -39,6 +39,7 @@ async fn new_fileserver_creates_assets_dir() -> anyhow::Result<()> {
         values: HashMap::new(),
         accept_defaults: true,
         no_vcs: false,
+        allow_overwrite: false,
     };
     manager
         .get("static-fileserver")?
@@ -85,6 +86,7 @@ async fn add_fileserver_creates_assets_dir_next_to_manifest() -> anyhow::Result<
         values: HashMap::new(),
         accept_defaults: true,
         no_vcs: false,
+        allow_overwrite: false,
     };
     manager
         .get("http-empty")?
@@ -104,6 +106,7 @@ async fn add_fileserver_creates_assets_dir_next_to_manifest() -> anyhow::Result<
         values: fs_settings,
         accept_defaults: true,
         no_vcs: false,
+        allow_overwrite: false,
     };
     manager
         .get("static-fileserver")?


### PR DESCRIPTION
An alternative approach to the problem identified in #2627.  With this PR:

* In a non-interactive environment (not a terminal), `spin new` and `spin add` will:
  * Not prompt for parameters (must be supplied via `-value`, `--values-file`, or `--accept-defaults`
  * Not prompt about generating into a non-empty directory (will fail and error out by default)
  * The implementation uses the established `interaction::Silent` strategy, which already gets exercised via the unit tests
* `spin new` and `spin add` now support a `--allow-overwrite` flag which will allow generating into a non-empty directory.  In a terminal, this skips the prompt; in a non-terminal, it changes the behaviour.

The `--allow-overwrite` flag has a `--allow-overwrites` alias because I kept typing the latter when testing _despite having defined the singular form not two minutes before_ that is why.

The PR has unit tests for the non-interactive case; obviously it's not very practical to includes tests for the interactive case but it seemed to work when I tried it!
