### PR TITLE
Turn llm feature on by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ vergen = { version = "^8.2.1", default-features = false, features = [
 wit-component = "0.19.0"
 
 [features]
-# TODO(factors): default = ["llm"]
+default = ["llm"]
 all-tests = ["extern-dependencies-tests"]
 extern-dependencies-tests = []
 llm = ["spin-trigger-http/llm"]


### PR DESCRIPTION
The [`llm` feature is on by default in the `main` branch](https://github.com/fermyon/spin/blob/b751e620afcc7be219920f2b4a196db8e045abd2/Cargo.toml#L117). 