### PR TITLE
Enable environmental authentication for Azure Key Vault var provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,33 +571,6 @@ dependencies = [
 [[package]]
 name = "azure_core"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
-dependencies = [
- "async-trait",
- "base64 0.22.0",
- "bytes",
- "dyn-clone",
- "futures",
- "getrandom 0.2.12",
- "http-types",
- "once_cell",
- "paste",
- "pin-project",
- "rand 0.8.5",
- "reqwest 0.12.4",
- "rustc_version",
- "serde 1.0.197",
- "serde_json",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_core"
-version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
@@ -629,7 +602,7 @@ version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
- "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "azure_core",
  "bytes",
  "futures",
  "serde 1.0.197",
@@ -644,33 +617,12 @@ dependencies = [
 [[package]]
 name = "azure_identity"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c97790480791ec1ee9b76f5c6499b1d0aac0d4cd1e62010bfc19bb545544c5"
-dependencies = [
- "async-lock 3.3.0",
- "async-process 2.2.2",
- "async-trait",
- "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures",
- "oauth2",
- "pin-project",
- "serde 1.0.197",
- "time",
- "tracing",
- "tz-rs",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_identity"
-version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-lock 3.3.0",
  "async-process 2.2.2",
  "async-trait",
- "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "azure_core",
  "futures",
  "oauth2",
  "pin-project",
@@ -685,11 +637,10 @@ dependencies = [
 [[package]]
 name = "azure_security_keyvault"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338cac645bda0555f59189873be0cccaf420c26791f009b2207b62474cebbab8"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
- "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_core",
  "futures",
  "serde 1.0.197",
  "serde_json",
@@ -7556,7 +7507,7 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
- "azure_identity 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "azure_identity",
  "futures",
  "serde 1.0.197",
  "spin-core",
@@ -8039,8 +7990,8 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "azure_identity 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_core",
+ "azure_identity",
  "azure_security_keyvault",
  "dotenvy",
  "once_cell",

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -204,7 +204,7 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
                 self.loader.add_dynamic_host_component(
                     &mut builder,
                     spin_variables::VariablesHostComponent::new(
-                        runtime_config.variables_providers(),
+                        runtime_config.variables_providers()?,
                     ),
                 )?;
             }
@@ -225,7 +225,7 @@ impl<Executor: TriggerExecutor> TriggerExecutorBuilder<Executor> {
         let app_name = app.borrowed().require_metadata(APP_NAME_KEY)?;
 
         let resolver =
-            spin_variables::make_resolver(app.borrowed(), runtime_config.variables_providers())?;
+            spin_variables::make_resolver(app.borrowed(), runtime_config.variables_providers()?)?;
         let prepared_resolver = std::sync::Arc::new(resolver.prepare().await?);
         resolver_cell
             .set(prepared_resolver.clone())

--- a/crates/variables/Cargo.toml
+++ b/crates/variables/Cargo.toml
@@ -18,9 +18,9 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 vaultrs = "0.6.2"
 serde = "1.0.188"
 tracing = { workspace = true }
-azure_security_keyvault = "0.20.0"
-azure_core = "0.20.0"
-azure_identity = "0.20.0"
+azure_security_keyvault = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
+azure_core = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
+azure_identity = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
 
 [dev-dependencies]
 toml = "0.5"

--- a/crates/variables/src/provider/azure_key_vault.rs
+++ b/crates/variables/src/provider/azure_key_vault.rs
@@ -2,36 +2,104 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use azure_core::auth::TokenCredential;
 use azure_core::Url;
 use azure_security_keyvault::SecretClient;
 use serde::Deserialize;
 use spin_expressions::{Key, Provider};
 use tracing::{instrument, Level};
 
-#[derive(Debug)]
-pub struct AzureKeyVaultProvider {
+/// Azure KeyVault runtime config literal options for authentication
+#[derive(Clone, Debug)]
+pub struct AzureKeyVaultRuntimeConfigOptions {
     client_id: String,
     client_secret: String,
     tenant_id: String,
-    vault_url: String,
     authority_host: AzureAuthorityHost,
+}
+
+impl AzureKeyVaultRuntimeConfigOptions {
+    pub fn new(
+        client_id: String,
+        client_secret: String,
+        tenant_id: String,
+        authority_host: Option<AzureAuthorityHost>,
+    ) -> Self {
+        Self {
+            client_id,
+            client_secret,
+            tenant_id,
+            authority_host: authority_host.unwrap_or_default(),
+        }
+    }
+}
+
+/// Azure Cosmos Key / Value enumeration for the possible authentication options
+#[derive(Clone, Debug)]
+pub enum AzureKeyVaultAuthOptions {
+    /// Runtime Config values indicates the service principal credentials have been supplied
+    RuntimeConfigValues(AzureKeyVaultRuntimeConfigOptions),
+    /// Environmental indicates that the environment variables of the process should be used to
+    /// create the TokenCredential for the Cosmos client. This will use the Azure Rust SDK's
+    /// DefaultCredentialChain to derive the TokenCredential based on what environment variables
+    /// have been set.
+    ///
+    /// Service Principal with client secret:
+    /// - `AZURE_TENANT_ID`: ID of the service principal's Azure tenant.
+    /// - `AZURE_CLIENT_ID`: the service principal's client ID.
+    /// - `AZURE_CLIENT_SECRET`: one of the service principal's secrets.
+    ///
+    /// Service Principal with certificate:
+    /// - `AZURE_TENANT_ID`: ID of the service principal's Azure tenant.
+    /// - `AZURE_CLIENT_ID`: the service principal's client ID.
+    /// - `AZURE_CLIENT_CERTIFICATE_PATH`: path to a PEM or PKCS12 certificate file including the private key.
+    /// - `AZURE_CLIENT_CERTIFICATE_PASSWORD`: (optional) password for the certificate file.
+    ///
+    /// Workload Identity (Kubernetes, injected by the Workload Identity mutating webhook):
+    /// - `AZURE_TENANT_ID`: ID of the service principal's Azure tenant.
+    /// - `AZURE_CLIENT_ID`: the service principal's client ID.
+    /// - `AZURE_FEDERATED_TOKEN_FILE`: TokenFilePath is the path of a file containing a Kubernetes service account token.
+    ///
+    /// Managed Identity (User Assigned or System Assigned identities):
+    /// - `AZURE_CLIENT_ID`: (optional) if using a user assigned identity, this will be the client ID of the identity.
+    ///
+    /// Azure CLI:
+    /// - `AZURE_TENANT_ID`: (optional) use a specific tenant via the Azure CLI.
+    ///
+    /// Common across each:
+    /// - `AZURE_AUTHORITY_HOST`: (optional) the host for the identity provider. For example, for Azure public cloud the host defaults to "https://login.microsoftonline.com".
+    /// See also: https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/identity/README.md
+    Environmental,
+}
+
+#[derive(Debug)]
+pub struct AzureKeyVaultProvider {
+    secret_client: SecretClient,
 }
 
 impl AzureKeyVaultProvider {
     pub fn new(
-        client_id: impl Into<String>,
-        client_secret: impl Into<String>,
-        tenant_id: impl Into<String>,
         vault_url: impl Into<String>,
-        authority_host: impl Into<AzureAuthorityHost>,
-    ) -> Self {
-        Self {
-            client_id: client_id.into(),
-            client_secret: client_secret.into(),
-            tenant_id: tenant_id.into(),
-            vault_url: vault_url.into(),
-            authority_host: authority_host.into(),
-        }
+        auth_options: AzureKeyVaultAuthOptions,
+    ) -> Result<Self> {
+        let http_client = azure_core::new_http_client();
+        let token_credential = match auth_options.clone() {
+            AzureKeyVaultAuthOptions::RuntimeConfigValues(config) => {
+                let credential = azure_identity::ClientSecretCredential::new(
+                    http_client,
+                    config.authority_host.into(),
+                    config.tenant_id.to_string(),
+                    config.client_id.to_string(),
+                    config.client_secret.to_string(),
+                );
+                Arc::new(credential) as Arc<dyn TokenCredential>
+            }
+            AzureKeyVaultAuthOptions::Environmental => azure_identity::create_default_credential()?,
+        };
+
+        Ok(Self {
+            secret_client: SecretClient::new(&vault_url.into(), token_credential)?,
+        })
     }
 }
 
@@ -39,17 +107,8 @@ impl AzureKeyVaultProvider {
 impl Provider for AzureKeyVaultProvider {
     #[instrument(name = "spin_variables.get_from_azure_key_vault", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(&self, key: &Key) -> Result<Option<String>> {
-        let http_client = azure_core::new_http_client();
-        let credential = azure_identity::ClientSecretCredential::new(
-            http_client,
-            self.authority_host.into(),
-            self.tenant_id.to_string(),
-            self.client_id.to_string(),
-            self.client_secret.to_string(),
-        );
-
-        let secret_client = SecretClient::new(&self.vault_url, Arc::new(credential))?;
-        let secret = secret_client
+        let secret = self
+            .secret_client
             .get(key.as_str())
             .await
             .context("Failed to read variable from Azure Key Vault")?;

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -473,33 +473,6 @@ dependencies = [
 [[package]]
 name = "azure_core"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ce3de4b65b1ee2667c81d1fc692949049502a4cf9c38118d811d6d79a7eaef"
-dependencies = [
- "async-trait",
- "base64 0.22.0",
- "bytes",
- "dyn-clone",
- "futures",
- "getrandom 0.2.12",
- "http-types",
- "once_cell",
- "paste",
- "pin-project",
- "rand 0.8.5",
- "reqwest 0.12.4",
- "rustc_version",
- "serde 1.0.203",
- "serde_json",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_core"
-version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
@@ -531,7 +504,7 @@ version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
- "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "azure_core",
  "bytes",
  "futures",
  "serde 1.0.203",
@@ -546,33 +519,12 @@ dependencies = [
 [[package]]
 name = "azure_identity"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c97790480791ec1ee9b76f5c6499b1d0aac0d4cd1e62010bfc19bb545544c5"
-dependencies = [
- "async-lock 3.3.0",
- "async-process 2.2.2",
- "async-trait",
- "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures",
- "oauth2",
- "pin-project",
- "serde 1.0.203",
- "time",
- "tracing",
- "tz-rs",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_identity"
-version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-lock 3.3.0",
  "async-process 2.2.2",
  "async-trait",
- "azure_core 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "azure_core",
  "futures",
  "oauth2",
  "pin-project",
@@ -587,11 +539,10 @@ dependencies = [
 [[package]]
 name = "azure_security_keyvault"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338cac645bda0555f59189873be0cccaf420c26791f009b2207b62474cebbab8"
+source = "git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
 dependencies = [
  "async-trait",
- "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_core",
  "futures",
  "serde 1.0.203",
  "serde_json",
@@ -5782,7 +5733,7 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
- "azure_identity 0.20.0 (git+https://github.com/azure/azure-sdk-for-rust.git?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c)",
+ "azure_identity",
  "futures",
  "serde 1.0.203",
  "spin-core",
@@ -6062,8 +6013,8 @@ version = "2.7.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "azure_core 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "azure_identity 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "azure_core",
+ "azure_identity",
  "azure_security_keyvault",
  "dotenvy",
  "once_cell",


### PR DESCRIPTION
This PR is related to #2566 in that it provides similar authentication behaviors for Azure Key Vault var provider. This change should be additive and not cause any breakage to existing applications.

It would probably be wise to follow on with some integration tests to guard against future breakage. I'm not clear on the project stance on spinning up cloud resources for testing, but if help is wanted, I'd be delighted to lend a hand.

To create the infra and test this, simply follow https://developer.fermyon.com/spin/v2/dynamic-configuration#azure-key-vault-application-variable-provider-example. You can skip over creating the service principal and instead use your current identity provided through Azure CLI to authenticate.

Runtime config should look like the following with `${your_vault_name]` replaced:
```toml
[[config_provider]]
type = "azure_key_vault"
vault_url = "https://${your_vault_name}.vault.azure.net/"
```

On a side note, fetching secrets from Key Vault upon each request is pretty slow. Might want to consider some form of memoization / caching for a period of time.