### PR TITLE
No connection reuse in SQLite Factor

### DIFF
--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -46,9 +46,9 @@ impl Factor for SqliteFactor {
         &self,
         mut ctx: spin_factors::ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
-        let connection_pools = ctx
+        let connection_creators = ctx
             .take_runtime_config()
-            .map(|r| r.pools)
+            .map(|r| r.connection_creators)
             .unwrap_or_default();
 
         let allowed_databases = ctx
@@ -68,20 +68,20 @@ impl Factor for SqliteFactor {
             })
             .collect::<anyhow::Result<HashMap<_, _>>>()?;
         let resolver = self.default_label_resolver.clone();
-        let get_connection_pool: host::ConnectionPoolGetter = Arc::new(move |label| {
-            connection_pools
+        let get_connection_creator: host::ConnectionCreatorGetter = Arc::new(move |label| {
+            connection_creators
                 .get(label)
                 .cloned()
                 .or_else(|| resolver.default(label))
         });
 
         ensure_allowed_databases_are_configured(&allowed_databases, |label| {
-            get_connection_pool(label).is_some()
+            get_connection_creator(label).is_some()
         })?;
 
         Ok(AppState {
             allowed_databases,
-            get_connection_pool,
+            get_connection_creator,
         })
     }
 
@@ -96,8 +96,11 @@ impl Factor for SqliteFactor {
             .get(ctx.app_component().id())
             .cloned()
             .unwrap_or_default();
-        let get_connection_pool = ctx.app_state().get_connection_pool.clone();
-        Ok(InstanceState::new(allowed_databases, get_connection_pool))
+        let get_connection_creator = ctx.app_state().get_connection_creator.clone();
+        Ok(InstanceState::new(
+            allowed_databases,
+            get_connection_creator,
+        ))
     }
 }
 
