### PR TITLE
Fix LlmCompute::into_engine type inference

### DIFF
--- a/crates/factor-llm/src/spin.rs
+++ b/crates/factor-llm/src/spin.rs
@@ -108,7 +108,7 @@ impl LlmCompute {
         state_dir: Option<PathBuf>,
         use_gpu: bool,
     ) -> anyhow::Result<Arc<Mutex<dyn LlmEngine>>> {
-        let engine = match self {
+        let engine: Arc<Mutex<dyn LlmEngine>> = match self {
             #[cfg(not(feature = "llm"))]
             LlmCompute::Spin => {
                 let _ = (state_dir, use_gpu);


### PR DESCRIPTION
```
expected struct `Arc<tokio::sync::Mutex<NoopLlmEngine>>`
   found struct `Arc<tokio::sync::Mutex<RemoteHttpLlmEngine>>`