### PR TITLE
Factors RuntimeConfig Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8451,6 +8451,7 @@ dependencies = [
  "spin-factors-executor",
  "spin-telemetry",
  "tokio",
+ "toml 0.8.14",
  "tracing",
 ]
 

--- a/crates/trigger2/Cargo.toml
+++ b/crates/trigger2/Cargo.toml
@@ -24,6 +24,7 @@ spin-factors = { path = "../factors" }
 spin-factors-executor = { path = "../factors-executor" }
 spin-telemetry = { path = "../telemetry" }
 tokio = { version = "1.23", features = ["fs"] }
+toml = "0.8"
 tracing = { workspace = true }
 
 [lints]

--- a/crates/trigger2/src/lib.rs
+++ b/crates/trigger2/src/lib.rs
@@ -8,6 +8,7 @@ use spin_factors_executor::{FactorsExecutorApp, FactorsInstanceBuilder};
 
 pub mod cli;
 mod factors;
+mod runtime_config;
 mod stdio;
 
 /// Type alias for a [`FactorsConfiguredApp`] specialized to a [`Trigger`].

--- a/crates/trigger2/src/runtime_config.rs
+++ b/crates/trigger2/src/runtime_config.rs
@@ -1,0 +1,39 @@
+use spin_factor_wasi::WasiFactor;
+use spin_factors::{
+    runtime_config::toml::TomlKeyTracker, FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer,
+};
+
+use crate::factors::TriggerFactorsRuntimeConfig;
+
+/// A runtime configuration source for the [`TriggerFactors`][crate::TriggerFactors].
+pub struct RuntimeConfigSource<'a> {
+    table: TomlKeyTracker<'a>,
+}
+
+impl<'a> RuntimeConfigSource<'a> {
+    pub fn new(table: &'a toml::Table) -> Self {
+        Self {
+            table: TomlKeyTracker::new(table),
+        }
+    }
+}
+
+impl RuntimeConfigSourceFinalizer for RuntimeConfigSource<'_> {
+    fn finalize(&mut self) -> anyhow::Result<()> {
+        Ok(self.table.validate_all_keys_used()?)
+    }
+}
+
+impl FactorRuntimeConfigSource<WasiFactor> for RuntimeConfigSource<'_> {
+    fn get_runtime_config(&mut self) -> anyhow::Result<Option<()>> {
+        Ok(None)
+    }
+}
+
+impl TryFrom<RuntimeConfigSource<'_>> for TriggerFactorsRuntimeConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RuntimeConfigSource<'_>) -> Result<Self, Self::Error> {
+        Self::from_source(value)
+    }
+}


### PR DESCRIPTION
Adds basic runtime config support to trigger2. 

This won't start to get interesting until we introduce additional factors beyond `WasiFactor` since `WasiFactor` (currently) has no runtime config support itself. I will explore adding an additional factor in a follow up. 