### PR TITLE
Update recommended extensions to point at the replacement for crates -- dependi

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "rust-lang.rust-analyzer",
-        "serayuzgur.crates",
+        "fill-labs.dependi",
     ]
 }


### PR DESCRIPTION
I finally got tired enough of VS Code telling me to download an extension that does not exist.