### PR TITLE
Fix CI issue in integration tests by updating conformance-test dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?rev=2bb3eb83467a9e9595fa0fd11d7a49fa0300b113#2bb3eb83467a9e9595fa0fd11d7a49fa0300b113"
+source = "git+https://github.com/fermyon/conformance-tests?rev=d2129a3fd73140a76c77f15a030a5273b37cbd11#d2129a3fd73140a76c77f15a030a5273b37cbd11"
 dependencies = [
  "anyhow",
  "flate2",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?rev=2bb3eb83467a9e9595fa0fd11d7a49fa0300b113#2bb3eb83467a9e9595fa0fd11d7a49fa0300b113"
+source = "git+https://github.com/fermyon/conformance-tests?rev=d2129a3fd73140a76c77f15a030a5273b37cbd11#d2129a3fd73140a76c77f15a030a5273b37cbd11"
 dependencies = [
  "anyhow",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ redis = "0.24"
 runtime-tests = { path = "tests/runtime-tests" }
 test-components = { path = "tests/test-components" }
 test-codegen-macro = { path = "crates/test-codegen-macro" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "2bb3eb83467a9e9595fa0fd11d7a49fa0300b113" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
 
 [build-dependencies]
 cargo-target-dep = { git = "https://github.com/fermyon/cargo-target-dep", rev = "482f269eceb7b1a7e8fc618bf8c082dd24979cf1" }
@@ -134,7 +134,9 @@ hyper = { version = "1.0.0", features = ["full"] }
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
 tracing = { version = "0.1", features = ["log"] }
 
-wasi-common-preview1 = { version = "22.0.0", package = "wasi-common", features = ["tokio"] }
+wasi-common-preview1 = { version = "22.0.0", package = "wasi-common", features = [
+  "tokio",
+] }
 wasmtime = "22.0.0"
 wasmtime-wasi = "22.0.0"
 wasmtime-wasi-http = "22.0.0"

--- a/tests/conformance-tests/Cargo.toml
+++ b/tests/conformance-tests/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1.0"
 testing-framework = { path = "../testing-framework" }
-conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "2bb3eb83467a9e9595fa0fd11d7a49fa0300b113" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "2bb3eb83467a9e9595fa0fd11d7a49fa0300b113" }
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
 
 [lints]
 workspace = true

--- a/tests/runtime-tests/Cargo.toml
+++ b/tests/runtime-tests/Cargo.toml
@@ -13,5 +13,5 @@ anyhow = "1.0"
 env_logger = "0.10.0"
 log = "0.4"
 testing-framework = { path = "../testing-framework" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "2bb3eb83467a9e9595fa0fd11d7a49fa0300b113" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
 test-components = { path = "../test-components" }

--- a/tests/testing-framework/Cargo.toml
+++ b/tests/testing-framework/Cargo.toml
@@ -13,7 +13,7 @@ nix = "0.26.1"
 regex = "1.10.2"
 reqwest = { workspace = true }
 temp-dir = "0.1.11"
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "2bb3eb83467a9e9595fa0fd11d7a49fa0300b113" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
 spin-trigger-http = { path = "../../crates/trigger-http" }
 spin-http = { path = "../../crates/http" }
 spin-trigger = { path = "../../crates/trigger" }


### PR DESCRIPTION
The dependency update brings in https://github.com/fermyon/conformance-tests/pull/27