### PR TITLE
simplify break condition for epoch ticker thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7466,7 +7466,6 @@ dependencies = [
  "bytes",
  "cap-primitives 3.0.0",
  "cap-std 3.0.0",
- "crossbeam-channel",
  "futures",
  "http 1.1.0",
  "io-extras",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-crossbeam-channel = "0.5"
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -5735,7 +5735,6 @@ dependencies = [
  "bytes",
  "cap-primitives",
  "cap-std",
- "crossbeam-channel",
  "http 1.1.0",
  "io-extras",
  "rustix 0.37.27",


### PR DESCRIPTION
It seems that the crossbeam channel was just being used as a way to exit the ticker loop. Once the sender was dropped, then try_recv would fail and the loop would break.

However, it also seems, based on the [wasmtime docs](https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html#method.increment_epoch) that just upgrading a weak reference to the Arc should serve roughly the same purpose. Once all references to the Engine are dropped, then the loop should break.

If there was a reason to use a channel here because there are potential references to the Engine Arc I didn't catch in the codebase, then feel free to ignore.

Thanks!
