### PR TITLE
Runtime Config Independent of Serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8689,9 +8689,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -8713,9 +8713,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7763,6 +7763,7 @@ dependencies = [
 name = "spin-factors-test"
 version = "2.7.0-pre0"
 dependencies = [
+ "serde 1.0.197",
  "spin-app",
  "spin-factors",
  "spin-factors-derive",

--- a/crates/factor-key-value/src/runtime_config.rs
+++ b/crates/factor-key-value/src/runtime_config.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use serde::{de::DeserializeOwned, Deserialize};
-use spin_factors::{anyhow, FactorRuntimeConfig};
+use spin_factors::anyhow;
 use spin_key_value::StoreManager;
 
 /// Runtime configuration for all key value stores.
@@ -10,10 +10,6 @@ use spin_key_value::StoreManager;
 pub struct RuntimeConfig<C> {
     /// Map of store names to store configurations.
     pub store_configs: HashMap<String, C>,
-}
-
-impl<C: DeserializeOwned> FactorRuntimeConfig for RuntimeConfig<C> {
-    const KEY: &'static str = "key_value_store";
 }
 
 /// Resolves some piece of runtime configuration to a key value store manager.

--- a/crates/factor-key-value/tests/test.rs
+++ b/crates/factor-key-value/tests/test.rs
@@ -70,10 +70,7 @@ async fn run_test_with_config_and_stores_for_label(
         source = "does-not-exist.wasm"
         key_value_stores = labels_clone
     });
-    if let Some(runtime_config) = runtime_config {
-        env.runtime_config.extend(runtime_config);
-    }
-    let state = env.build_instance_state(factors).await?;
+    let state = env.build_instance_state(factors, runtime_config).await?;
     assert_eq!(
         labels,
         state.key_value.allowed_stores().iter().collect::<Vec<_>>()

--- a/crates/factor-key-value/tests/test.rs
+++ b/crates/factor-key-value/tests/test.rs
@@ -4,7 +4,9 @@ use spin_factor_key_value::{
 };
 use spin_factor_key_value_redis::RedisKeyValueStore;
 use spin_factor_key_value_spin::{SpinKeyValueRuntimeConfig, SpinKeyValueStore};
-use spin_factors::RuntimeFactors;
+use spin_factors::{
+    Factor, FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer, RuntimeFactors,
+};
 use spin_factors_test::{toml, TestEnvironment};
 use std::collections::HashSet;
 
@@ -41,7 +43,7 @@ async fn default_key_value_works() -> anyhow::Result<()> {
         source = "does-not-exist.wasm"
         key_value_stores = ["default"]
     });
-    let state = env.build_instance_state(factors).await?;
+    let state = env.build_instance_state(factors, ()).await?;
 
     assert_eq!(
         state.key_value.allowed_stores(),
@@ -65,12 +67,14 @@ async fn run_test_with_config_and_stores_for_label(
         key_value: KeyValueFactor::new(test_resolver),
     };
     let labels_clone = labels.clone();
-    let mut env = TestEnvironment::default_manifest_extend(toml! {
+    let env = TestEnvironment::default_manifest_extend(toml! {
         [component.test-component]
         source = "does-not-exist.wasm"
         key_value_stores = labels_clone
     });
-    let state = env.build_instance_state(factors, runtime_config).await?;
+    let state = env
+        .build_instance_state(factors, TomlConfig(runtime_config))
+        .await?;
     assert_eq!(
         labels,
         state.key_value.allowed_stores().iter().collect::<Vec<_>>()
@@ -203,13 +207,14 @@ async fn multiple_custom_key_value_uses_first_store() -> anyhow::Result<()> {
     let factors = TestFactors {
         key_value: KeyValueFactor::new(test_resolver),
     };
-    let mut env = TestEnvironment::default_manifest_extend(toml! {
+    let env = TestEnvironment::default_manifest_extend(toml! {
         [component.test-component]
         source = "does-not-exist.wasm"
         key_value_stores = ["custom"]
     });
-    env.runtime_config.extend(runtime_config);
-    let state = env.build_instance_state(factors).await?;
+    let state = env
+        .build_instance_state(factors, TomlConfig(Some(runtime_config)))
+        .await?;
 
     assert_eq!(
         state.key_value.allowed_stores(),
@@ -218,4 +223,33 @@ async fn multiple_custom_key_value_uses_first_store() -> anyhow::Result<()> {
     // Check that the first store in the config was chosen by verifying the existence of the DB directory
     assert!(tmp_dir.path().exists());
     Ok(())
+}
+
+struct TomlConfig(Option<toml::Table>);
+
+impl TryFrom<TomlConfig> for TestFactorsRuntimeConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TomlConfig) -> Result<Self, Self::Error> {
+        Self::from_source(value)
+    }
+}
+
+impl FactorRuntimeConfigSource<KeyValueFactor<DelegatingRuntimeConfigResolver>> for TomlConfig {
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<
+        Option<<KeyValueFactor<DelegatingRuntimeConfigResolver> as Factor>::RuntimeConfig>,
+    > {
+        let Some(table) = self.0.as_ref().and_then(|t| t.get("key_value_store")) else {
+            return Ok(None);
+        };
+        Ok(Some(table.clone().try_into()?))
+    }
+}
+
+impl RuntimeConfigSourceFinalizer for TomlConfig {
+    fn finalize(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/factor-llm/tests/factor.rs
+++ b/crates/factor-llm/tests/factor.rs
@@ -48,7 +48,7 @@ async fn llm_works() -> anyhow::Result<()> {
         source = "does-not-exist.wasm"
         ai_models = ["llama2-chat"]
     });
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
     assert_eq!(
         &*state.llm.allowed_models,
         &["llama2-chat".to_owned()]

--- a/crates/factor-outbound-http/tests/factor_test.rs
+++ b/crates/factor-outbound-http/tests/factor_test.rs
@@ -37,7 +37,7 @@ async fn disallowed_host_fails() -> anyhow::Result<()> {
         http: OutboundHttpFactor,
     };
     let env = test_env();
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
     let mut wasi_http = OutboundHttpFactor::get_wasi_http_impl(&mut state).unwrap();
 
     let req = Request::get("https://denied.test").body(Default::default())?;

--- a/crates/factor-outbound-http/tests/factor_test.rs
+++ b/crates/factor-outbound-http/tests/factor_test.rs
@@ -4,7 +4,7 @@ use anyhow::bail;
 use http::Request;
 use spin_factor_outbound_http::OutboundHttpFactor;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
-use spin_factor_variables::VariablesFactor;
+use spin_factor_variables::spin_cli::VariablesFactor;
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
 use spin_factors::{anyhow, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};

--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -59,7 +59,10 @@ impl Factor for OutboundNetworkingFactor {
             .get(ctx.app_component().id())
             .cloned()
             .context("missing component allowed hosts")?;
-        let resolver = builders.get_mut::<VariablesFactor>()?.resolver().clone();
+        let resolver = builders
+            .get_mut::<VariablesFactor>()?
+            .expression_resolver()
+            .clone();
         let allowed_hosts_future = async move {
             let prepared = resolver.prepare().await?;
             AllowedHostsConfig::parse(&hosts, &prepared)

--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -60,7 +60,7 @@ impl Factor for OutboundNetworkingFactor {
             .cloned()
             .context("missing component allowed hosts")?;
         let resolver = builders
-            .get_mut::<VariablesFactor>()?
+            .get_mut::<VariablesFactor<()>>()?
             .expression_resolver()
             .clone();
         let allowed_hosts_future = async move {

--- a/crates/factor-outbound-networking/tests/factor_test.rs
+++ b/crates/factor-outbound-networking/tests/factor_test.rs
@@ -29,7 +29,7 @@ async fn configures_wasi_socket_addr_check() -> anyhow::Result<()> {
     };
 
     let env = test_env();
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
     let mut wasi = WasiFactor::get_wasi_impl(&mut state).unwrap();
 
     let network_resource = wasi.instance_network()?;
@@ -62,10 +62,13 @@ async fn wasi_factor_is_optional() -> anyhow::Result<()> {
         networking: OutboundNetworkingFactor,
     }
     TestEnvironment::default()
-        .build_instance_state(WithoutWasi {
-            variables: VariablesFactor::default(),
-            networking: OutboundNetworkingFactor,
-        })
+        .build_instance_state(
+            WithoutWasi {
+                variables: VariablesFactor::default(),
+                networking: OutboundNetworkingFactor,
+            },
+            (),
+        )
         .await?;
     Ok(())
 }

--- a/crates/factor-outbound-networking/tests/factor_test.rs
+++ b/crates/factor-outbound-networking/tests/factor_test.rs
@@ -1,5 +1,5 @@
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
-use spin_factor_variables::VariablesFactor;
+use spin_factor_variables::spin_cli::VariablesFactor;
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
 use spin_factors::{anyhow, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};

--- a/crates/factor-outbound-pg/tests/factor_test.rs
+++ b/crates/factor-outbound-pg/tests/factor_test.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factor_outbound_pg::client::Client;
 use spin_factor_outbound_pg::OutboundPgFactor;
-use spin_factor_variables::{StaticVariables, VariablesFactor};
+use spin_factor_variables::spin_cli::{StaticVariables, VariablesFactor};
 use spin_factors::{anyhow, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};
 use spin_world::async_trait;

--- a/crates/factor-outbound-pg/tests/factor_test.rs
+++ b/crates/factor-outbound-pg/tests/factor_test.rs
@@ -24,7 +24,7 @@ fn factors() -> Result<TestFactors> {
         networking: OutboundNetworkingFactor,
         pg: OutboundPgFactor::<MockClient>::new(),
     };
-    f.variables.add_provider_type(StaticVariables)?;
+    f.variables.add_provider_resolver(StaticVariables)?;
     Ok(f)
 }
 
@@ -43,7 +43,7 @@ async fn disallowed_host_fails() -> anyhow::Result<()> {
         [component.test-component]
         source = "does-not-exist.wasm"
     });
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
 
     let res = state
         .pg
@@ -61,7 +61,7 @@ async fn disallowed_host_fails() -> anyhow::Result<()> {
 async fn allowed_host_succeeds() -> anyhow::Result<()> {
     let factors = factors()?;
     let env = test_env();
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
 
     let res = state
         .pg
@@ -78,7 +78,7 @@ async fn allowed_host_succeeds() -> anyhow::Result<()> {
 async fn exercise_execute() -> anyhow::Result<()> {
     let factors = factors()?;
     let env = test_env();
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
 
     let connection = state
         .pg
@@ -97,7 +97,7 @@ async fn exercise_execute() -> anyhow::Result<()> {
 async fn exercise_query() -> anyhow::Result<()> {
     let factors = factors()?;
     let env = test_env();
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
 
     let connection = state
         .pg

--- a/crates/factor-outbound-redis/tests/factor_test.rs
+++ b/crates/factor-outbound-redis/tests/factor_test.rs
@@ -41,7 +41,7 @@ async fn no_outbound_hosts_fails() -> anyhow::Result<()> {
         },
         ..Default::default()
     };
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
     let connection = state
         .redis
         .open("redis://redis.test:8080".to_string())

--- a/crates/factor-outbound-redis/tests/factor_test.rs
+++ b/crates/factor-outbound-redis/tests/factor_test.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factor_outbound_redis::OutboundRedisFactor;
-use spin_factor_variables::{StaticVariables, VariablesFactor};
+use spin_factor_variables::spin_cli::{StaticVariables, VariablesFactor};
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
 use spin_factors::{anyhow, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};

--- a/crates/factor-outbound-redis/tests/factor_test.rs
+++ b/crates/factor-outbound-redis/tests/factor_test.rs
@@ -28,7 +28,7 @@ fn get_test_factors() -> TestFactors {
 async fn no_outbound_hosts_fails() -> anyhow::Result<()> {
     let mut factors = get_test_factors();
 
-    factors.variables.add_provider_type(StaticVariables)?;
+    factors.variables.add_provider_resolver(StaticVariables)?;
 
     let env = TestEnvironment {
         manifest: toml! {

--- a/crates/factor-sqlite/src/runtime_config.rs
+++ b/crates/factor-sqlite/src/runtime_config.rs
@@ -3,29 +3,17 @@ pub mod spin;
 
 use std::{collections::HashMap, sync::Arc};
 
-use serde::{de::DeserializeOwned, Deserialize};
-use spin_factors::{anyhow, FactorRuntimeConfig};
-
 use crate::ConnectionPool;
 
-#[derive(Deserialize)]
-#[serde(transparent)]
-pub struct RuntimeConfig<C> {
-    pub store_configs: HashMap<String, C>,
+/// A runtime configuration for SQLite databases.
+///
+/// Maps database labels to connection pools.
+pub struct RuntimeConfig {
+    pub pools: HashMap<String, Arc<dyn ConnectionPool>>,
 }
 
-impl<C: DeserializeOwned> FactorRuntimeConfig for RuntimeConfig<C> {
-    const KEY: &'static str = "sqlite_database";
-}
-
-/// Resolves some piece of runtime configuration to a connection pool
-pub trait RuntimeConfigResolver: Send + Sync {
-    type Config: DeserializeOwned;
-
-    /// Get a connection pool for a given config.
-    ///
-    fn get_pool(&self, config: Self::Config) -> anyhow::Result<Arc<dyn ConnectionPool>>;
-
+/// Resolves a label to a default connection pool.
+pub trait DefaultLabelResolver: Send + Sync {
     /// If there is no runtime configuration for a given database label, return a default connection pool.
     ///
     /// If `Option::None` is returned, the database is not allowed.

--- a/crates/factor-sqlite/src/runtime_config.rs
+++ b/crates/factor-sqlite/src/runtime_config.rs
@@ -11,11 +11,3 @@ use crate::ConnectionPool;
 pub struct RuntimeConfig {
     pub pools: HashMap<String, Arc<dyn ConnectionPool>>,
 }
-
-/// Resolves a label to a default connection pool.
-pub trait DefaultLabelResolver: Send + Sync {
-    /// If there is no runtime configuration for a given database label, return a default connection pool.
-    ///
-    /// If `Option::None` is returned, the database is not allowed.
-    fn default(&self, label: &str) -> Option<Arc<dyn ConnectionPool>>;
-}

--- a/crates/factor-sqlite/src/runtime_config/spin.rs
+++ b/crates/factor-sqlite/src/runtime_config/spin.rs
@@ -10,8 +10,7 @@ use spin_factors::anyhow::{self, Context as _};
 use spin_world::v2::sqlite as v2;
 use tokio::sync::OnceCell;
 
-use super::DefaultLabelResolver;
-use crate::{Connection, ConnectionPool, SimpleConnectionPool};
+use crate::{Connection, ConnectionPool, DefaultLabelResolver, SimpleConnectionPool};
 
 /// Spin's default handling of the runtime configuration for SQLite databases.
 ///

--- a/crates/factor-sqlite/src/runtime_config/spin.rs
+++ b/crates/factor-sqlite/src/runtime_config/spin.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use serde::Deserialize;
-use spin_factors::anyhow::{self, Context as _};
+use spin_factors::{
+    anyhow::{self, Context as _},
+    runtime_config::toml::GetTomlValue,
+};
 use spin_world::v2::sqlite as v2;
 use tokio::sync::OnceCell;
 
@@ -55,7 +58,7 @@ impl SpinSqliteRuntimeConfig {
     /// type = "$database-type"
     /// ... extra type specific configuration ...
     /// ```
-    pub fn config_from_table<T: GetKey + AsRef<toml::Table>>(
+    pub fn config_from_table<T: GetTomlValue + AsRef<toml::Table>>(
         &self,
         table: &T,
     ) -> anyhow::Result<Option<super::RuntimeConfig>> {
@@ -86,10 +89,6 @@ impl SpinSqliteRuntimeConfig {
         };
         Ok(Arc::new(pool))
     }
-}
-
-pub trait GetKey {
-    fn get(&self, key: &str) -> Option<&toml::Value>;
 }
 
 #[derive(Deserialize)]

--- a/crates/factor-sqlite/tests/factor.rs
+++ b/crates/factor-sqlite/tests/factor.rs
@@ -181,7 +181,7 @@ impl DefaultLabelResolver {
     }
 }
 
-impl factor_sqlite::runtime_config::DefaultLabelResolver for DefaultLabelResolver {
+impl factor_sqlite::DefaultLabelResolver for DefaultLabelResolver {
     fn default(&self, label: &str) -> Option<Arc<dyn factor_sqlite::ConnectionPool>> {
         let Some(default) = &self.default else {
             return None;

--- a/crates/factor-sqlite/tests/factor.rs
+++ b/crates/factor-sqlite/tests/factor.rs
@@ -77,7 +77,7 @@ async fn no_error_when_database_is_configured() -> anyhow::Result<()> {
     if let Err(e) = env
         .build_instance_state(
             factors,
-            Foo(TomlRuntimeSource::new(&runtime_config, sqlite_config)),
+            TomlRuntimeSource::new(&runtime_config, sqlite_config),
         )
         .await
     {
@@ -112,6 +112,14 @@ impl FactorRuntimeConfigSource<SqliteFactor> for TomlRuntimeSource<'_> {
 impl RuntimeConfigSourceFinalizer for TomlRuntimeSource<'_> {
     fn finalize(&mut self) -> anyhow::Result<()> {
         Ok(self.table.validate_all_keys_used().unwrap())
+    }
+}
+
+impl TryFrom<TomlRuntimeSource<'_>> for TestFactorsRuntimeConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TomlRuntimeSource<'_>) -> Result<Self, Self::Error> {
+        Self::from_source(value)
     }
 }
 

--- a/crates/factor-variables/src/lib.rs
+++ b/crates/factor-variables/src/lib.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use serde::{de::DeserializeOwned, Deserialize};
 use spin_expressions::ProviderResolver as ExpressionResolver;
 use spin_factors::{
-    anyhow, ConfigureAppContext, Factor, FactorRuntimeConfig, InitContext, InstanceBuilders,
-    PrepareContext, RuntimeFactors, SelfInstanceBuilder,
+    anyhow, ConfigureAppContext, Factor, InitContext, InstanceBuilders, PrepareContext,
+    RuntimeFactors, SelfInstanceBuilder,
 };
 use spin_world::{async_trait, v1, v2::variables};
 
@@ -102,10 +102,6 @@ impl<C: DeserializeOwned + 'static> Factor for VariablesFactor<C> {
 #[serde(transparent)]
 pub struct RuntimeConfig<C> {
     provider_configs: Vec<C>,
-}
-
-impl<C: DeserializeOwned> FactorRuntimeConfig for RuntimeConfig<C> {
-    const KEY: &'static str = "variable_provider";
 }
 
 pub struct AppState {

--- a/crates/factor-variables/src/provider.rs
+++ b/crates/factor-variables/src/provider.rs
@@ -1,30 +1,17 @@
-mod env;
-mod statik;
-
-pub use env::EnvVariables;
-pub use statik::StaticVariables;
-
 use serde::de::DeserializeOwned;
 use spin_expressions::Provider;
 use spin_factors::anyhow;
 
+/// A trait for converting a runtime configuration into a variables provider.
 pub trait MakeVariablesProvider: 'static {
-    const RUNTIME_CONFIG_TYPE: &'static str;
-
+    /// Serialized configuration for the provider.
     type RuntimeConfig: DeserializeOwned;
-    type Provider: Provider;
 
-    fn make_provider(&self, runtime_config: Self::RuntimeConfig) -> anyhow::Result<Self::Provider>;
-}
-
-pub(crate) type ProviderFromToml = Box<dyn Fn(toml::Table) -> anyhow::Result<Box<dyn Provider>>>;
-
-pub(crate) fn provider_from_toml_fn<T: MakeVariablesProvider>(
-    provider_type: T,
-) -> ProviderFromToml {
-    Box::new(move |table| {
-        let runtime_config: T::RuntimeConfig = table.try_into()?;
-        let provider = provider_type.make_provider(runtime_config)?;
-        Ok(Box::new(provider))
-    })
+    /// Create a variables provider from the given runtime configuration.
+    ///
+    /// Returns `Ok(None)` if the provider is not applicable to the given configuration.
+    fn make_provider(
+        &self,
+        runtime_config: &Self::RuntimeConfig,
+    ) -> anyhow::Result<Option<Box<dyn Provider>>>;
 }

--- a/crates/factor-variables/src/provider.rs
+++ b/crates/factor-variables/src/provider.rs
@@ -3,14 +3,14 @@ use spin_expressions::Provider;
 use spin_factors::anyhow;
 
 /// A trait for converting a runtime configuration into a variables provider.
-pub trait MakeVariablesProvider: 'static {
+pub trait ProviderResolver: 'static {
     /// Serialized configuration for the provider.
     type RuntimeConfig: DeserializeOwned;
 
     /// Create a variables provider from the given runtime configuration.
     ///
     /// Returns `Ok(None)` if the provider is not applicable to the given configuration.
-    fn make_provider(
+    fn resolve_provider(
         &self,
         runtime_config: &Self::RuntimeConfig,
     ) -> anyhow::Result<Option<Box<dyn Provider>>>;

--- a/crates/factor-variables/src/spin_cli/env.rs
+++ b/crates/factor-variables/src/spin_cli/env.rs
@@ -13,19 +13,19 @@ use tracing::{instrument, Level};
 
 use crate::ProviderResolver;
 
-use super::RuntimeConfig;
+use super::VariableProviderConfiguration;
 
 /// Creator of a environment variables provider.
 pub struct EnvVariables;
 
 impl ProviderResolver for EnvVariables {
-    type RuntimeConfig = RuntimeConfig;
+    type RuntimeConfig = VariableProviderConfiguration;
 
     fn resolve_provider(
         &self,
         runtime_config: &Self::RuntimeConfig,
     ) -> anyhow::Result<Option<Box<dyn Provider>>> {
-        let RuntimeConfig::Env(runtime_config) = runtime_config else {
+        let VariableProviderConfiguration::Env(runtime_config) = runtime_config else {
             return Ok(None);
         };
         Ok(Some(Box::new(EnvVariablesProvider::new(

--- a/crates/factor-variables/src/spin_cli/env.rs
+++ b/crates/factor-variables/src/spin_cli/env.rs
@@ -11,17 +11,17 @@ use spin_factors::anyhow::{self, Context as _};
 use spin_world::async_trait;
 use tracing::{instrument, Level};
 
-use crate::MakeVariablesProvider;
+use crate::ProviderResolver;
 
 use super::RuntimeConfig;
 
 /// Creator of a environment variables provider.
 pub struct EnvVariables;
 
-impl MakeVariablesProvider for EnvVariables {
+impl ProviderResolver for EnvVariables {
     type RuntimeConfig = RuntimeConfig;
 
-    fn make_provider(
+    fn resolve_provider(
         &self,
         runtime_config: &Self::RuntimeConfig,
     ) -> anyhow::Result<Option<Box<dyn Provider>>> {

--- a/crates/factor-variables/src/spin_cli/mod.rs
+++ b/crates/factor-variables/src/spin_cli/mod.rs
@@ -9,9 +9,12 @@ pub use statik::StaticVariables;
 use serde::Deserialize;
 use statik::StaticVariablesProvider;
 
+/// The runtime configuration for the variables factor used in the Spin CLI.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum RuntimeConfig {
+    /// A static provider of variables.
     Static(StaticVariablesProvider),
+    /// An environment variable provider.
     Env(env::EnvVariablesConfig),
 }

--- a/crates/factor-variables/src/spin_cli/mod.rs
+++ b/crates/factor-variables/src/spin_cli/mod.rs
@@ -9,12 +9,18 @@ pub use statik::StaticVariables;
 use serde::Deserialize;
 use statik::StaticVariablesProvider;
 
-/// The runtime configuration for the variables factor used in the Spin CLI.
+/// A runtime configuration used in the Spin CLI for one type of variable provider.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
-pub enum RuntimeConfig {
+pub enum VariableProviderConfiguration {
     /// A static provider of variables.
     Static(StaticVariablesProvider),
     /// An environment variable provider.
     Env(env::EnvVariablesConfig),
 }
+
+/// The runtime configuration for the variables factor used in the Spin CLI.
+pub type RuntimeConfig = super::RuntimeConfig<VariableProviderConfiguration>;
+
+/// The variables factor used in the Spin CLI.
+pub type VariablesFactor = super::VariablesFactor<VariableProviderConfiguration>;

--- a/crates/factor-variables/src/spin_cli/mod.rs
+++ b/crates/factor-variables/src/spin_cli/mod.rs
@@ -1,0 +1,17 @@
+//! The runtime configuration for the variables factor used in the Spin CLI.
+
+mod env;
+mod statik;
+
+pub use env::EnvVariables;
+pub use statik::StaticVariables;
+
+use serde::Deserialize;
+use statik::StaticVariablesProvider;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum RuntimeConfig {
+    Static(StaticVariablesProvider),
+    Env(env::EnvVariablesConfig),
+}

--- a/crates/factor-variables/src/spin_cli/statik.rs
+++ b/crates/factor-variables/src/spin_cli/statik.rs
@@ -6,19 +6,19 @@ use spin_factors::anyhow;
 
 use crate::ProviderResolver;
 
-use super::RuntimeConfig;
+use super::VariableProviderConfiguration;
 
 /// Creator of a static variables provider.
 pub struct StaticVariables;
 
 impl ProviderResolver for StaticVariables {
-    type RuntimeConfig = RuntimeConfig;
+    type RuntimeConfig = VariableProviderConfiguration;
 
     fn resolve_provider(
         &self,
         runtime_config: &Self::RuntimeConfig,
     ) -> anyhow::Result<Option<Box<dyn Provider>>> {
-        let RuntimeConfig::Static(config) = runtime_config else {
+        let VariableProviderConfiguration::Static(config) = runtime_config else {
             return Ok(None);
         };
         Ok(Some(Box::new(config.clone()) as _))

--- a/crates/factor-variables/src/spin_cli/statik.rs
+++ b/crates/factor-variables/src/spin_cli/statik.rs
@@ -4,17 +4,17 @@ use serde::Deserialize;
 use spin_expressions::{async_trait::async_trait, Key, Provider};
 use spin_factors::anyhow;
 
-use crate::MakeVariablesProvider;
+use crate::ProviderResolver;
 
 use super::RuntimeConfig;
 
 /// Creator of a static variables provider.
 pub struct StaticVariables;
 
-impl MakeVariablesProvider for StaticVariables {
+impl ProviderResolver for StaticVariables {
     type RuntimeConfig = RuntimeConfig;
 
-    fn make_provider(
+    fn resolve_provider(
         &self,
         runtime_config: &Self::RuntimeConfig,
     ) -> anyhow::Result<Option<Box<dyn Provider>>> {

--- a/crates/factor-variables/src/spin_cli/statik.rs
+++ b/crates/factor-variables/src/spin_cli/statik.rs
@@ -6,22 +6,27 @@ use spin_factors::anyhow;
 
 use crate::MakeVariablesProvider;
 
+use super::RuntimeConfig;
+
 /// Creator of a static variables provider.
 pub struct StaticVariables;
 
 impl MakeVariablesProvider for StaticVariables {
-    const RUNTIME_CONFIG_TYPE: &'static str = "static";
+    type RuntimeConfig = RuntimeConfig;
 
-    type RuntimeConfig = StaticVariablesProvider;
-    type Provider = StaticVariablesProvider;
-
-    fn make_provider(&self, runtime_config: Self::RuntimeConfig) -> anyhow::Result<Self::Provider> {
-        Ok(runtime_config)
+    fn make_provider(
+        &self,
+        runtime_config: &Self::RuntimeConfig,
+    ) -> anyhow::Result<Option<Box<dyn Provider>>> {
+        let RuntimeConfig::Static(config) = runtime_config else {
+            return Ok(None);
+        };
+        Ok(Some(Box::new(config.clone()) as _))
     }
 }
 
 /// A variables provider that reads variables from an static map.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct StaticVariablesProvider {
     values: Arc<HashMap<String, String>>,
 }

--- a/crates/factor-variables/tests/factor_test.rs
+++ b/crates/factor-variables/tests/factor_test.rs
@@ -2,7 +2,9 @@ use spin_factor_variables::spin_cli::{
     EnvVariables, StaticVariables, VariableProviderConfiguration,
 };
 use spin_factor_variables::VariablesFactor;
-use spin_factors::{anyhow, RuntimeFactors};
+use spin_factors::{
+    anyhow, Factor, FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer, RuntimeFactors,
+};
 use spin_factors_test::{toml, TestEnvironment};
 use spin_world::v2::variables::Host;
 
@@ -12,24 +14,23 @@ struct TestFactors {
 }
 
 fn test_env() -> TestEnvironment {
-    let mut env = TestEnvironment::default_manifest_extend(toml! {
+    TestEnvironment::default_manifest_extend(toml! {
         [variables]
         foo = { required = true }
 
         [component.test-component]
         source = "does-not-exist.wasm"
         variables = { baz = "<{{ foo }}>" }
-    });
-    env.runtime_config = toml! {
-        [[variable_provider]]
-        type = "static"
-        values = { foo = "bar" }
-    };
-    env
+    })
 }
 
 #[tokio::test]
 async fn static_provider_works() -> anyhow::Result<()> {
+    let runtime_config = toml! {
+        [[variable_provider]]
+        type = "static"
+        values = { foo = "bar" }
+    };
     let mut factors = TestFactors {
         variables: VariablesFactor::default(),
     };
@@ -38,8 +39,39 @@ async fn static_provider_works() -> anyhow::Result<()> {
     factors.variables.add_provider_resolver(EnvVariables)?;
 
     let env = test_env();
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env
+        .build_instance_state(factors, TomlConfig(runtime_config))
+        .await?;
     let val = state.variables.get("baz".try_into().unwrap()).await?;
     assert_eq!(val, "<bar>");
     Ok(())
+}
+
+struct TomlConfig(toml::Table);
+
+impl TryFrom<TomlConfig> for TestFactorsRuntimeConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TomlConfig) -> Result<Self, Self::Error> {
+        Self::from_source(value)
+    }
+}
+
+impl FactorRuntimeConfigSource<VariablesFactor<VariableProviderConfiguration>> for TomlConfig {
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<
+        Option<<VariablesFactor<VariableProviderConfiguration> as Factor>::RuntimeConfig>,
+    > {
+        let Some(table) = self.0.get("variable_provider") else {
+            return Ok(None);
+        };
+        Ok(Some(table.clone().try_into()?))
+    }
+}
+
+impl RuntimeConfigSourceFinalizer for TomlConfig {
+    fn finalize(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/factor-variables/tests/factor_test.rs
+++ b/crates/factor-variables/tests/factor_test.rs
@@ -1,4 +1,4 @@
-use spin_factor_variables::spin_cli::{RuntimeConfig, StaticVariables};
+use spin_factor_variables::spin_cli::{EnvVariables, RuntimeConfig, StaticVariables};
 use spin_factor_variables::VariablesFactor;
 use spin_factors::{anyhow, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};
@@ -30,13 +30,15 @@ async fn static_provider_works() -> anyhow::Result<()> {
     let mut factors = TestFactors {
         variables: VariablesFactor::default(),
     };
-    factors.variables.add_provider_type(StaticVariables)?;
+    factors.variables.add_provider_resolver(StaticVariables)?;
+    // The env provider will be ignored since there's no configuration for it.
+    factors.variables.add_provider_resolver(EnvVariables)?;
 
     let env = test_env();
     let state = env.build_instance_state(factors).await?;
     let val = state
         .variables
-        .resolver()
+        .expression_resolver()
         .resolve("test-component", "baz".try_into().unwrap())
         .await?;
     assert_eq!(val, "<bar>");

--- a/crates/factor-variables/tests/factor_test.rs
+++ b/crates/factor-variables/tests/factor_test.rs
@@ -1,10 +1,11 @@
-use spin_factor_variables::{StaticVariables, VariablesFactor};
+use spin_factor_variables::spin_cli::{RuntimeConfig, StaticVariables};
+use spin_factor_variables::VariablesFactor;
 use spin_factors::{anyhow, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};
 
 #[derive(RuntimeFactors)]
 struct TestFactors {
-    variables: VariablesFactor,
+    variables: VariablesFactor<RuntimeConfig>,
 }
 
 fn test_env() -> TestEnvironment {

--- a/crates/factor-variables/tests/factor_test.rs
+++ b/crates/factor-variables/tests/factor_test.rs
@@ -1,11 +1,14 @@
-use spin_factor_variables::spin_cli::{EnvVariables, RuntimeConfig, StaticVariables};
+use spin_factor_variables::spin_cli::{
+    EnvVariables, StaticVariables, VariableProviderConfiguration,
+};
 use spin_factor_variables::VariablesFactor;
 use spin_factors::{anyhow, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};
+use spin_world::v2::variables::Host;
 
 #[derive(RuntimeFactors)]
 struct TestFactors {
-    variables: VariablesFactor<RuntimeConfig>,
+    variables: VariablesFactor<VariableProviderConfiguration>,
 }
 
 fn test_env() -> TestEnvironment {
@@ -35,12 +38,8 @@ async fn static_provider_works() -> anyhow::Result<()> {
     factors.variables.add_provider_resolver(EnvVariables)?;
 
     let env = test_env();
-    let state = env.build_instance_state(factors).await?;
-    let val = state
-        .variables
-        .expression_resolver()
-        .resolve("test-component", "baz".try_into().unwrap())
-        .await?;
+    let mut state = env.build_instance_state(factors).await?;
+    let val = state.variables.get("baz".try_into().unwrap()).await?;
     assert_eq!(val, "<bar>");
     Ok(())
 }

--- a/crates/factor-wasi/tests/factor_test.rs
+++ b/crates/factor-wasi/tests/factor_test.rs
@@ -22,7 +22,7 @@ async fn environment_works() -> anyhow::Result<()> {
         wasi: WasiFactor::new(DummyFilesMounter),
     };
     let env = test_env();
-    let mut state = env.build_instance_state(factors).await?;
+    let mut state = env.build_instance_state(factors, ()).await?;
     let mut wasi = WasiFactor::get_wasi_impl(&mut state).unwrap();
     let val = wasi
         .get_environment()?

--- a/crates/factors-test/Cargo.toml
+++ b/crates/factors-test/Cargo.toml
@@ -5,6 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+serde = "1.0"
 spin-app = { path = "../app" }
 spin-factors = { path = "../factors" }
 spin-factors-derive = { path = "../factors-derive", features = ["expander"] }

--- a/crates/factors-test/src/lib.rs
+++ b/crates/factors-test/src/lib.rs
@@ -47,10 +47,14 @@ impl TestEnvironment {
     /// Starting from a new _uninitialized_ [`RuntimeFactors`], run through the
     /// [`Factor`]s' lifecycle(s) to build a [`RuntimeFactors::InstanceState`]
     /// for the last component defined in the manifest.
-    pub async fn build_instance_state<'a, T: RuntimeFactors, C: RuntimeConfigSource + 'a>(
+    pub async fn build_instance_state<
+        'a,
+        T: RuntimeFactors,
+        S: RuntimeConfigSource<T::RuntimeConfig> + 'a,
+    >(
         &'a self,
         mut factors: T,
-        runtime_config: C,
+        runtime_config: S,
     ) -> anyhow::Result<T::InstanceState> {
         let mut linker = Self::new_linker::<T::InstanceState>();
         factors.init(&mut linker)?;
@@ -85,20 +89,3 @@ impl TestEnvironment {
         spin_loader::from_file(&path, FilesMountStrategy::Direct, None).await
     }
 }
-
-// / A [`RuntimeConfigSource`] that reads from a TOML table.
-// pub struct TomlRuntimeConfig<'a>(&'a toml::Table);
-
-// impl RuntimeConfigSource for TomlRuntimeConfig<'_> {
-//     fn factor_config_keys(&self) -> impl IntoIterator<Item = &str> {
-//         self.0.keys().map(|key| key.as_str())
-//     }
-
-//     fn get_factor_config<F: Factor>(&self, key: &str) -> anyhow::Result<Option<F>> {
-//         let Some(val) = self.0.get(key) else {
-//             return Ok(None);
-//         };
-//         let config = val.clone().try_into()?;
-//         Ok(Some(config))
-//     }
-// }

--- a/crates/factors/Cargo.toml
+++ b/crates/factors/Cargo.toml
@@ -10,6 +10,8 @@ serde = "1.0"
 spin-app = { path = "../app" }
 spin-factors-derive = { path = "../factors-derive" }
 thiserror = "1.0"
+# TODO: make this optional and behind a feature flag
+toml = "0.8"
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 
@@ -28,7 +30,6 @@ spin-factor-variables = { path = "../factor-variables" }
 spin-factor-wasi = { path = "../factor-wasi" }
 spin-loader = { path = "../loader" }
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
-toml = "0.8"
 wasmtime-wasi-http = { workspace = true }
 
 [build-dependencies]

--- a/crates/factors/src/factor.rs
+++ b/crates/factors/src/factor.rs
@@ -3,8 +3,8 @@ use std::any::Any;
 use wasmtime::component::{Linker, ResourceTable};
 
 use crate::{
-    prepare::FactorInstanceBuilder, runtime_config::RuntimeConfigTracker, App, Error,
-    FactorRuntimeConfig, InstanceBuilders, PrepareContext, RuntimeConfigSource, RuntimeFactors,
+    prepare::FactorInstanceBuilder, App, Error, InstanceBuilders, PrepareContext,
+    RuntimeConfigSource, RuntimeFactors,
 };
 
 /// A contained (i.e., "factored") piece of runtime functionality.
@@ -13,7 +13,7 @@ pub trait Factor: Any + Sized {
     ///
     /// Runtime configuration allows for user-provided customization of the
     /// factor's behavior on a per-app basis.
-    type RuntimeConfig: FactorRuntimeConfig;
+    type RuntimeConfig;
 
     /// The application state of this factor.
     ///
@@ -140,9 +140,10 @@ impl<'a, T: RuntimeFactors, F: Factor> ConfigureAppContext<'a, T, F> {
     pub fn new<S: RuntimeConfigSource>(
         app: &'a App,
         app_state: &'a T::AppState,
-        runtime_config_tracker: &mut RuntimeConfigTracker<S>,
+        runtime_config: &mut S,
     ) -> crate::Result<Self> {
-        let runtime_config = runtime_config_tracker.get_config::<F>()?;
+        // TODO: fix error
+        let runtime_config = runtime_config.get_factor_config::<F>().unwrap();
         Ok(Self {
             app,
             app_state,

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -13,9 +13,7 @@ pub use spin_factors_derive::RuntimeFactors;
 pub use crate::{
     factor::{ConfigureAppContext, ConfiguredApp, Factor, FactorInstanceState, InitContext},
     prepare::{FactorInstanceBuilder, InstanceBuilders, PrepareContext, SelfInstanceBuilder},
-    runtime_config::{
-        FactorRuntimeConfigSource, RuntimeConfigSource, RuntimeConfigSourceFinalizer,
-    },
+    runtime_config::{FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer},
     runtime_factors::{RuntimeFactors, RuntimeFactorsInstanceState},
 };
 

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -13,7 +13,7 @@ pub use spin_factors_derive::RuntimeFactors;
 pub use crate::{
     factor::{ConfigureAppContext, ConfiguredApp, Factor, FactorInstanceState, InitContext},
     prepare::{FactorInstanceBuilder, InstanceBuilders, PrepareContext, SelfInstanceBuilder},
-    runtime_config::{FactorRuntimeConfig, RuntimeConfigSource},
+    runtime_config::RuntimeConfigSource,
     runtime_factors::{RuntimeFactors, RuntimeFactorsInstanceState},
 };
 
@@ -63,7 +63,7 @@ impl Error {
         Self::NoSuchFactor(std::any::type_name::<T>())
     }
 
-    fn runtime_config_reused_key<T: Factor>(key: impl Into<String>) -> Self {
+    pub fn runtime_config_reused_key<T: Factor>(key: impl Into<String>) -> Self {
         Self::RuntimeConfigReusedKey {
             factor: std::any::type_name::<T>(),
             key: key.into(),
@@ -95,9 +95,4 @@ impl Error {
         let factor = std::any::type_name::<T>();
         Self::FactorBuildError { factor, source }
     }
-}
-
-#[doc(hidden)]
-pub mod __internal {
-    pub use crate::runtime_config::RuntimeConfigTracker;
 }

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -22,6 +22,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("two or more factors share the same type: {0}")]
+    DuplicateFactorTypes(String),
     #[error("factor dependency ordering error: {0}")]
     DependencyOrderingError(String),
     #[error("{factor}::InstanceBuilder::build failed: {source}")]

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -13,7 +13,9 @@ pub use spin_factors_derive::RuntimeFactors;
 pub use crate::{
     factor::{ConfigureAppContext, ConfiguredApp, Factor, FactorInstanceState, InitContext},
     prepare::{FactorInstanceBuilder, InstanceBuilders, PrepareContext, SelfInstanceBuilder},
-    runtime_config::RuntimeConfigSource,
+    runtime_config::{
+        FactorRuntimeConfigSource, RuntimeConfigSource, RuntimeConfigSourceFinalizer,
+    },
     runtime_factors::{RuntimeFactors, RuntimeFactorsInstanceState},
 };
 

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -1,6 +1,6 @@
 mod factor;
 mod prepare;
-mod runtime_config;
+pub mod runtime_config;
 mod runtime_factors;
 
 pub use anyhow;

--- a/crates/factors/src/runtime_config.rs
+++ b/crates/factors/src/runtime_config.rs
@@ -1,3 +1,5 @@
+pub mod toml;
+
 use crate::Factor;
 
 /// The source of runtime configuration for a particular [`Factor`].

--- a/crates/factors/src/runtime_config.rs
+++ b/crates/factors/src/runtime_config.rs
@@ -1,103 +1,17 @@
-use std::collections::HashSet;
-
-use serde::de::DeserializeOwned;
-
-use crate::{Error, Factor};
-
-pub const NO_RUNTIME_CONFIG: &str = "<no runtime config>";
-
-/// FactorRuntimeConfig represents an application's runtime configuration.
-///
-/// Runtime configuration is partitioned, with each partition being the
-/// responsibility of exactly one [`crate::Factor`]. If configuration needs
-/// to be shared between Factors, one Factor can be selected as the owner
-/// and the others will have a dependency relationship with that owner.
-pub trait FactorRuntimeConfig: DeserializeOwned {
-    /// The key used to identify this runtime configuration in a [`RuntimeConfigSource`].
-    const KEY: &'static str;
-}
-
-impl FactorRuntimeConfig for () {
-    const KEY: &'static str = NO_RUNTIME_CONFIG;
-}
+use crate::Factor;
 
 /// The source of runtime configuration for a Factor.
 pub trait RuntimeConfigSource {
-    /// Returns an iterator of factor config keys available in this source.
-    ///
-    /// Should only include keys that have been positively provided and that
-    /// haven't already been parsed by the runtime. A runtime may treat
-    /// unrecognized keys as a warning or error.
-    fn factor_config_keys(&self) -> impl IntoIterator<Item = &str>;
-
     /// Returns deserialized runtime config of the given type for the given
     /// factor config key.
     ///
     /// Returns Ok(None) if no configuration is available for the given key.
     /// Returns Err if configuration is available but deserialization fails.
-    fn get_factor_config<T: DeserializeOwned>(&self, key: &str) -> anyhow::Result<Option<T>>;
+    fn get_factor_config<F: Factor>(&self) -> anyhow::Result<Option<F::RuntimeConfig>>;
 }
 
 impl RuntimeConfigSource for () {
-    fn get_factor_config<T: DeserializeOwned>(
-        &self,
-        _factor_config_key: &str,
-    ) -> anyhow::Result<Option<T>> {
+    fn get_factor_config<F: Factor>(&self) -> anyhow::Result<Option<F::RuntimeConfig>> {
         Ok(None)
-    }
-
-    fn factor_config_keys(&self) -> impl IntoIterator<Item = &str> {
-        std::iter::empty()
-    }
-}
-
-/// Tracks runtime configuration keys used by the runtime.
-///
-/// This ensures that the runtime config source does not have any unused keys.
-#[doc(hidden)]
-pub struct RuntimeConfigTracker<S> {
-    source: S,
-    used_keys: HashSet<&'static str>,
-    unused_keys: HashSet<String>,
-}
-
-impl<S: RuntimeConfigSource> RuntimeConfigTracker<S> {
-    #[doc(hidden)]
-    pub fn new(source: S) -> Self {
-        let unused_keys = source
-            .factor_config_keys()
-            .into_iter()
-            .map(ToOwned::to_owned)
-            .collect();
-        Self {
-            source,
-            used_keys: Default::default(),
-            unused_keys,
-        }
-    }
-
-    #[doc(hidden)]
-    pub fn validate_all_keys_used(self) -> crate::Result<()> {
-        if !self.unused_keys.is_empty() {
-            return Err(Error::RuntimeConfigUnusedKeys {
-                keys: self.unused_keys.into_iter().collect(),
-            });
-        }
-        Ok(())
-    }
-
-    /// Get the runtime configuration for a factor.
-    pub(crate) fn get_config<F: Factor>(&mut self) -> crate::Result<Option<F::RuntimeConfig>> {
-        let key = F::RuntimeConfig::KEY;
-        if key == NO_RUNTIME_CONFIG {
-            return Ok(None);
-        }
-        if !self.used_keys.insert(key) {
-            return Err(Error::runtime_config_reused_key::<F>(key));
-        }
-        self.unused_keys.remove(key);
-        self.source
-            .get_factor_config::<F::RuntimeConfig>(key)
-            .map_err(Error::RuntimeConfigSource)
     }
 }

--- a/crates/factors/src/runtime_config.rs
+++ b/crates/factors/src/runtime_config.rs
@@ -1,19 +1,5 @@
 use crate::Factor;
 
-/// The source of runtime configuration for a [`RuntimeFactors`][crate::RuntimeFactors].
-pub trait RuntimeConfigSource<C> {
-    /// Get the runtime configuration for all the factors.
-    ///
-    /// This will be called once per call to [`RuntimeFactors::configure_app`][crate::RuntimeFactors::configure_app].
-    fn get_factor_configs(&mut self) -> anyhow::Result<C>;
-}
-
-impl RuntimeConfigSource<()> for () {
-    fn get_factor_configs(&mut self) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-
 /// The source of runtime configuration for a particular [`Factor`].
 pub trait FactorRuntimeConfigSource<F: Factor> {
     /// Get the runtime configuration for the factor.

--- a/crates/factors/src/runtime_config/toml.rs
+++ b/crates/factors/src/runtime_config/toml.rs
@@ -1,0 +1,50 @@
+//! Helpers for reading runtime configuration from a TOML file.
+
+use std::{cell::RefCell, collections::HashSet};
+
+/// A trait for getting a TOML value by key.
+pub trait GetTomlValue {
+    fn get(&self, key: &str) -> Option<&toml::Value>;
+}
+
+/// A helper for tracking which keys have been used in a TOML table.
+pub struct TomlKeyTracker<'a> {
+    unused_keys: RefCell<HashSet<&'a str>>,
+    table: &'a toml::Table,
+}
+
+impl<'a> TomlKeyTracker<'a> {
+    pub fn new(table: &'a toml::Table) -> Self {
+        Self {
+            unused_keys: RefCell::new(table.keys().map(String::as_str).collect()),
+            table,
+        }
+    }
+
+    pub fn validate_all_keys_used(&self) -> crate::Result<()> {
+        if !self.unused_keys.borrow().is_empty() {
+            return Err(crate::Error::RuntimeConfigUnusedKeys {
+                keys: self
+                    .unused_keys
+                    .borrow()
+                    .iter()
+                    .map(|s| (*s).to_owned())
+                    .collect(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl GetTomlValue for TomlKeyTracker<'_> {
+    fn get(&self, key: &str) -> Option<&toml::Value> {
+        self.unused_keys.borrow_mut().remove(key);
+        self.table.get(key)
+    }
+}
+
+impl AsRef<toml::Table> for TomlKeyTracker<'_> {
+    fn as_ref(&self) -> &toml::Table {
+        self.table
+    }
+}

--- a/crates/factors/src/runtime_factors.rs
+++ b/crates/factors/src/runtime_factors.rs
@@ -1,6 +1,6 @@
 use wasmtime::component::{Linker, ResourceTable};
 
-use crate::{factor::FactorInstanceState, App, ConfiguredApp, Factor, RuntimeConfigSource};
+use crate::{factor::FactorInstanceState, App, ConfiguredApp, Factor};
 
 /// A collection of `Factor`s that are initialized and configured together.
 ///
@@ -53,7 +53,7 @@ pub trait RuntimeFactors: Sized + 'static {
     fn configure_app(
         &self,
         app: App,
-        runtime_config: impl RuntimeConfigSource<Self::RuntimeConfig>,
+        runtime_config: Self::RuntimeConfig,
     ) -> crate::Result<ConfiguredApp<Self>>;
 
     /// Prepare the factors' instance state builders.

--- a/crates/factors/src/runtime_factors.rs
+++ b/crates/factors/src/runtime_factors.rs
@@ -37,6 +37,8 @@ pub trait RuntimeFactors: Sized + 'static {
     type InstanceState: RuntimeFactorsInstanceState;
     /// The collection of all the `InstanceBuilder`s of the factors.
     type InstanceBuilders;
+    /// TODO
+    type RuntimeConfig;
 
     /// Initialize the factors with the given linker.
     ///
@@ -51,7 +53,7 @@ pub trait RuntimeFactors: Sized + 'static {
     fn configure_app(
         &self,
         app: App,
-        runtime_config: impl RuntimeConfigSource,
+        runtime_config: impl RuntimeConfigSource<Self::RuntimeConfig>,
     ) -> crate::Result<ConfiguredApp<Self>>;
 
     /// Prepare the factors' instance state builders.

--- a/crates/factors/src/runtime_factors.rs
+++ b/crates/factors/src/runtime_factors.rs
@@ -37,7 +37,7 @@ pub trait RuntimeFactors: Sized + 'static {
     type InstanceState: RuntimeFactorsInstanceState;
     /// The collection of all the `InstanceBuilder`s of the factors.
     type InstanceBuilders;
-    /// TODO
+    /// The runtime configuration of all the factors.
     type RuntimeConfig;
 
     /// Initialize the factors with the given linker.

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -61,7 +61,7 @@ async fn smoke_test_works() -> anyhow::Result<()> {
         key_value: KeyValueFactor::new(key_value_resolver),
     };
 
-    factors.variables.add_provider_type(StaticVariables)?;
+    factors.variables.add_provider_resolver(StaticVariables)?;
 
     let locked = spin_loader::from_file(
         "tests/smoke-app/spin.toml",
@@ -83,7 +83,7 @@ async fn smoke_test_works() -> anyhow::Result<()> {
     assert_eq!(
         state
             .variables
-            .resolver()
+            .expression_resolver()
             .resolve("smoke-app", "other".try_into().unwrap())
             .await
             .unwrap(),

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -11,7 +11,7 @@ use spin_factor_key_value_redis::RedisKeyValueStore;
 use spin_factor_key_value_spin::{SpinKeyValueRuntimeConfig, SpinKeyValueStore};
 use spin_factor_outbound_http::OutboundHttpFactor;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
-use spin_factor_variables::{StaticVariables, VariablesFactor};
+use spin_factor_variables::{spin_cli::StaticVariables, VariablesFactor};
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
 use spin_factors::{FactorRuntimeConfig, RuntimeConfigSource, RuntimeFactors};
 use wasmtime_wasi_http::WasiHttpView;
@@ -19,7 +19,7 @@ use wasmtime_wasi_http::WasiHttpView;
 #[derive(RuntimeFactors)]
 struct Factors {
     wasi: WasiFactor,
-    variables: VariablesFactor,
+    variables: VariablesFactor<spin_factor_variables::spin_cli::VariableProviderConfiguration>,
     outbound_networking: OutboundNetworkingFactor,
     outbound_http: OutboundHttpFactor,
     key_value: KeyValueFactor<DelegatingRuntimeConfigResolver>,
@@ -142,7 +142,7 @@ struct TestSource;
 
 impl RuntimeConfigSource for TestSource {
     fn factor_config_keys(&self) -> impl IntoIterator<Item = &str> {
-        [spin_factor_variables::RuntimeConfig::KEY]
+        [spin_factor_variables::RuntimeConfig::<()>::KEY]
     }
 
     fn get_factor_config<T: serde::de::DeserializeOwned>(

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -13,7 +13,7 @@ use spin_factor_outbound_http::OutboundHttpFactor;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factor_variables::{spin_cli::StaticVariables, VariablesFactor};
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
-use spin_factors::{FactorRuntimeConfig, RuntimeConfigSource, RuntimeFactors};
+use spin_factors::RuntimeFactors;
 use wasmtime_wasi_http::WasiHttpView;
 
 #[derive(RuntimeFactors)]

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -11,15 +11,20 @@ use spin_factor_key_value_redis::RedisKeyValueStore;
 use spin_factor_key_value_spin::{SpinKeyValueRuntimeConfig, SpinKeyValueStore};
 use spin_factor_outbound_http::OutboundHttpFactor;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
-use spin_factor_variables::{spin_cli::StaticVariables, VariablesFactor};
+use spin_factor_variables::{
+    spin_cli::{StaticVariables, VariableProviderConfiguration},
+    VariablesFactor,
+};
 use spin_factor_wasi::{DummyFilesMounter, WasiFactor};
-use spin_factors::RuntimeFactors;
+use spin_factors::{
+    Factor, FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer, RuntimeFactors,
+};
 use wasmtime_wasi_http::WasiHttpView;
 
 #[derive(RuntimeFactors)]
 struct Factors {
     wasi: WasiFactor,
-    variables: VariablesFactor<spin_factor_variables::spin_cli::VariableProviderConfiguration>,
+    variables: VariablesFactor<VariableProviderConfiguration>,
     outbound_networking: OutboundNetworkingFactor,
     outbound_http: OutboundHttpFactor,
     key_value: KeyValueFactor<DelegatingRuntimeConfigResolver>,
@@ -76,7 +81,7 @@ async fn smoke_test_works() -> anyhow::Result<()> {
 
     factors.init(&mut linker)?;
 
-    let configured_app = factors.configure_app(app, TestSource)?;
+    let configured_app = factors.configure_app(app, TestSource.try_into()?)?;
     let builders = factors.prepare(&configured_app, "smoke-app")?;
     let state = factors.build_instance_state(builders)?;
 
@@ -140,29 +145,74 @@ async fn smoke_test_works() -> anyhow::Result<()> {
 
 struct TestSource;
 
-impl RuntimeConfigSource for TestSource {
-    fn factor_config_keys(&self) -> impl IntoIterator<Item = &str> {
-        [spin_factor_variables::RuntimeConfig::<()>::KEY]
-    }
+impl TryFrom<TestSource> for FactorsRuntimeConfig {
+    type Error = anyhow::Error;
 
-    fn get_factor_config<T: serde::de::DeserializeOwned>(
-        &self,
-        key: &str,
-    ) -> anyhow::Result<Option<T>> {
-        let Some(table) = toml::toml! {
+    fn try_from(value: TestSource) -> Result<Self, Self::Error> {
+        Self::from_source(value)
+    }
+}
+
+impl FactorRuntimeConfigSource<KeyValueFactor<DelegatingRuntimeConfigResolver>> for TestSource {
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<
+        Option<<KeyValueFactor<DelegatingRuntimeConfigResolver> as Factor>::RuntimeConfig>,
+    > {
+        let config = toml::toml! {
+            [other]
+            type = "redis"
+            url = "redis://localhost:6379"
+        };
+
+        Ok(Some(config.try_into()?))
+    }
+}
+
+impl FactorRuntimeConfigSource<VariablesFactor<VariableProviderConfiguration>> for TestSource {
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<
+        Option<<VariablesFactor<VariableProviderConfiguration> as Factor>::RuntimeConfig>,
+    > {
+        let config = toml::toml! {
             [[variable_provider]]
             type = "static"
             [variable_provider.values]
             foo = "bar"
-
-            [key_value_store.other]
-            type = "redis"
-            url = "redis://localhost:6379"
         }
-        .remove(key) else {
-            return Ok(None);
-        };
-        let config = table.try_into()?;
-        Ok(Some(config))
+        .remove("variable_provider")
+        .unwrap();
+        Ok(Some(config.try_into()?))
+    }
+}
+
+impl FactorRuntimeConfigSource<WasiFactor> for TestSource {
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<Option<<WasiFactor as Factor>::RuntimeConfig>> {
+        Ok(None)
+    }
+}
+
+impl FactorRuntimeConfigSource<OutboundNetworkingFactor> for TestSource {
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<Option<<OutboundNetworkingFactor as Factor>::RuntimeConfig>> {
+        Ok(None)
+    }
+}
+
+impl FactorRuntimeConfigSource<OutboundHttpFactor> for TestSource {
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<Option<<OutboundHttpFactor as Factor>::RuntimeConfig>> {
+        Ok(None)
+    }
+}
+
+impl RuntimeConfigSourceFinalizer for TestSource {
+    fn finalize(&mut self) -> anyhow::Result<()> {
+        Ok(())
     }
 }

--- a/crates/factors/tests/smoke.rs
+++ b/crates/factors/tests/smoke.rs
@@ -74,7 +74,7 @@ async fn smoke_test_works() -> anyhow::Result<()> {
     let engine = wasmtime::Engine::new(wasmtime::Config::new().async_support(true))?;
     let mut linker = wasmtime::component::Linker::new(&engine);
 
-    factors.init(&mut linker).unwrap();
+    factors.init(&mut linker)?;
 
     let configured_app = factors.configure_app(app, TestSource)?;
     let builders = factors.prepare(&configured_app, "smoke-app")?;


### PR DESCRIPTION
This change makes runtime config completely independent of how (or even if) it is serialized. The advantage of this is that we are no longer imposing toml of runtimes while still providing convenient handling of toml for runtimes that want to handle runtime config with toml. 

`RuntimeFactors` gains an associated type `RuntimeConfig` which is passed directly to `RuntimeFactors::configure_app`. The derive macro ensures that this `RuntimeConfig` type implements `FactorRuntimeConfigSource<F> where F: Factor` for every factor in the `RuntimeFactors` collection. This works out that the runtime embedder then can implement `FactorRuntimeConfigSource<F>` for each of the factors they use. 

I recommend checking out the tests and the smoke test for how this works in practice. 