### PR TITLE
factor: Add key value Redis factor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7530,6 +7530,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-factor-key-value-redis"
+version = "2.7.0-pre0"
+dependencies = [
+ "anyhow",
+ "serde 1.0.197",
+ "spin-factor-key-value",
+ "spin-key-value-redis",
+]
+
+[[package]]
 name = "spin-factor-outbound-http"
 version = "2.7.0-pre0"
 dependencies = [
@@ -7592,6 +7602,7 @@ dependencies = [
  "spin-app",
  "spin-componentize",
  "spin-factor-key-value",
+ "spin-factor-key-value-redis",
  "spin-factor-outbound-http",
  "spin-factor-outbound-networking",
  "spin-factor-variables",

--- a/crates/factor-key-value-redis/Cargo.toml
+++ b/crates/factor-key-value-redis/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spin-factor-key-value-redis"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+anyhow = "1.0"
+serde = { version = "1.0", features = ["rc"] }
+spin-factor-key-value = { path = "../factor-key-value" }
+# TODO: merge with this crate
+spin-key-value-redis = { path = "../key-value-redis" }
+
+[lints]
+workspace = true

--- a/crates/factor-key-value-redis/src/lib.rs
+++ b/crates/factor-key-value-redis/src/lib.rs
@@ -1,0 +1,24 @@
+use serde::Deserialize;
+use spin_factor_key_value::MakeKeyValueStore;
+use spin_key_value_redis::KeyValueRedis;
+pub struct RedisKeyValueStore;
+
+#[derive(Deserialize)]
+pub struct RedisKeyValueRuntimeConfig {
+    url: String,
+}
+
+impl MakeKeyValueStore for RedisKeyValueStore {
+    const RUNTIME_CONFIG_TYPE: &'static str = "redis";
+
+    type RuntimeConfig = RedisKeyValueRuntimeConfig;
+
+    type StoreManager = KeyValueRedis;
+
+    fn make_store(
+        &self,
+        runtime_config: Self::RuntimeConfig,
+    ) -> anyhow::Result<Self::StoreManager> {
+        KeyValueRedis::new(runtime_config.url)
+    }
+}

--- a/crates/factors/Cargo.toml
+++ b/crates/factors/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 spin-componentize = { path = "../componentize" }
 spin-factors-derive = { path = "../factors-derive", features = ["expander"] }
 spin-factor-key-value = { path = "../factor-key-value" }
+spin-factor-key-value-redis = { path = "../factor-key-value-redis" }
 spin-factor-outbound-http = { path = "../factor-outbound-http" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factor-variables = { path = "../factor-variables" }

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -11,6 +11,7 @@ use spin_factor_variables::{StaticVariables, VariablesFactor};
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
 use spin_factors::{FactorRuntimeConfig, RuntimeConfigSource, RuntimeFactors};
 use spin_key_value_sqlite::{DatabaseLocation, KeyValueSqlite};
+use spin_factor_key_value_redis::RedisKeyValueStore;
 use wasmtime_wasi_http::WasiHttpView;
 
 #[derive(RuntimeFactors)]
@@ -35,6 +36,8 @@ async fn smoke_test_works() -> anyhow::Result<()> {
     factors.variables.add_provider_type(StaticVariables)?;
 
     factors.key_value.add_store_type(TestSpinKeyValueStore)?;
+
+    factors.key_value.add_store_type(RedisKeyValueStore)?;
 
     let locked = spin_loader::from_file(
         "tests/smoke-app/spin.toml",
@@ -124,6 +127,9 @@ impl RuntimeConfigSource for TestSource {
 
             [key_value_store.default]
             type = "spin"
+            [key_value_store.other]
+            type = "redis"
+            url = "redis://localhost:6379"
         }
         .remove(key) else {
             return Ok(None);


### PR DESCRIPTION
We could also add these changes to `key-value-redis` crate and later rename that crate to `factor-key-value-redis`. @lann which would you prefer?

Also, adds support for configuring the default KV store.