### PR TITLE
Run v0.1.0 of the conformance tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?rev=d2129a3fd73140a76c77f15a030a5273b37cbd11#d2129a3fd73140a76c77f15a030a5273b37cbd11"
+source = "git+https://github.com/fermyon/conformance-tests?rev=387b7f375df59e6254a7c29cf4a53507a9f46d32#387b7f375df59e6254a7c29cf4a53507a9f46d32"
 dependencies = [
  "anyhow",
  "flate2",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?rev=d2129a3fd73140a76c77f15a030a5273b37cbd11#d2129a3fd73140a76c77f15a030a5273b37cbd11"
+source = "git+https://github.com/fermyon/conformance-tests?rev=387b7f375df59e6254a7c29cf4a53507a9f46d32#387b7f375df59e6254a7c29cf4a53507a9f46d32"
 dependencies = [
  "anyhow",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,8 @@ redis = "0.24"
 runtime-tests = { path = "tests/runtime-tests" }
 test-components = { path = "tests/test-components" }
 test-codegen-macro = { path = "crates/test-codegen-macro" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
-conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
+test-environment = { workspace = true }
+conformance-tests = { workspace = true }
 conformance = { path = "tests/conformance-tests" }
 
 [build-dependencies]
@@ -135,6 +135,8 @@ http-body-util = "0.1.0"
 hyper = { version = "1.0.0", features = ["full"] }
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
 tracing = { version = "0.1", features = ["log"] }
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
 
 wasi-common-preview1 = { version = "22.0.0", package = "wasi-common", features = [
   "tokio",

--- a/tests/conformance-tests/Cargo.toml
+++ b/tests/conformance-tests/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1.0"
 testing-framework = { path = "../testing-framework" }
-conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
+conformance-tests = { workspace = true }
+test-environment = { workspace = true }
 
 [lints]
 workspace = true

--- a/tests/conformance-tests/src/main.rs
+++ b/tests/conformance-tests/src/main.rs
@@ -3,5 +3,8 @@ fn main() {
         .nth(1)
         .expect("expected first argument to be path to spin binary")
         .into();
-    conformance_tests::run_tests(move |test| conformance::run_test(test, &spin_binary)).unwrap();
+    conformance_tests::run_tests("v0.1.0", move |test| {
+        conformance::run_test(test, &spin_binary)
+    })
+    .unwrap();
 }

--- a/tests/runtime-tests/Cargo.toml
+++ b/tests/runtime-tests/Cargo.toml
@@ -13,5 +13,5 @@ anyhow = "1.0"
 env_logger = "0.10.0"
 log = "0.4"
 testing-framework = { path = "../testing-framework" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
+test-environment = { workspace = true }
 test-components = { path = "../test-components" }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -28,8 +28,10 @@ mod runtime_tests {
 
     #[test]
     fn conformance_tests() {
-        conformance_tests::run_tests(move |test| conformance::run_test(test, &spin_binary()))
-            .unwrap();
+        conformance_tests::run_tests("v0.1.0", move |test| {
+            conformance::run_test(test, &spin_binary())
+        })
+        .unwrap();
     }
 
     fn spin_binary() -> PathBuf {

--- a/tests/testing-framework/Cargo.toml
+++ b/tests/testing-framework/Cargo.toml
@@ -13,7 +13,7 @@ nix = "0.26.1"
 regex = "1.10.2"
 reqwest = { workspace = true }
 temp-dir = "0.1.11"
-test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "d2129a3fd73140a76c77f15a030a5273b37cbd11" }
+test-environment = { workspace = true }
 spin-trigger-http = { path = "../../crates/trigger-http" }
 spin-http = { path = "../../crates/http" }
 spin-trigger = { path = "../../crates/trigger" }


### PR DESCRIPTION
This allows us to evolve the conformance tests without immediately breaking Spin CI.