### PR TITLE
factors: Add RuntimeFactors::prepare

### DIFF
--- a/crates/factors-derive/src/lib.rs
+++ b/crates/factors-derive/src/lib.rs
@@ -118,10 +118,10 @@ fn expand_factors(input: &DeriveInput) -> syn::Result<TokenStream> {
                 Ok(#ConfiguredApp::new(app, app_state))
             }
 
-            fn build_instance_state(
+            fn prepare(
                 &self, configured_app: &#ConfiguredApp<Self>,
                 component_id: &str,
-            ) -> #Result<Self::InstanceState> {
+            ) -> #Result<Self::InstanceBuilders> {
                 let app_component = configured_app.app().get_component(component_id).ok_or_else(|| {
                     #factors_path::Error::UnknownComponent(component_id.to_string())
                 })?;
@@ -140,6 +140,13 @@ fn expand_factors(input: &DeriveInput) -> syn::Result<TokenStream> {
                         ).map_err(#Error::factor_prepare_error::<#factor_types>)?
                     );
                 )*
+                Ok(builders)
+            }
+
+            fn build_instance_state(
+                &self,
+                builders: Self::InstanceBuilders,
+            ) -> #Result<Self::InstanceState> {
                 Ok(#state_name {
                     #(
                         #factor_names: #FactorInstanceBuilder::build(

--- a/crates/factors-test/src/lib.rs
+++ b/crates/factors-test/src/lib.rs
@@ -69,7 +69,9 @@ impl TestEnvironment {
             configured_app.app().components().next().context(
                 "expected configured app to have at least one component, but it did not",
             )?;
-        Ok(factors.build_instance_state(&configured_app, component.id())?)
+        let builders = factors.prepare(&configured_app, component.id())?;
+
+        Ok(factors.build_instance_state(builders)?)
     }
 
     pub fn new_linker<T: RuntimeFactors>() -> Linker<T> {

--- a/crates/factors/src/runtime_factors.rs
+++ b/crates/factors/src/runtime_factors.rs
@@ -46,11 +46,17 @@ pub trait RuntimeFactors: Sized + 'static {
         runtime_config: impl RuntimeConfigSource,
     ) -> crate::Result<ConfiguredApp<Self>>;
 
-    /// Build the instance state for the factors.
-    fn build_instance_state(
+    /// Prepare the factors' instance state builders.
+    fn prepare(
         &self,
         configured_app: &ConfiguredApp<Self>,
         component_id: &str,
+    ) -> crate::Result<Self::InstanceBuilders>;
+
+    /// Build the instance state for the factors.
+    fn build_instance_state(
+        &self,
+        builders: Self::InstanceBuilders,
     ) -> crate::Result<Self::InstanceState>;
 
     /// Get the app state related to a particular factor.

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -5,13 +5,13 @@ use http_body_util::BodyExt;
 use serde::Deserialize;
 use spin_app::App;
 use spin_factor_key_value::{KeyValueFactor, MakeKeyValueStore};
+use spin_factor_key_value_redis::RedisKeyValueStore;
 use spin_factor_outbound_http::OutboundHttpFactor;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factor_variables::{StaticVariables, VariablesFactor};
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
 use spin_factors::{FactorRuntimeConfig, RuntimeConfigSource, RuntimeFactors};
 use spin_key_value_sqlite::{DatabaseLocation, KeyValueSqlite};
-use spin_factor_key_value_redis::RedisKeyValueStore;
 use wasmtime_wasi_http::WasiHttpView;
 
 #[derive(RuntimeFactors)]
@@ -53,7 +53,8 @@ async fn smoke_test_works() -> anyhow::Result<()> {
     factors.init(&mut linker).unwrap();
 
     let configured_app = factors.configure_app(app, TestSource)?;
-    let data = factors.build_instance_state(&configured_app, "smoke-app")?;
+    let builders = factors.prepare(&configured_app, "smoke-app")?;
+    let data = factors.build_instance_state(builders)?;
 
     assert_eq!(
         data.variables


### PR DESCRIPTION
This breaks RuntimeFactors::build_instance_state into two steps, mirroring Factor's methods.

Some triggers will need access to these builders, e.g. WAGI needs access to WasiFactor's stdin configuration.