### PR TITLE
Fix subtle runtime config issues

### DIFF
--- a/crates/factor-variables/src/spin_cli/mod.rs
+++ b/crates/factor-variables/src/spin_cli/mod.rs
@@ -20,7 +20,10 @@ use crate::runtime_config::RuntimeConfig;
 pub fn runtime_config_from_toml(table: &impl GetTomlValue) -> anyhow::Result<RuntimeConfig> {
     // Always include the environment variable provider.
     let mut providers = vec![Box::<EnvVariablesProvider>::default() as _];
-    let Some(array) = table.get("variable_provider") else {
+    let value = table
+        .get("variables_provider")
+        .or_else(|| table.get("config_provider"));
+    let Some(array) = value else {
         return Ok(RuntimeConfig { providers });
     };
 


### PR DESCRIPTION
Two bugs:
* Variables runtime config key is either `variables_provider` or `config_provider`
* Change log_dir and state_dir logic to prefer explicitly provided options with a fallback to the runtime config toml if none was provided. 