### PR TITLE
Run sqlite statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7989,6 +7989,8 @@ dependencies = [
  "spin-factors-executor",
  "spin-runtime-config",
  "spin-telemetry",
+ "spin-world",
+ "tempfile",
  "terminal",
  "tokio",
  "tracing",

--- a/build.rs
+++ b/build.rs
@@ -68,16 +68,6 @@ error: the `wasm32-wasi` target is not installed
     std::fs::create_dir_all("target/test-programs").unwrap();
 
     build_wasm_test_program("core-wasi-test.wasm", "crates/core/tests/core-wasi-test");
-    // build_wasm_test_program("redis-rust.wasm", "crates/trigger-redis/tests/rust");
-    // build_wasm_test_program(
-    //     "spin-http-benchmark.wasm",
-    //     "crates/trigger-http/benches/spin-http-benchmark",
-    // );
-    // build_wasm_test_program(
-    //     "wagi-benchmark.wasm",
-    //     "crates/trigger-http/benches/wagi-benchmark",
-    // );
-    // build_wasm_test_program("timer_app_example.wasm", "examples/spin-timer/app-example");
 
     cargo_build(TIMER_TRIGGER_INTEGRATION_TEST);
 }

--- a/crates/factor-sqlite/src/host.rs
+++ b/crates/factor-sqlite/src/host.rs
@@ -66,15 +66,12 @@ impl v2::HostConnection for InstanceState {
         if !self.allowed_databases.contains(&database) {
             return Err(v2::Error::AccessDenied);
         }
-        (self.get_connection_creator)(&database)
+        let conn = (self.get_connection_creator)(&database)
             .ok_or(v2::Error::NoSuchDatabase)?
-            .create_connection()
-            .await
-            .and_then(|conn| {
-                self.connections
-                    .push(conn)
-                    .map_err(|()| v2::Error::Io("too many connections opened".to_string()))
-            })
+            .create_connection()?;
+        self.connections
+            .push(conn)
+            .map_err(|()| v2::Error::Io("too many connections opened".to_string()))
             .map(Resource::new_own)
     }
 

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -81,10 +81,7 @@ impl Factor for SqliteFactor {
             get_connection_creator(label).is_some()
         })?;
 
-        Ok(AppState {
-            allowed_databases,
-            get_connection_creator,
-        })
+        Ok(AppState::new(allowed_databases, get_connection_creator))
     }
 
     fn prepare<T: spin_factors::RuntimeFactors>(
@@ -158,6 +155,17 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Create a new `AppState`
+    pub fn new(
+        allowed_databases: HashMap<String, Arc<HashSet<String>>>,
+        get_connection_creator: host::ConnectionCreatorGetter,
+    ) -> Self {
+        Self {
+            allowed_databases,
+            get_connection_creator,
+        }
+    }
+
     /// Get a connection for a given database label.
     ///
     /// Returns `None` if there is no connection creator for the given label.

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -173,28 +173,24 @@ impl AppState {
         &self,
         label: &str,
     ) -> Option<Result<Box<dyn Connection>, v2::Error>> {
-        let connection = (self.get_connection_creator)(label)?
-            .create_connection()
-            .await;
+        let connection = (self.get_connection_creator)(label)?.create_connection();
         Some(connection)
     }
 }
 
 /// A creator of a connections for a particular SQLite database.
-#[async_trait]
 pub trait ConnectionCreator: Send + Sync {
     /// Get a *new* [`Connection`]
     ///
     /// The connection should be a new connection, not a reused one.
-    async fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error>;
+    fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error>;
 }
 
