### PR TITLE
Use Swift 6.0 for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,10 +196,9 @@ jobs:
         with:
           node-version: '20.x'
       - name: Install Swift
-        run: |
-          wget https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.8-SNAPSHOT-2023-02-24-a/swift-wasm-5.8-SNAPSHOT-2023-02-24-a-ubuntu22.04_x86_64.tar.gz
-          tar -xf swift-wasm-5.8-SNAPSHOT-2023-02-24-a-ubuntu22.04_x86_64.tar.gz
-          echo "$PWD/swift-wasm-5.8-SNAPSHOT-2023-02-24-a/usr/bin" >> $GITHUB_PATH
+        uses: swiftwasm/setup-swiftwasm@v1
+        with:
+          swift-version: "wasm-6.0-SNAPSHOT-2024-07-20-a"
       - name: Install Grain
         run: |
           wget https://github.com/grain-lang/grain/releases/download/grain-v0.5.4/grain-linux-x64

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -657,7 +657,6 @@ Caused by:
 
     #[test]
     #[cfg(feature = "extern-dependencies-tests")]
-    #[ignore = "https://github.com/fermyon/spin/issues/2774"]
     fn http_swift_template_smoke_test() -> anyhow::Result<()> {
         http_smoke_test_template(
             "http-swift",


### PR DESCRIPTION
Currently just testing CI here...

Swift 5.x uses an old wasi-sdk which _might_ make it susceptible to https://github.com/WebAssembly/wasi-libc/pull/377 when used with WAGI.