### PR TITLE
Add summarize_runtime_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7984,6 +7984,7 @@ dependencies = [
  "tempfile",
  "terminal",
  "tokio",
+ "toml 0.8.14",
  "tracing",
 ]
 

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -42,6 +42,8 @@ pub struct ResolvedRuntimeConfig<T> {
     ///
     /// `None` is used for an "unset" log directory.
     pub log_dir: Option<PathBuf>,
+    /// The input TOML, for informational summaries.
+    pub toml: toml::Table,
 }
 
 impl<T> ResolvedRuntimeConfig<T>
@@ -140,6 +142,7 @@ where
             sqlite_resolver: sqlite_config_resolver,
             state_dir: toml_resolver.state_dir()?,
             log_dir: toml_resolver.log_dir()?,
+            toml,
         })
     }
 

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -43,6 +43,7 @@ spin-runtime-config = { path = "../runtime-config" }
 spin-telemetry = { path = "../telemetry" }
 terminal = { path = "../terminal" }
 tokio = { version = "1.23", features = ["fs", "rt"] }
+toml = "0.8"
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -15,7 +15,9 @@ use spin_core::async_trait;
 use spin_factors_executor::{ComponentLoader, FactorsExecutor};
 use spin_runtime_config::{ResolvedRuntimeConfig, UserProvidedPath};
 use sqlite_statements::SqlStatementExecutorHook;
-use summary::{KeyValueDefaultStoreSummaryHook, SqliteDefaultStoreSummaryHook};
+use summary::{
+    summarize_runtime_config, KeyValueDefaultStoreSummaryHook, SqliteDefaultStoreSummaryHook,
+};
 
 use crate::factors::{TriggerFactors, TriggerFactorsRuntimeConfig};
 use crate::stdio::{FollowComponents, StdioLoggingExecutorHooks};
@@ -341,6 +343,8 @@ impl<T: Trigger> TriggerAppBuilder<T> {
                 use_gpu,
             )?;
 
+        summarize_runtime_config(&runtime_config, runtime_config_path);
+
         runtime_config
             .set_initial_key_values(&options.initial_key_values)
             .await?;
@@ -421,8 +425,6 @@ impl<T: Trigger> TriggerAppBuilder<T> {
             options.follow_components,
             log_dir,
         ));
-        // TODO:
-        // builder.hooks(SummariseRuntimeConfigHook::new(&self.runtime_config_file));
         executor.add_hooks(KeyValueDefaultStoreSummaryHook);
         executor.add_hooks(SqliteDefaultStoreSummaryHook);
         executor.add_hooks(SqlStatementExecutorHook::new(options.sqlite_statements));

--- a/crates/trigger/src/cli/summary.rs
+++ b/crates/trigger/src/cli/summary.rs
@@ -1,9 +1,51 @@
+use std::path::Path;
+
+use spin_common::ui::quoted_path;
 use spin_core::async_trait;
 use spin_factor_key_value::KeyValueFactor;
 use spin_factor_sqlite::SqliteFactor;
 use spin_factors_executor::ExecutorHooks;
+use spin_runtime_config::ResolvedRuntimeConfig;
+use toml::Value;
 
 use crate::factors::TriggerFactors;
+
+pub fn summarize_runtime_config<T>(
+    runtime_config: &ResolvedRuntimeConfig<T>,
+    runtime_config_path: Option<&Path>,
+) {
+    let toml = &runtime_config.toml;
+    let summarize_labeled_typed_tables = |key| {
+        let mut summaries = vec![];
+        if let Some(tables) = toml.get(key).and_then(Value::as_table) {
+            for (label, config) in tables {
+                if let Some(ty) = config.get("type").and_then(Value::as_str) {
+                    summaries.push(format!("[{key}.{label}: {ty}]"))
+                }
+            }
+        }
+        summaries
+    };
+
+    let mut summaries = vec![];
+    // [key_value_store.<label>: <type>]
+    summaries.extend(summarize_labeled_typed_tables("key_value_store"));
+    // [sqlite_database.<label>: <type>]
+    summaries.extend(summarize_labeled_typed_tables("sqlite_database"));
+    // [llm_compute: <type>]
+    if let Some(table) = toml.get("llm_compute").and_then(Value::as_table) {
+        if let Some(ty) = table.get("type").and_then(Value::as_str) {
+            summaries.push(format!("[llm_compute: {ty}"));
+        }
+    }
+    if !summaries.is_empty() {
+        let summaries = summaries.join(", ");
+        let from_path = runtime_config_path
+            .map(|path| format!("from {}", quoted_path(path)))
+            .unwrap_or_default();
+        println!("Using runtime config {summaries} {from_path}");
+    }
+}
 
 /// An [`ExecutorHooks`] that prints information about the default KV store.
 pub struct KeyValueDefaultStoreSummaryHook;

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -4249,6 +4249,7 @@ dependencies = [
  "spin-telemetry",
  "terminal",
  "tokio",
+ "toml",
  "tracing",
 ]
 


### PR DESCRIPTION
Given that the output here [reflects the input runtime config file](https://github.com/fermyon/spin/issues/1852#issue-1927059224) it seems fine to derive it from the TOML source itself.