### PR TITLE
Fix path handling in sqlite and kv

### DIFF
--- a/crates/factor-key-value/src/runtime_config.rs
+++ b/crates/factor-key-value/src/runtime_config.rs
@@ -13,6 +13,8 @@ pub struct RuntimeConfig {
 
 impl RuntimeConfig {
     /// Adds a store manager for the store with the given label to the runtime configuration.
+    ///
+    /// If a store manager already exists for the given label, it will be replaced.
     pub fn add_store_manager(&mut self, label: String, store_manager: Arc<dyn StoreManager>) {
         self.store_managers.insert(label, store_manager);
     }

--- a/crates/factor-key-value/src/runtime_config/spin.rs
+++ b/crates/factor-key-value/src/runtime_config/spin.rs
@@ -62,8 +62,20 @@ impl RuntimeConfigResolver {
     ///
     /// Users must ensure that the store type for `config` has been registered with
     /// the resolver using [`Self::register_store_type`].
-    pub fn add_default_store(&mut self, label: &'static str, config: StoreConfig) {
-        self.defaults.insert(label, config);
+    pub fn add_default_store<T>(
+        &mut self,
+        label: &'static str,
+        config: T::RuntimeConfig,
+    ) -> anyhow::Result<()>
+    where
+        T: MakeKeyValueStore,
+        T::RuntimeConfig: Serialize,
+    {
+        self.defaults.insert(
+            label,
+            StoreConfig::new(T::RUNTIME_CONFIG_TYPE.to_owned(), config)?,
+        );
+        Ok(())
     }
 
     /// Registers a store type to the resolver.

--- a/crates/factor-key-value/tests/factor_test.rs
+++ b/crates/factor-key-value/tests/factor_test.rs
@@ -1,12 +1,13 @@
-use anyhow::Context;
+use anyhow::Context as _;
 use spin_factor_key_value::{
-    runtime_config::spin::{MakeKeyValueStore, RuntimeConfigResolver, StoreConfig},
+    runtime_config::spin::{MakeKeyValueStore, RuntimeConfigResolver},
     KeyValueFactor, RuntimeConfig,
 };
 use spin_factor_key_value_redis::RedisKeyValueStore;
-use spin_factor_key_value_spin::{SpinKeyValueRuntimeConfig, SpinKeyValueStore};
+use spin_factor_key_value_spin::SpinKeyValueStore;
 use spin_factors::{FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer, RuntimeFactors};
 use spin_factors_test::{toml, TestEnvironment};
+use spin_world::v2::key_value::HostStore;
 use std::{collections::HashSet, sync::Arc};
 
 #[derive(RuntimeFactors)]
@@ -14,25 +15,11 @@ struct TestFactors {
     key_value: KeyValueFactor,
 }
 
-fn default_key_value_resolver() -> anyhow::Result<(RuntimeConfigResolver, tempdir::TempDir)> {
-    let mut test_resolver = RuntimeConfigResolver::new();
-    test_resolver.register_store_type(SpinKeyValueStore::new(
-        std::env::current_dir().context("failed to get current directory")?,
-    ))?;
-    let tmp_dir = tempdir::TempDir::new("example")?;
-    let path = tmp_dir.path().to_path_buf();
-    let default_config = SpinKeyValueRuntimeConfig::default(Some(path));
-    let store_config = StoreConfig::new(
-        SpinKeyValueStore::RUNTIME_CONFIG_TYPE.to_string(),
-        default_config,
-    )?;
-    test_resolver.add_default_store("default", store_config);
-    Ok((test_resolver, tmp_dir))
-}
-
 #[tokio::test]
 async fn default_key_value_works() -> anyhow::Result<()> {
-    let (test_resolver, dir) = default_key_value_resolver()?;
+    let mut test_resolver = RuntimeConfigResolver::new();
+    test_resolver.register_store_type(SpinKeyValueStore::new(None))?;
+    test_resolver.add_default_store::<SpinKeyValueStore>("default", Default::default())?;
     let factors = TestFactors {
         key_value: KeyValueFactor::new(test_resolver),
     };
@@ -47,8 +34,6 @@ async fn default_key_value_works() -> anyhow::Result<()> {
         state.key_value.allowed_stores(),
         &["default".into()].into_iter().collect::<HashSet<_>>()
     );
-    // Ensure the database directory is created
-    assert!(dir.path().exists());
     Ok(())
 }
 
@@ -56,7 +41,7 @@ async fn run_test_with_config_and_stores_for_label(
     runtime_config: Option<toml::Table>,
     store_types: Vec<impl MakeKeyValueStore>,
     labels: Vec<&str>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<TestFactorsInstanceState> {
     let mut test_resolver = RuntimeConfigResolver::new();
     for store_type in store_types {
         test_resolver.register_store_type(store_type)?;
@@ -79,7 +64,7 @@ async fn run_test_with_config_and_stores_for_label(
         state.key_value.allowed_stores().iter().collect::<Vec<_>>()
     );
 
-    Ok(())
+    Ok(state)
 }
 
 #[tokio::test]
@@ -94,7 +79,8 @@ async fn overridden_default_key_value_works() -> anyhow::Result<()> {
         vec![RedisKeyValueStore::new()],
         vec!["default"],
     )
-    .await
+    .await?;
+    Ok(())
 }
 
 #[tokio::test]
@@ -105,52 +91,69 @@ async fn custom_spin_key_value_works() -> anyhow::Result<()> {
     };
     run_test_with_config_and_stores_for_label(
         Some(runtime_config),
-        vec![SpinKeyValueStore::new(
-            std::env::current_dir().context("failed to get current directory")?,
-        )],
+        vec![SpinKeyValueStore::new(None)],
         vec!["custom"],
     )
-    .await
+    .await?;
+    Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn custom_spin_key_value_works_with_absolute_path() -> anyhow::Result<()> {
     let tmp_dir = tempdir::TempDir::new("example")?;
-    let path = tmp_dir.path().join("custom.db");
-    let path_str = path.to_str().unwrap();
+    let db_path = tmp_dir.path().join("foo/custom.db");
+    // Check that the db does not exist yet - it will exist by the end of the test
+    assert!(!db_path.exists());
+
+    let path_str = db_path.to_str().unwrap();
     let runtime_config = toml::toml! {
         [key_value_store.custom]
         type = "spin"
         path = path_str
     };
-    run_test_with_config_and_stores_for_label(
+    let mut state = run_test_with_config_and_stores_for_label(
         Some(runtime_config),
-        vec![SpinKeyValueStore::new(
+        vec![SpinKeyValueStore::new(Some(
             std::env::current_dir().context("failed to get current directory")?,
-        )],
+        ))],
         vec!["custom"],
     )
     .await?;
-    assert!(tmp_dir.path().exists());
+
+    // Actually et a key since store creation is lazy
+    let store = state.key_value.open("custom".to_owned()).await??;
+    let _ = state.key_value.get(store, "foo".to_owned()).await??;
+
+    // Check that the parent has been created
+    assert!(db_path.exists());
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn custom_spin_key_value_works_with_relative_path() -> anyhow::Result<()> {
     let tmp_dir = tempdir::TempDir::new("example")?;
-    let path = tmp_dir.path().to_owned();
+    let db_path = tmp_dir.path().join("custom.db");
+    // Check that the db does not exist yet - it will exist by the end of the test
+    assert!(!db_path.exists());
+
     let runtime_config = toml::toml! {
         [key_value_store.custom]
         type = "spin"
         path = "custom.db"
     };
-    run_test_with_config_and_stores_for_label(
+    let mut state = run_test_with_config_and_stores_for_label(
         Some(runtime_config),
-        vec![SpinKeyValueStore::new(path)],
+        vec![SpinKeyValueStore::new(Some(tmp_dir.path().to_owned()))],
         vec!["custom"],
     )
     .await?;
-    assert!(tmp_dir.path().exists());
+
+    // Actually et a key since store creation is lazy
+    let store = state.key_value.open("custom".to_owned()).await??;
+    let _ = state.key_value.get(store, "foo".to_owned()).await??;
+
+    // Check that the correct store in the config was chosen by verifying the existence of the DB
+    assert!(db_path.exists());
     Ok(())
 }
 
@@ -166,37 +169,55 @@ async fn custom_redis_key_value_works() -> anyhow::Result<()> {
         vec![RedisKeyValueStore::new()],
         vec!["custom"],
     )
-    .await
+    .await?;
+    Ok(())
 }
 
 #[tokio::test]
 async fn misconfigured_spin_key_value_fails() -> anyhow::Result<()> {
+    let tmp_dir = tempdir::TempDir::new("example")?;
     let runtime_config = toml::toml! {
         [key_value_store.custom]
         type = "spin"
         path = "/$$&/bad/path/foo.db"
     };
-    assert!(run_test_with_config_and_stores_for_label(
+    let result = run_test_with_config_and_stores_for_label(
         Some(runtime_config),
-        vec![SpinKeyValueStore::new(
-            std::env::current_dir().context("failed to get current directory")?
-        )],
-        vec!["custom"]
+        vec![SpinKeyValueStore::new(Some(tmp_dir.path().to_owned()))],
+        vec!["custom"],
     )
-    .await
-    .is_err());
+    .await;
+    // TODO(rylev): This only fails on my machine due to a read-only file system error.
+    // We should consider adding a check for the error message.
+    assert!(result.is_err());
     Ok(())
 }
 
-#[tokio::test]
-async fn multiple_custom_key_value_uses_first_store() -> anyhow::Result<()> {
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+// TODO(rylev): consider removing this test as it is really only a consequence of
+// toml deserialization and not a feature of the key-value store.
+async fn multiple_custom_key_value_uses_second_store() -> anyhow::Result<()> {
     let tmp_dir = tempdir::TempDir::new("example")?;
+    let db_path = tmp_dir.path().join("custom.db");
+    // Check that the db does not exist yet - it will exist by the end of the test
+    assert!(!db_path.exists());
+
     let mut test_resolver = RuntimeConfigResolver::new();
     test_resolver.register_store_type(RedisKeyValueStore::new())?;
-    test_resolver.register_store_type(SpinKeyValueStore::new(tmp_dir.path().to_owned()))?;
+    test_resolver.register_store_type(SpinKeyValueStore::new(Some(tmp_dir.path().to_owned())))?;
     let test_resolver = Arc::new(test_resolver);
     let factors = TestFactors {
         key_value: KeyValueFactor::new(test_resolver.clone()),
+    };
+    let runtime_config = toml::toml! {
+        [key_value_store.custom]
+        type = "redis"
+        url = "redis://localhost:6379"
+
+        [key_value_store.custom]
+        type = "spin"
+        path = "custom.db"
+
     };
     let env = TestEnvironment::new(factors)
         .extend_manifest(toml! {
@@ -204,26 +225,19 @@ async fn multiple_custom_key_value_uses_first_store() -> anyhow::Result<()> {
             source = "does-not-exist.wasm"
             key_value_stores = ["custom"]
         })
-        .runtime_config(TomlConfig::new(
-            test_resolver,
-            Some(toml::toml! {
-                [key_value_store.custom]
-                type = "spin"
-                path = "custom.db"
+        .runtime_config(TomlConfig::new(test_resolver, Some(runtime_config)))?;
+    let mut state = env.build_instance_state().await?;
 
-                [key_value_store.custom]
-                type = "redis"
-                url = "redis://localhost:6379"
-            }),
-        ))?;
-    let state = env.build_instance_state().await?;
+    // Actually et a key since store creation is lazy
+    let store = state.key_value.open("custom".to_owned()).await??;
+    let _ = state.key_value.get(store, "foo".to_owned()).await??;
 
     assert_eq!(
         state.key_value.allowed_stores(),
         &["custom".into()].into_iter().collect::<HashSet<_>>()
     );
-    // Check that the first store in the config was chosen by verifying the existence of the DB directory
-    assert!(tmp_dir.path().exists());
+    // Check that the correct store in the config was chosen by verifying the existence of the DB
+    assert!(db_path.exists());
     Ok(())
 }
 

--- a/crates/factor-sqlite/tests/factor_test.rs
+++ b/crates/factor-sqlite/tests/factor_test.rs
@@ -66,7 +66,7 @@ async fn no_error_when_database_is_configured() -> anyhow::Result<()> {
         [sqlite_database.foo]
         type = "spin"
     };
-    let sqlite_config = RuntimeConfigResolver::new("/".into(), "/".into());
+    let sqlite_config = RuntimeConfigResolver::new(None, "/".into());
     let env = TestEnvironment::new(factors)
         .extend_manifest(toml! {
             [component.test-component]

--- a/crates/key-value-sqlite/src/lib.rs
+++ b/crates/key-value-sqlite/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
 use tokio::task;
 use tracing::{instrument, Level};
 
+#[derive(Clone, Debug)]
 pub enum DatabaseLocation {
     InMemory,
     Path(PathBuf),

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
-use spin_factor_key_value::runtime_config::spin::{self as key_value, MakeKeyValueStore};
+use spin_factor_key_value::runtime_config::spin::{self as key_value};
 use spin_factor_key_value::{DefaultLabelResolver as _, KeyValueFactor};
+use spin_factor_key_value_spin::SpinKeyValueStore;
 use spin_factor_llm::{spin as llm, LlmFactor};
 use spin_factor_outbound_http::OutboundHttpFactor;
 use spin_factor_outbound_mqtt::OutboundMqttFactor;
@@ -46,10 +47,9 @@ where
         use_gpu: bool,
     ) -> anyhow::Result<Self> {
         let tls_resolver = SpinTlsRuntimeConfig::new(runtime_config_path);
-        let state_dir = PathBuf::from(state_dir.unwrap_or(DEFAULT_STATE_DIR));
-        let key_value_config_resolver = key_value_config_resolver(state_dir.clone());
+        let key_value_config_resolver = key_value_config_resolver(state_dir.map(Into::into));
 
-        let sqlite_config_resolver = sqlite_config_resolver(state_dir.clone())
+        let sqlite_config_resolver = sqlite_config_resolver(state_dir.map(Into::into))
             .context("failed to resolve sqlite runtime config")?;
 
         let file = std::fs::read_to_string(runtime_config_path).with_context(|| {
@@ -66,7 +66,7 @@ where
         })?;
         let runtime_config: T = TomlRuntimeConfigSource::new(
             &toml,
-            state_dir,
+            state_dir.unwrap_or(DEFAULT_STATE_DIR).into(),
             &key_value_config_resolver,
             &tls_resolver,
             &sqlite_config_resolver,
@@ -106,11 +106,11 @@ where
 
 impl<T: Default> ResolvedRuntimeConfig<T> {
     pub fn default(state_dir: Option<&str>) -> Self {
-        let state_dir = state_dir.unwrap_or(DEFAULT_STATE_DIR);
+        let state_dir = state_dir.map(PathBuf::from);
         Self {
-            sqlite_resolver: sqlite_config_resolver(PathBuf::from(state_dir))
+            sqlite_resolver: sqlite_config_resolver(state_dir.clone())
                 .expect("failed to resolve sqlite runtime config"),
-            key_value_resolver: key_value_config_resolver(PathBuf::from(state_dir)),
+            key_value_resolver: key_value_config_resolver(state_dir),
             runtime_config: Default::default(),
         }
     }
@@ -231,14 +231,13 @@ impl RuntimeConfigSourceFinalizer for TomlRuntimeConfigSource<'_> {
     }
 }
 
-const DEFAULT_KEY_VALUE_STORE_FILENAME: &str = "sqlite_key_value.db";
 const DEFAULT_KEY_VALUE_STORE_LABEL: &str = "default";
 
 /// The key-value runtime configuration resolver.
 ///
 /// Takes a base path for the local store.
 pub fn key_value_config_resolver(
-    local_store_base_path: PathBuf,
+    local_store_base_path: Option<PathBuf>,
 ) -> key_value::RuntimeConfigResolver {
     let mut key_value = key_value::RuntimeConfigResolver::new();
 
@@ -246,7 +245,7 @@ pub fn key_value_config_resolver(
     // Unwraps are safe because the store types are known to not overlap.
     key_value
         .register_store_type(spin_factor_key_value_spin::SpinKeyValueStore::new(
-            local_store_base_path,
+            local_store_base_path.clone(),
         ))
         .unwrap();
     key_value
@@ -257,27 +256,25 @@ pub fn key_value_config_resolver(
         .unwrap();
 
     // Add handling of "default" store.
-    key_value.add_default_store(
-        DEFAULT_KEY_VALUE_STORE_LABEL,
-        key_value::StoreConfig {
-            type_: spin_factor_key_value_spin::SpinKeyValueStore::RUNTIME_CONFIG_TYPE.to_owned(),
-            config: toml::toml! {
-                path = DEFAULT_KEY_VALUE_STORE_FILENAME
-            },
-        },
-    );
+    // Unwraps are safe because the store is known to be serializable as toml.
+    key_value
+        .add_default_store::<SpinKeyValueStore>(DEFAULT_KEY_VALUE_STORE_LABEL, Default::default())
+        .unwrap();
 
     key_value
 }
 
 /// The sqlite runtime configuration resolver.
 ///
-/// Takes a base path to the state directory.
-fn sqlite_config_resolver(state_dir: PathBuf) -> anyhow::Result<sqlite::RuntimeConfigResolver> {
+/// Takes a path to the directory where the default database should be stored.
+/// If the path is `None`, the default database will be in-memory.
+fn sqlite_config_resolver(
+    default_database_dir: Option<PathBuf>,
+) -> anyhow::Result<sqlite::RuntimeConfigResolver> {
     let local_database_dir =
         std::env::current_dir().context("failed to get current working directory")?;
     Ok(sqlite::RuntimeConfigResolver::new(
-        state_dir,
+        default_database_dir,
         local_database_dir,
     ))
 }


### PR DESCRIPTION
The follow changes were made:
* The "spin" key-value store handler's take an optional `base_path`. This path is used to determine the location for stores. If it is `None`, an in-memory database will always be used (regardless of if a path is set in the runtime config).
  * If the runtime-config doesn't provide a path, then an in-memory database will be used (regardless of whether a base path is set).
* SQLite databases work differently. An optional base directory path is provided to the `RuntimeConfigResolver` - if it is set the default db will be created at that path - otherwise it will be in-memory. A second *non*-optional path is provided for the base path of SQLite databases with a path set in the runtime config. This will always be the parent directory of the database if a path is provided in the runtime-config. 
  * In other words, there is no way to force all SQLite databases to be in-memory regardless of runtime config (unlike the mechanism above for key-value which can force all key-values to be in-memory, regardless of runtime-config). Should we also make this optional and provide the CLI with some configuration option?
* Lots of tests were changed as they were simply not testing what they said they were. For example, some tests simply asserted that the temporary directory created at the beginning of test existed. Such tests would always pass as temporary directories are created immediately and not lazily. 