@@ -136,45 +139,47 @@ fn ensure_allowed_databases_are_configured(
 
 pub const ALLOWED_DATABASES_KEY: MetadataKey<Vec<String>> = MetadataKey::new("databases");
 
-/// Resolves a label to a default connection pool.
+/// Resolves a label to a default connection creator.
 pub trait DefaultLabelResolver: Send + Sync {
-    /// If there is no runtime configuration for a given database label, return a default connection pool.
+    /// If there is no runtime configuration for a given database label, return a default connection creator.
     ///
     /// If `Option::None` is returned, the database is not allowed.
-    fn default(&self, label: &str) -> Option<Arc<dyn ConnectionPool>>;
+    fn default(&self, label: &str) -> Option<Arc<dyn ConnectionCreator>>;
 }
 
 pub struct AppState {
     /// A map from component id to a set of allowed database labels.
     allowed_databases: HashMap<String, Arc<HashSet<String>>>,
-    /// A function for mapping from database name to a connection pool
-    get_connection_pool: host::ConnectionPoolGetter,
+    /// A function for mapping from database name to a connection creator.
+    get_connection_creator: host::ConnectionCreatorGetter,
 }
 
-/// A pool of connections for a particular SQLite database
+/// A creator of a connections for a particular SQLite database.
 #[async_trait]
-pub trait ConnectionPool: Send + Sync {
-    /// Get a `Connection` from the pool
-    async fn get_connection(&self) -> Result<Arc<dyn Connection + 'static>, v2::Error>;
+pub trait ConnectionCreator: Send + Sync {
+    /// Get a *new* [`Connection`]
+    ///
+    /// The connection should be a new connection, not a reused one.
+    async fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error>;
 }
 
-/// A simple [`ConnectionPool`] that always creates a new connection.
-pub struct SimpleConnectionPool(
-    Box<dyn Fn() -> anyhow::Result<Arc<dyn Connection + 'static>> + Send + Sync>,
+/// A simple [`ConnectionCreator`] that delegates to a function.
+pub struct FunctionConnectionCreator(
+    Box<dyn Fn() -> anyhow::Result<Box<dyn Connection + 'static>> + Send + Sync>,
 );
 
-impl SimpleConnectionPool {
-    /// Create a new `SimpleConnectionPool` with the given connection factory.
+impl FunctionConnectionCreator {
+    /// Create a new [`FunctionConnectionCreator`] with the given connection factory function.
     pub fn new(
-        factory: impl Fn() -> anyhow::Result<Arc<dyn Connection + 'static>> + Send + Sync + 'static,
+        factory: impl Fn() -> anyhow::Result<Box<dyn Connection + 'static>> + Send + Sync + 'static,
     ) -> Self {
         Self(Box::new(factory))
     }
 }
 
 #[async_trait::async_trait]
-impl ConnectionPool for SimpleConnectionPool {
-    async fn get_connection(&self) -> Result<Arc<dyn Connection + 'static>, v2::Error> {
+impl ConnectionCreator for FunctionConnectionCreator {
+    async fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error> {
         (self.0)().map_err(|_| v2::Error::InvalidConnection)
     }
 }

--- a/crates/factor-sqlite/src/runtime_config.rs
+++ b/crates/factor-sqlite/src/runtime_config.rs
@@ -3,11 +3,11 @@ pub mod spin;
 
 use std::{collections::HashMap, sync::Arc};
 
-use crate::ConnectionPool;
+use crate::ConnectionCreator;
 
 /// A runtime configuration for SQLite databases.
 ///
-/// Maps database labels to connection pools.
+/// Maps database labels to connection creators.
 pub struct RuntimeConfig {
-    pub pools: HashMap<String, Arc<dyn ConnectionPool>>,
+    pub connection_creators: HashMap<String, Arc<dyn ConnectionCreator>>,
 }

--- a/crates/factor-sqlite/src/runtime_config/spin.rs
+++ b/crates/factor-sqlite/src/runtime_config/spin.rs
@@ -13,7 +13,7 @@ use spin_factors::{
 use spin_world::v2::sqlite as v2;
 use tokio::sync::OnceCell;
 
-use crate::{Connection, ConnectionCreator, DefaultLabelResolver, FunctionConnectionCreator};
+use crate::{Connection, ConnectionCreator, DefaultLabelResolver};
 
 /// Spin's default handling of the runtime configuration for SQLite databases.
 ///
@@ -66,30 +66,34 @@ impl SpinSqliteRuntimeConfig {
             return Ok(None);
         };
         let config: std::collections::HashMap<String, RuntimeConfig> = table.clone().try_into()?;
-        let pools = config
+        let connection_creators = config
             .into_iter()
-            .map(|(k, v)| Ok((k, self.get_pool(v)?)))
+            .map(|(k, v)| Ok((k, self.get_connection_creator(v)?)))
             .collect::<anyhow::Result<_>>()?;
         Ok(Some(super::RuntimeConfig {
-            connection_creators: pools,
+            connection_creators,
         }))
     }
 
-    /// Get a connection pool for a given runtime configuration.
-    pub fn get_pool(&self, config: RuntimeConfig) -> anyhow::Result<Arc<dyn ConnectionCreator>> {
+    /// Get a connection creator for a given runtime configuration.
+    pub fn get_connection_creator(
+        &self,
+        config: RuntimeConfig,
+    ) -> anyhow::Result<Arc<dyn ConnectionCreator>> {
         let database_kind = config.type_.as_str();
-        let pool = match database_kind {
+        match database_kind {
             "spin" => {
                 let config: LocalDatabase = config.config.try_into()?;
-                config.pool(&self.local_database_dir)?
+                Ok(Arc::new(
+                    config.connection_creator(&self.local_database_dir)?,
+                ))
             }
             "libsql" => {
                 let config: LibSqlDatabase = config.config.try_into()?;
-                config.pool()?
+                Ok(Arc::new(config.connection_creator()?))
             }
             _ => anyhow::bail!("Unknown database kind: {database_kind}"),
-        };
-        Ok(Arc::new(pool))
+        }
     }
 }
 
@@ -114,8 +118,7 @@ impl DefaultLabelResolver for SpinSqliteRuntimeConfig {
             let connection = spin_sqlite_inproc::InProcConnection::new(location)?;
             Ok(Box::new(connection) as _)
         };
-        let pool = FunctionConnectionCreator::new(factory);
-        Some(Arc::new(pool))
+        Some(Arc::new(factory))
     }
 }
 
@@ -198,10 +201,10 @@ pub struct LocalDatabase {
 }
 
 impl LocalDatabase {
-    /// Create a new connection pool for a local database.
+    /// Get a new connection creator for a local database.
     ///
     /// `base_dir` is the base directory path from which `path` is resolved if it is a relative path.
-    fn pool(self, base_dir: &Path) -> anyhow::Result<FunctionConnectionCreator> {
+    fn connection_creator(self, base_dir: &Path) -> anyhow::Result<impl ConnectionCreator> {
         let location = match self.path {
             Some(path) => {
                 let path = resolve_relative_path(&path, base_dir);
@@ -217,7 +220,7 @@ impl LocalDatabase {
             let connection = spin_sqlite_inproc::InProcConnection::new(location.clone())?;
             Ok(Box::new(connection) as _)
         };
-        Ok(FunctionConnectionCreator::new(factory))
+        Ok(factory)
     }
 }
 
@@ -240,8 +243,8 @@ pub struct LibSqlDatabase {
 }
 
 impl LibSqlDatabase {
-    /// Create a new connection pool for a libSQL database.
-    fn pool(self) -> anyhow::Result<FunctionConnectionCreator> {
+    /// Get a new connection creator for a libSQL database.
+    fn connection_creator(self) -> anyhow::Result<impl ConnectionCreator> {
         let url = check_url(&self.url)
             .with_context(|| {
                 format!(
@@ -254,7 +257,7 @@ impl LibSqlDatabase {
             let connection = LibSqlConnection::new(url.clone(), self.token.clone());
             Ok(Box::new(connection) as _)
         };
-        Ok(FunctionConnectionCreator::new(factory))
+        Ok(factory)
     }
 }
 

--- a/crates/factor-sqlite/tests/factor_test.rs
+++ b/crates/factor-sqlite/tests/factor_test.rs
@@ -130,7 +130,7 @@ impl DefaultLabelResolver {
 }
 
 impl factor_sqlite::DefaultLabelResolver for DefaultLabelResolver {
-    fn default(&self, label: &str) -> Option<Arc<dyn factor_sqlite::ConnectionPool>> {
+    fn default(&self, label: &str) -> Option<Arc<dyn factor_sqlite::ConnectionCreator>> {
         let Some(default) = &self.default else {
             return None;
         };
@@ -142,8 +142,8 @@ impl factor_sqlite::DefaultLabelResolver for DefaultLabelResolver {
 struct InvalidConnectionPool;
 
 #[async_trait::async_trait]
-impl factor_sqlite::ConnectionPool for InvalidConnectionPool {
-    async fn get_connection(
+impl factor_sqlite::ConnectionCreator for InvalidConnectionPool {
+    async fn create_connection(
         &self,
     ) -> Result<Arc<dyn factor_sqlite::Connection + 'static>, spin_world::v2::sqlite::Error> {
         Err(spin_world::v2::sqlite::Error::InvalidConnection)

--- a/crates/factor-sqlite/tests/factor_test.rs
+++ b/crates/factor-sqlite/tests/factor_test.rs
@@ -116,7 +116,7 @@ impl TryFrom<TomlRuntimeSource<'_>> for TestFactorsRuntimeConfig {
     }
 }
 
-/// Will return an `InvalidConnectionPool` for the supplied default database.
+/// Will return an `InvalidConnectionCreator` for the supplied default database.
 struct DefaultLabelResolver {
     default: Option<String>,
 }
@@ -134,18 +134,18 @@ impl factor_sqlite::DefaultLabelResolver for DefaultLabelResolver {
         let Some(default) = &self.default else {
             return None;
         };
-        (default == label).then_some(Arc::new(InvalidConnectionPool))
+        (default == label).then_some(Arc::new(InvalidConnectionCreator))
     }
 }
 
-/// A connection pool that always returns an error.
-struct InvalidConnectionPool;
+/// A connection creator that always returns an error.
+struct InvalidConnectionCreator;
 
 #[async_trait::async_trait]
-impl factor_sqlite::ConnectionCreator for InvalidConnectionPool {
+impl factor_sqlite::ConnectionCreator for InvalidConnectionCreator {
     async fn create_connection(
         &self,
-    ) -> Result<Arc<dyn factor_sqlite::Connection + 'static>, spin_world::v2::sqlite::Error> {
+    ) -> Result<Box<dyn factor_sqlite::Connection + 'static>, spin_world::v2::sqlite::Error> {
         Err(spin_world::v2::sqlite::Error::InvalidConnection)
     }
 }


### PR DESCRIPTION
*Paired with @karthik2804*

Per #2705, we don't want connection reuse across instances. Factors technically already fixes this issue, but it was not obvious at first due to some type and naming choices (e.g., the use of the term "pool" when connections were not actually pooled). This changes those type and naming choices to make it clear that connections are not reused across instances. 