### PR TITLE
set `max_core_instance_size` in pooling config

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -114,9 +114,12 @@ impl Default for Config {
                 .max_component_instance_size(
                     env("SPIN_WASMTIME_INSTANCE_SIZE", (10 * MB) as u32) as usize
                 )
+                .max_core_instance_size(
+                    env("SPIN_WASMTIME_CORE_INSTANCE_SIZE", (10 * MB) as u32) as usize
+                )
                 .max_core_instances_per_component(env("SPIN_WASMTIME_CORE_INSTANCE_COUNT", 200))
                 .max_tables_per_component(env("SPIN_WASMTIME_INSTANCE_TABLES", 20))
-                .table_elements(env("SPIN_WASMTIME_INSTANCE_TABLE_ELEMENTS", 30_000))
+                .table_elements(env("SPIN_WASMTIME_INSTANCE_TABLE_ELEMENTS", 100_000))
                 // The number of memories an instance can have effectively limits the number of inner components
                 // a composed component can have (since each inner component has its own memory). We default to 32 for now, and
                 // we'll see how often this limit gets reached.


### PR DESCRIPTION
...and make it configurable via an environment variable.

Also, increase the `table_elements` default value.

As of this writing, ahead-of-time compiled ASP.NET Core apps require more memory for metadata and larger tables than we had previously anticipated.  This allows them to run.