### PR TITLE
Remove toml assumption

### DIFF
--- a/crates/factor-key-value/src/delegating_resolver.rs
+++ b/crates/factor-key-value/src/delegating_resolver.rs
@@ -36,7 +36,9 @@ impl DelegatingRuntimeConfigResolver {
     }
 }
 
-impl RuntimeConfigResolver<StoreConfig> for DelegatingRuntimeConfigResolver {
+impl RuntimeConfigResolver for DelegatingRuntimeConfigResolver {
+    type Config = StoreConfig;
+
     fn get_store(&self, config: StoreConfig) -> anyhow::Result<Arc<dyn StoreManager>> {
         let store_kind = config.type_.as_str();
         let store_from_toml = self

--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -8,8 +8,7 @@ use std::{
 };
 
 use anyhow::ensure;
-use runtime_config::RuntimeConfig;
-use serde::de::DeserializeOwned;
+use runtime_config::{RuntimeConfig, RuntimeConfigResolver};
 use spin_factors::{
     ConfigureAppContext, Factor, FactorInstanceBuilder, InitContext, InstanceBuilders,
     PrepareContext, RuntimeFactors,
@@ -20,22 +19,20 @@ use spin_key_value::{
 };
 pub use store::MakeKeyValueStore;
 
-pub struct KeyValueFactor<C> {
-    runtime_config_resolver: Arc<dyn runtime_config::RuntimeConfigResolver<Config = C>>,
+pub struct KeyValueFactor<R> {
+    runtime_config_resolver: Arc<R>,
 }
 
-impl<C> KeyValueFactor<C> {
-    pub fn new(
-        runtime_config_resolver: impl runtime_config::RuntimeConfigResolver<Config = C> + 'static,
-    ) -> Self {
+impl<R> KeyValueFactor<R> {
+    pub fn new(runtime_config_resolver: R) -> Self {
         Self {
             runtime_config_resolver: Arc::new(runtime_config_resolver),
         }
     }
 }
 
-impl<C: DeserializeOwned + 'static> Factor for KeyValueFactor<C> {
-    type RuntimeConfig = RuntimeConfig<C>;
+impl<R: RuntimeConfigResolver + 'static> Factor for KeyValueFactor<R> {
+    type RuntimeConfig = RuntimeConfig<R::Config>;
     type AppState = AppState;
     type InstanceBuilder = InstanceBuilder;
 

--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -21,12 +21,12 @@ use spin_key_value::{
 pub use store::MakeKeyValueStore;
 
 pub struct KeyValueFactor<C> {
-    runtime_config_resolver: Arc<dyn runtime_config::RuntimeConfigResolver<C>>,
+    runtime_config_resolver: Arc<dyn runtime_config::RuntimeConfigResolver<Config = C>>,
 }
 
 impl<C> KeyValueFactor<C> {
     pub fn new(
-        runtime_config_resolver: impl runtime_config::RuntimeConfigResolver<C> + 'static,
+        runtime_config_resolver: impl runtime_config::RuntimeConfigResolver<Config = C> + 'static,
     ) -> Self {
         Self {
             runtime_config_resolver: Arc::new(runtime_config_resolver),

--- a/crates/factor-key-value/src/runtime_config.rs
+++ b/crates/factor-key-value/src/runtime_config.rs
@@ -15,9 +15,12 @@ impl<C: DeserializeOwned> FactorRuntimeConfig for RuntimeConfig<C> {
 }
 
 /// Resolves some piece of runtime configuration to a connection pool
-pub trait RuntimeConfigResolver<C>: Send + Sync {
+pub trait RuntimeConfigResolver: Send + Sync {
+    /// The type of configuration that this resolver can handle.
+    type Config: DeserializeOwned;
+
     /// Get a store manager for a given config.
-    fn get_store(&self, config: C) -> anyhow::Result<Arc<dyn StoreManager>>;
+    fn get_store(&self, config: Self::Config) -> anyhow::Result<Arc<dyn StoreManager>>;
 
     /// Returns a default store manager for a given label. Should only be called
     /// if there is no runtime configuration for the label.

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -7,29 +7,29 @@ use std::sync::Arc;
 use host::InstanceState;
 
 use async_trait::async_trait;
-use serde::de::DeserializeOwned;
+use runtime_config::RuntimeConfigResolver;
 use spin_factors::{anyhow, Factor};
 use spin_locked_app::MetadataKey;
 use spin_world::v1::sqlite as v1;
 use spin_world::v2::sqlite as v2;
 
-pub struct SqliteFactor<C> {
-    runtime_config_resolver: Arc<dyn runtime_config::RuntimeConfigResolver<Config = C>>,
+pub struct SqliteFactor<R> {
+    runtime_config_resolver: Arc<R>,
 }
 
-impl<C> SqliteFactor<C> {
+impl<R> SqliteFactor<R> {
     /// Create a new `SqliteFactor`
-    pub fn new(
-        runtime_config_resolver: impl runtime_config::RuntimeConfigResolver<Config = C> + 'static,
-    ) -> Self {
+    ///
+    /// Takes a `runtime_config_resolver` that can resolve a runtime configuration into a connection pool.
+    pub fn new(runtime_config_resolver: R) -> Self {
         Self {
             runtime_config_resolver: Arc::new(runtime_config_resolver),
         }
     }
 }
 
-impl<C: DeserializeOwned + 'static> Factor for SqliteFactor<C> {
-    type RuntimeConfig = runtime_config::RuntimeConfig<C>;
+impl<R: RuntimeConfigResolver + 'static> Factor for SqliteFactor<R> {
+    type RuntimeConfig = runtime_config::RuntimeConfig<R::Config>;
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -14,13 +14,13 @@ use spin_world::v1::sqlite as v1;
 use spin_world::v2::sqlite as v2;
 
 pub struct SqliteFactor<C> {
-    runtime_config_resolver: Arc<dyn runtime_config::RuntimeConfigResolver<C>>,
+    runtime_config_resolver: Arc<dyn runtime_config::RuntimeConfigResolver<Config = C>>,
 }
 
 impl<C> SqliteFactor<C> {
     /// Create a new `SqliteFactor`
     pub fn new(
-        runtime_config_resolver: impl runtime_config::RuntimeConfigResolver<C> + 'static,
+        runtime_config_resolver: impl runtime_config::RuntimeConfigResolver<Config = C> + 'static,
     ) -> Self {
         Self {
             runtime_config_resolver: Arc::new(runtime_config_resolver),

--- a/crates/factor-sqlite/src/runtime_config.rs
+++ b/crates/factor-sqlite/src/runtime_config.rs
@@ -19,10 +19,12 @@ impl<C: DeserializeOwned> FactorRuntimeConfig for RuntimeConfig<C> {
 }
 
 /// Resolves some piece of runtime configuration to a connection pool
-pub trait RuntimeConfigResolver<C>: Send + Sync {
+pub trait RuntimeConfigResolver: Send + Sync {
+    type Config;
+
     /// Get a connection pool for a given config.
     ///
-    fn get_pool(&self, config: C) -> anyhow::Result<Arc<dyn ConnectionPool>>;
+    fn get_pool(&self, config: Self::Config) -> anyhow::Result<Arc<dyn ConnectionPool>>;
 
     /// If there is no runtime configuration for a given database label, return a default connection pool.
     ///

--- a/crates/factor-sqlite/src/runtime_config.rs
+++ b/crates/factor-sqlite/src/runtime_config.rs
@@ -20,7 +20,7 @@ impl<C: DeserializeOwned> FactorRuntimeConfig for RuntimeConfig<C> {
 
 /// Resolves some piece of runtime configuration to a connection pool
 pub trait RuntimeConfigResolver: Send + Sync {
-    type Config;
+    type Config: DeserializeOwned;
 
     /// Get a connection pool for a given config.
     ///

--- a/crates/factor-sqlite/src/runtime_config.rs
+++ b/crates/factor-sqlite/src/runtime_config.rs
@@ -3,40 +3,26 @@ pub mod spin;
 
 use std::{collections::HashMap, sync::Arc};
 
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
 use spin_factors::{anyhow, FactorRuntimeConfig};
 
 use crate::ConnectionPool;
 
 #[derive(Deserialize)]
 #[serde(transparent)]
-pub struct RuntimeConfig {
-    pub store_configs: HashMap<String, StoreConfig>,
+pub struct RuntimeConfig<C> {
+    pub store_configs: HashMap<String, C>,
 }
 
-impl FactorRuntimeConfig for RuntimeConfig {
+impl<C: DeserializeOwned> FactorRuntimeConfig for RuntimeConfig<C> {
     const KEY: &'static str = "sqlite_database";
 }
 
-#[derive(Deserialize)]
-pub struct StoreConfig {
-    #[serde(rename = "type")]
-    pub type_: String,
-    #[serde(flatten)]
-    pub config: toml::Table,
-}
-
 /// Resolves some piece of runtime configuration to a connection pool
-pub trait RuntimeConfigResolver: Send + Sync {
-    /// Get a connection pool for a given database kind and the raw configuration.
+pub trait RuntimeConfigResolver<C>: Send + Sync {
+    /// Get a connection pool for a given config.
     ///
-    /// `database_kind` is equivalent to the `type` field in the
-    /// `[sqlite_database.$databasename]` runtime configuration table.
-    fn get_pool(
-        &self,
-        database_kind: &str,
-        config: toml::Table,
-    ) -> anyhow::Result<Arc<dyn ConnectionPool>>;
+    fn get_pool(&self, config: C) -> anyhow::Result<Arc<dyn ConnectionPool>>;
 
     /// If there is no runtime configuration for a given database label, return a default connection pool.
     ///

--- a/crates/factor-sqlite/src/runtime_config/spin.rs
+++ b/crates/factor-sqlite/src/runtime_config/spin.rs
@@ -50,11 +50,10 @@ impl SpinSqliteRuntimeConfig {
     }
 }
 
-impl RuntimeConfigResolver for SpinSqliteRuntimeConfig {
+impl RuntimeConfigResolver<(&str, toml::Table)> for SpinSqliteRuntimeConfig {
     fn get_pool(
         &self,
-        database_kind: &str,
-        config: toml::Table,
+        (database_kind, config): (&str, toml::Table),
     ) -> anyhow::Result<Arc<dyn ConnectionPool>> {
         let pool = match database_kind {
             "spin" => {

--- a/crates/factor-sqlite/src/runtime_config/spin.rs
+++ b/crates/factor-sqlite/src/runtime_config/spin.rs
@@ -50,21 +50,29 @@ impl SpinSqliteRuntimeConfig {
     }
 }
 
-impl RuntimeConfigResolver<(&str, toml::Table)> for SpinSqliteRuntimeConfig {
-    fn get_pool(
-        &self,
-        (database_kind, config): (&str, toml::Table),
-    ) -> anyhow::Result<Arc<dyn ConnectionPool>> {
+#[derive(Deserialize)]
+pub struct RuntimeConfig {
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(flatten)]
+    pub config: toml::Table,
+}
+
+impl RuntimeConfigResolver for SpinSqliteRuntimeConfig {
+    type Config = RuntimeConfig;
+
+    fn get_pool(&self, config: RuntimeConfig) -> anyhow::Result<Arc<dyn ConnectionPool>> {
+        let database_kind = config.type_.as_str();
         let pool = match database_kind {
             "spin" => {
-                let config: LocalDatabase = config.try_into()?;
+                let config: LocalDatabase = config.config.try_into()?;
                 config.pool(&self.local_database_dir)?
             }
             "libsql" => {
-                let config: LibSqlDatabase = config.try_into()?;
+                let config: LibSqlDatabase = config.config.try_into()?;
                 config.pool()?
             }
-            _ => anyhow::bail!("Unknown database kind: {}", database_kind),
+            _ => anyhow::bail!("Unknown database kind: {database_kind}"),
         };
         Ok(Arc::new(pool))
     }

--- a/crates/factor-sqlite/tests/factor.rs
+++ b/crates/factor-sqlite/tests/factor.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, sync::Arc};
 
-use factor_sqlite::SqliteFactor;
-use serde::Deserialize;
+use factor_sqlite::{runtime_config::spin::RuntimeConfig, SqliteFactor};
 use spin_factors::{
     anyhow::{self, bail},
     RuntimeFactors,
@@ -91,7 +90,9 @@ impl RuntimeConfigResolver {
     }
 }
 
-impl factor_sqlite::runtime_config::RuntimeConfigResolver<RuntimeConfig> for RuntimeConfigResolver {
+impl factor_sqlite::runtime_config::RuntimeConfigResolver for RuntimeConfigResolver {
+    type Config = RuntimeConfig;
+
     fn get_pool(
         &self,
         config: RuntimeConfig,
@@ -118,12 +119,4 @@ impl factor_sqlite::ConnectionPool for InvalidConnectionPool {
     ) -> Result<Arc<dyn factor_sqlite::Connection + 'static>, spin_world::v2::sqlite::Error> {
         Err(spin_world::v2::sqlite::Error::InvalidConnection)
     }
-}
-
-#[derive(Deserialize)]
-pub struct RuntimeConfig {
-    #[serde(rename = "type")]
-    pub type_: String,
-    #[serde(flatten)]
-    pub config: toml::Table,
 }

--- a/crates/factor-sqlite/tests/factor.rs
+++ b/crates/factor-sqlite/tests/factor.rs
@@ -9,7 +9,7 @@ use spin_factors_test::{toml, TestEnvironment};
 
 #[derive(RuntimeFactors)]
 struct TestFactors {
-    sqlite: SqliteFactor<RuntimeConfig>,
+    sqlite: SqliteFactor<RuntimeConfigResolver>,
 }
 
 #[tokio::test]

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -22,7 +22,7 @@ struct Factors {
     variables: VariablesFactor,
     outbound_networking: OutboundNetworkingFactor,
     outbound_http: OutboundHttpFactor,
-    key_value: KeyValueFactor<StoreConfig>,
+    key_value: KeyValueFactor<DelegatingRuntimeConfigResolver>,
 }
 
 struct Data {


### PR DESCRIPTION
Currently many factors assume that their runtime configs are serialized as toml. This hurts reusability as this assumption might not be true for many runtimes. 

This PR removes this assumption (for sqlite and kv) instead making the implementations generic on their runtime configurations. While this does add a generic to the code, the underlying factor code already was generic on runtime config - it just made the assumption that that generic config was serialized as toml. Now it knows nothing about the config other than it implements `DeserializeOwned`.

You can notice that the shape of how runtime config is serialized is moved to Spin CLI specific code while the core Factor impl does not care at all about this.

*Note: eventually I would like to remove the assumption that runtime config is serialized at all, but that's a bigger change that requires more controversial decisions. This is still a step towards that direction while still being a good decision IMO even if we keep deserialization assumptions.*