-#[async_trait::async_trait]
 impl<F> ConnectionCreator for F
 where
     F: Fn() -> anyhow::Result<Box<dyn Connection + 'static>> + Send + Sync + 'static,
 {
-    async fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error> {
+    fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error> {
         (self)().map_err(|_| v2::Error::InvalidConnection)
     }
 }

--- a/crates/factor-sqlite/tests/factor_test.rs
+++ b/crates/factor-sqlite/tests/factor_test.rs
@@ -143,9 +143,8 @@ impl spin_factor_sqlite::DefaultLabelResolver for DefaultLabelResolver {
 /// A connection creator that always returns an error.
 struct InvalidConnectionCreator;
 
-#[async_trait::async_trait]
 impl spin_factor_sqlite::ConnectionCreator for InvalidConnectionCreator {
-    async fn create_connection(
+    fn create_connection(
         &self,
     ) -> Result<Box<dyn spin_factor_sqlite::Connection + 'static>, spin_world::v2::sqlite::Error>
     {

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -45,5 +45,9 @@ terminal = { path = "../terminal" }
 tokio = { version = "1.23", features = ["fs", "rt"] }
 tracing = { workspace = true }
 
+[dev-dependencies]
+spin-world = { path = "../world" }
+tempfile = "3.12"
+
 [lints]
 workspace = true

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -42,7 +42,7 @@ spin-factors-executor = { path = "../factors-executor" }
 spin-runtime-config = { path = "../runtime-config" }
 spin-telemetry = { path = "../telemetry" }
 terminal = { path = "../terminal" }
-tokio = { version = "1.23", features = ["fs"] }
+tokio = { version = "1.23", features = ["fs", "rt"] }
 tracing = { workspace = true }
 
 [lints]

--- a/crates/trigger/src/cli/sqlite_statements.rs
+++ b/crates/trigger/src/cli/sqlite_statements.rs
@@ -1,0 +1,99 @@
+use anyhow::Context as _;
+use spin_factor_sqlite::SqliteFactor;
+use spin_factors::RuntimeFactors;
+use spin_factors_executor::ExecutorHooks;
+
+/// The default sqlite label
+const DEFAULT_SQLITE_LABEL: &str = "default";
+
+/// ExecutorHook for executing sqlite statements.
+///
+/// This executor assumes that the configured app has access to `SqliteFactor`.
+/// It will silently ignore the hook if the app does not have access to `SqliteFactor`.
+pub struct SqlStatementExecutorHook {
+    sql_statements: Vec<String>,
+}
+
+impl SqlStatementExecutorHook {
+    /// Creates a new SqlStatementExecutorHook
+    ///
+    /// The statements can be either a list of raw SQL statements or a list of `@{file:label}` statements.
+    pub fn new(sql_statements: Vec<String>) -> Self {
+        Self { sql_statements }
+    }
+}
+
+impl<F: RuntimeFactors, U> ExecutorHooks<F, U> for SqlStatementExecutorHook {
+    fn configure_app(
+        &mut self,
+        configured_app: &spin_factors::ConfiguredApp<F>,
+    ) -> anyhow::Result<()> {
+        if self.sql_statements.is_empty() {
+            return Ok(());
+        }
+        let Some(sqlite) = configured_app.app_state::<SqliteFactor>().ok() else {
+            return Ok(());
+        };
+        if let Ok(current) = tokio::runtime::Handle::try_current() {
+            let _ = current.spawn(execute(sqlite.clone(), self.sql_statements.clone()));
+        }
+        Ok(())
+    }
+}
+
+/// Executes the sql statements.
+pub async fn execute(
+    sqlite: spin_factor_sqlite::AppState,
+    sql_statements: Vec<String>,
+) -> anyhow::Result<()> {
+    let get_database = |label| {
+        let sqlite = &sqlite;
+        async move {
+            sqlite
+                .get_connection(label)
+                .await
+                .transpose()
+                .with_context(|| format!("failed connect to database with label '{label}'"))
+        }
+    };
+
+    for statement in &sql_statements {
+        if let Some(config) = statement.strip_prefix('@') {
+            let (file, label) = parse_file_and_label(config)?;
+            let database = get_database(label).await?.with_context(|| {
+                    format!(
+                        "based on the '@{config}' a registered database named '{label}' was expected but not found."
+                    )
+                })?;
+            let sql = std::fs::read_to_string(file).with_context(|| {
+                format!("could not read file '{file}' containing sql statements")
+            })?;
+            database.execute_batch(&sql).await.with_context(|| {
+                format!("failed to execute sql against database '{label}' from file '{file}'")
+            })?;
+        } else {
+            let Some(default) = get_database(DEFAULT_SQLITE_LABEL).await? else {
+                debug_assert!(false, "the '{DEFAULT_SQLITE_LABEL}' sqlite database should always be available but for some reason was not");
+                return Ok(());
+            };
+            default
+                    .query(statement, Vec::new())
+                    .await
+                    .with_context(|| format!("failed to execute following sql statement against default database: '{statement}'"))?;
+        }
+    }
+    Ok(())
+}
+
+/// Parses a @{file:label} sqlite statement
+fn parse_file_and_label(config: &str) -> anyhow::Result<(&str, &str)> {
+    let config = config.trim();
+    let (file, label) = match config.split_once(':') {
+        Some((_, label)) if label.trim().is_empty() => {
+            anyhow::bail!("database label is empty in the '@{config}' sqlite statement")
+        }
+        Some((file, label)) => (file.trim(), label.trim()),
+        None => (config, "default"),
+    };
+    Ok((file, label))
+}

--- a/crates/trigger/src/cli/sqlite_statements.rs
+++ b/crates/trigger/src/cli/sqlite_statements.rs
@@ -177,9 +177,8 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl ConnectionCreator for MockCreator {
-        async fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error> {
+        fn create_connection(&self) -> Result<Box<dyn Connection + 'static>, v2::Error> {
             Ok(Box::new(MockConnection {
                 tx: self.tx.clone(),
             }))

--- a/crates/trigger/src/cli/summary.rs
+++ b/crates/trigger/src/cli/summary.rs
@@ -1,3 +1,4 @@
+use spin_core::async_trait;
 use spin_factor_key_value::KeyValueFactor;
 use spin_factors_executor::ExecutorHooks;
 
@@ -5,8 +6,9 @@ use crate::factors::TriggerFactors;
 
 pub struct KeyValueDefaultStoreSummaryHook;
 
+#[async_trait]
 impl<U> ExecutorHooks<TriggerFactors, U> for KeyValueDefaultStoreSummaryHook {
-    fn configure_app(
+    async fn configure_app(
         &mut self,
         configured_app: &spin_factors::ConfiguredApp<TriggerFactors>,
     ) -> anyhow::Result<()> {

--- a/crates/trigger/src/stdio.rs
+++ b/crates/trigger/src/stdio.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use spin_common::ui::quoted_path;
+use spin_core::async_trait;
 use spin_factors_executor::ExecutorHooks;
 use tokio::io::AsyncWrite;
 
@@ -87,8 +88,9 @@ impl StdioLoggingExecutorHooks {
     }
 }
 
+#[async_trait]
 impl<U> ExecutorHooks<TriggerFactors, U> for StdioLoggingExecutorHooks {
-    fn configure_app(
+    async fn configure_app(
         &mut self,
         configured_app: &spin_factors::ConfiguredApp<TriggerFactors>,
     ) -> anyhow::Result<()> {


### PR DESCRIPTION
This works, but I don't love how it turned out. `ResolvedRuntimeConfig` knows nothing about the underlying runtime config type that is parsed from the runtime config source. This means that only the caller knows that the parsed runtime config has access to sqlite specific runtime config (and thus the list of labels -> connection creators). So we have to pass that information back down from the caller into the callee.

It's perhaps not 100% elegant, but it works. Perhaps we can think of a better way to structure this so that this round about data passing isn't necessary.