### PR TITLE
remove *.md docs from gh build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
     branches: ["main", "v*"]
     paths-ignore:
       - "docs/**"
-      - "README.md"
+      - "*.md"
       - "tests/README.md"
 
 # Serialize workflow runs per ref


### PR DESCRIPTION
removes all recently added governance related docs from build as well.