### PR TITLE
Change implementation of `incoming-request.authority`

### DIFF
--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -1,6 +1,6 @@
 use std::{io::Cursor, net::SocketAddr, sync::Arc};
 
-use crate::HttpInstance;
+use crate::{HttpInstance, SelfRequestDefinition};
 use anyhow::{anyhow, ensure, Context, Result};
 use async_trait::async_trait;
 use http_body_util::BodyExt;
@@ -28,7 +28,7 @@ impl HttpExecutor for WagiHttpExecutor {
         route_match: &RouteMatch,
         req: Request<Body>,
         client_addr: SocketAddr,
-        _self_authority: &str,
+        _self_authority: SelfRequestDefinition,
     ) -> Result<Response<Body>> {
         let component = route_match.component_id();
 

--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -28,6 +28,7 @@ impl HttpExecutor for WagiHttpExecutor {
         route_match: &RouteMatch,
         req: Request<Body>,
         client_addr: SocketAddr,
+        _self_authority: &str,
     ) -> Result<Response<Body>> {
         let component = route_match.component_id();
 

--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -1,6 +1,6 @@
 use std::{io::Cursor, net::SocketAddr, sync::Arc};
 
-use crate::{HttpInstance, SelfRequestDefinition};
+use crate::{HttpInstance, SelfRequestOrigin};
 use anyhow::{anyhow, ensure, Context, Result};
 use async_trait::async_trait;
 use http_body_util::BodyExt;
@@ -28,7 +28,7 @@ impl HttpExecutor for WagiHttpExecutor {
         route_match: &RouteMatch,
         req: Request<Body>,
         client_addr: SocketAddr,
-        _self_authority: SelfRequestDefinition,
+        _self_origin: SelfRequestOrigin,
     ) -> Result<Response<Body>> {
         let component = route_match.component_id();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -355,7 +355,7 @@ Caused by:
     }
 
     #[test]
-    fn outbound_http_works() -> anyhow::Result<()> {
+    fn outbound_http_to_same_app_works() -> anyhow::Result<()> {
         run_test(
             "outbound-http-to-same-app",
             SpinConfig {

--- a/tests/runtime-tests/src/lib.rs
+++ b/tests/runtime-tests/src/lib.rs
@@ -147,7 +147,7 @@ impl RuntimeTest<InProcessSpin> {
     pub fn run(&mut self) {
         self.run_test(|env| {
             let runtime = env.runtime_mut();
-            let response = runtime.make_http_request(Request::new(Method::Get, "/"))?;
+            let response = runtime.make_http_request(Request::full(Method::Get, "/", &[("Host", "example.com")], None))?;
             if response.status() == 200 {
                 return Ok(());
             }


### PR DESCRIPTION
The guest will now see `incoming-request.authority` as whatever is set in the incoming request's `Host` header.

Previously we were relying on the definition of `incoming-request.authority` not being set by user input because outbound requests to the special `self` host would be ultimately directed towards whatever was in `incoming-request.authority`. Now, `self` requests are specifically defined (with scheme and authority) in the host. The implementation currently sets the `self` definition to be the same scheme as the incoming request and the authority is set to the listener address of the Spin web server. 