### PR TITLE
feat(docker): add spin cli Dockerfiles; add build/push to release.yml

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  git
+
+ARG TARGETARCH
+ARG TARGETOS
+COPY spin-${TARGETOS}-${TARGETARCH} /usr/local/bin/spin
+
+ENTRYPOINT [ "/usr/local/bin/spin" ]

--- a/.github/distroless.Dockerfile
+++ b/.github/distroless.Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/distroless/static-debian12
+
+ARG TARGETARCH
+ARG TARGETOS
+COPY spin-static-${TARGETOS}-${TARGETARCH} /usr/local/bin/spin
+
+ENTRYPOINT [ "/usr/local/bin/spin" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,3 +380,80 @@ jobs:
           repository: fermyon/homebrew-tap
           event-type: spin-release
           client-payload: '{"version": "${{ github.ref_name }}"}'
+
+  docker:
+    runs-on: "ubuntu-20.04"
+    needs: [build-and-sign, build-spin-static]
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    strategy:
+      matrix:
+        config:
+          - { dockerfile: "Dockerfile", tag-suffix: "" }
+          - { dockerfile: "distroless.Dockerfile", tag-suffix: "-distroless" }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup version info
+        id: version
+        run: |
+          if [[ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=canary" >> $GITHUB_OUTPUT
+          fi
+
+      - name: download release assets
+        uses: actions/download-artifact@v3
+        with:
+          name: spin
+
+      - name: extract binaries
+        shell: bash
+        run: |
+          if [[ "${{ matrix.config.tag-suffix }}" == "-distroless" ]]; then
+            static="-static"
+          fi
+          tar xvf spin-${{ steps.version.outputs.version }}${static}-linux-amd64.tar.gz
+          mv spin spin${static}-linux-amd64
+          tar xvf spin-${{ steps.version.outputs.version }}${static}-linux-aarch64.tar.gz
+          # Note: here we s/aarch64/arm64 to conform to Docker's TARGETARCH standards
+          mv spin spin${static}-linux-arm64
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/${{ matrix.config.dockerfile }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}${{ matrix.config.tag-suffix }}


### PR DESCRIPTION
Adds Dockerfiles/CI for producing images wrapping the spin CLI on releases.  These may be generally useful but were recently motivated by utilization in SpinKube.  See https://github.com/fermyon/spin/issues/2677 for further motivation/discussion.

On a Spin release, the default image, eg `ghcr.io/fermyon/spin:v2.8.0`, has a Debian base (currently `bookworm-slim`) and includes the standard, dynamically-linked Spin binary, with a few utilities to enable further extension if desired (eg installing plugins).  A smaller, distroless image is also produced, eg `ghcr.io/fermyon/spin:v2.8.0-distroless`, which bundles a statically-linked Spin binary for purposes when, say, only `spin up --from ...` is needed and further extensibility isn't required.

Here I've opted to pull in binaries built in the previous build steps, as opposed to attempting to (re)-run the build in the container itself.  This cuts out potential headaches of debugging failed Docker builds and repurposes the same artifacts that are installed/run directly (sans container).

Closes https://github.com/fermyon/spin/issues/2677