### PR TITLE
Changes need to make Rust and Clippy happy on Rust 1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8428,9 +8428,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -8452,9 +8452,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/crates/componentize/src/abi_conformance/mod.rs
+++ b/crates/componentize/src/abi_conformance/mod.rs
@@ -12,12 +12,12 @@
 //! (i.e. inbound requests) or by the host (i.e. outbound requests).
 //!
 //! - For a guest-implemented function, the host will call the function and assert the result matches what is
-//! expected (see [`Report::inbound_http`] for an example).
+//!   expected (see [`Report::inbound_http`] for an example).
 //!
 //! - For a host-implemented function, the host will call a guest-implemented function according to the specified
-//! [`InvocationStyle`] with a set of arguments indicating which host function to call and with what arguments.
-//! The host then asserts that host function was indeed called with the expected arguments (see
-//! [`Report::http`] for an example).
+//!   [`InvocationStyle`] with a set of arguments indicating which host function to call and with what arguments.
+//!   The host then asserts that host function was indeed called with the expected arguments (see
+//!   [`Report::http`] for an example).
 
 #![deny(warnings)]
 
@@ -88,7 +88,7 @@ pub struct TestConfig {
 /// - Guest-implemented exports which behave as prescribed by the test (e.g. `inbound_http` and `inbound_redis`)
 ///
 /// - Host-implemented imports which are called by the guest with the arguments specified by the host
-/// (e.g. `http`)
+///   (e.g. `http`)
 #[derive(Serialize, PartialEq, Eq, Debug)]
 pub struct Report {
     /// Result of the Spin inbound HTTP test

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -160,7 +160,6 @@ async fn test_host_component_data_update() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg(not(tarpaulin))]
 async fn test_panic() {
     let err = run_core_wasi_test(["panic"], |_| {}).await.unwrap_err();
     let trap = err.downcast::<Trap>().expect("trap");

--- a/crates/key-value-azure/src/lib.rs
+++ b/crates/key-value-azure/src/lib.rs
@@ -61,7 +61,7 @@ pub enum KeyValueAzureCosmosAuthOptions {
     ///
     /// Common across each:
     /// - `AZURE_AUTHORITY_HOST`: (optional) the host for the identity provider. For example, for Azure public cloud the host defaults to "https://login.microsoftonline.com".
-    /// See also: https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/identity/README.md
+    ///   See also: https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/identity/README.md
     Environmental,
 }
 

--- a/crates/trigger/src/runtime_config.rs
+++ b/crates/trigger/src/runtime_config.rs
@@ -346,7 +346,7 @@ impl TriggerHooks for SummariseRuntimeConfigHook {
                 for (id, opt) in &opt.sqlite_databases {
                     opts.push(Self::summarise_sqlite(id, opt));
                 }
-                for opt in &opt.llm_compute {
+                if let Some(opt) = &opt.llm_compute {
                     opts.push(Self::summarise_llm(opt));
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1038,7 +1038,6 @@ route = "/..."
 
     /// Build an app whose component `workdir` is a subdirectory.
     #[test]
-    #[cfg(not(tarpaulin))]
     fn test_build_command_nested_workdir() -> anyhow::Result<()> {
         do_test_build_command("tests/testcases/nested-build")
     }


### PR DESCRIPTION
This includes a bump to the time crate version which used to compile but no longer does due to an addition of a trait impl to the std library. This was decided to be acceptable by the Rust project, and the fix is to bump the version of the `time` crate.

The rest of the changes are just small cosmetic changes to make the linters happy. 