### PR TITLE
Allow multiple commands in a component build section

### DIFF
--- a/crates/doctor/src/rustlang/target.rs
+++ b/crates/doctor/src/rustlang/target.rs
@@ -19,7 +19,7 @@ impl Diagnostic for TargetDiagnostic {
         let uses_rust = manifest.components.values().any(|c| {
             c.build
                 .as_ref()
-                .map(|b| b.command.starts_with("cargo"))
+                .map(|b| b.commands().any(|c| c.starts_with("cargo")))
                 .unwrap_or_default()
         });
 


### PR DESCRIPTION
So we don't need to resort to `&&` kludges which thwart our Windows users.

(This inspired by e.g. the Leptos template and the Moonbit SDK.)

Syntax:

```
# multiple
[component.motivational.build]
command = [
    "cargo build --target wasm32-wasi --release",
    "echo HUZZAH"
]
watch = ["src/**/*.rs", "Cargo.toml"]

# existing syntax still works
[component.sensible.build]
command = "cargo build --target wasm32-wasi --release"
watch = ["src/**/*.rs", "Cargo.toml"]
```
