### PR TITLE
factors: Remove InstanceFactors

### DIFF
--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -7,8 +7,7 @@ use std::{
 
 use anyhow::ensure;
 use spin_factors::{
-    ConfigureAppContext, Factor, FactorInstanceBuilder, InitContext, PrepareContext,
-    PreparedInstanceBuilders, RuntimeFactors,
+    ConfigureAppContext, Factor, FactorInstanceBuilder, InitContext, PrepareContext, RuntimeFactors,
 };
 use spin_key_value::{
     CachingStoreManager, DefaultManagerGetter, DelegatingStoreManager, KeyValueDispatch, Store,
@@ -87,8 +86,7 @@ impl Factor for KeyValueFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        ctx: PrepareContext<Self>,
-        _builders: &mut PreparedInstanceBuilders<T>,
+        ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<InstanceBuilder> {
         let app_state = ctx.app_state();
         let allowed_stores = app_state

--- a/crates/factor-llm/src/lib.rs
+++ b/crates/factor-llm/src/lib.rs
@@ -6,8 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use spin_factors::{
-    ConfigureAppContext, Factor, PrepareContext, PreparedInstanceBuilders, RuntimeFactors,
-    SelfInstanceBuilder,
+    ConfigureAppContext, Factor, PrepareContext, RuntimeFactors, SelfInstanceBuilder,
 };
 use spin_locked_app::MetadataKey;
 use spin_world::v1::llm::{self as v1};
@@ -77,8 +76,7 @@ impl Factor for LlmFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        ctx: PrepareContext<Self>,
-        _builders: &mut PreparedInstanceBuilders<T>,
+        ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
         let allowed_models = ctx
             .app_state()

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -14,8 +14,7 @@ use spin_factor_outbound_networking::{
     ComponentTlsConfigs, OutboundAllowedHosts, OutboundNetworkingFactor,
 };
 use spin_factors::{
-    anyhow, ConfigureAppContext, Factor, PrepareContext, PreparedInstanceBuilders, RuntimeFactors,
-    SelfInstanceBuilder,
+    anyhow, ConfigureAppContext, Factor, PrepareContext, RuntimeFactors, SelfInstanceBuilder,
 };
 use wasmtime_wasi_http::WasiHttpCtx;
 
@@ -59,10 +58,9 @@ impl Factor for OutboundHttpFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        _ctx: PrepareContext<Self>,
-        builders: &mut PreparedInstanceBuilders<T>,
+        mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
-        let outbound_networking = builders.get_mut::<OutboundNetworkingFactor>()?;
+        let outbound_networking = ctx.instance_builder::<OutboundNetworkingFactor>()?;
         let allowed_hosts = outbound_networking.allowed_hosts();
         let component_tls_configs = outbound_networking.component_tls_configs().clone();
         Ok(InstanceState {

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -9,8 +9,7 @@ use rumqttc::{AsyncClient, Event, Incoming, Outgoing, QoS};
 use spin_core::async_trait;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factors::{
-    ConfigureAppContext, Factor, PrepareContext, PreparedInstanceBuilders, RuntimeFactors,
-    SelfInstanceBuilder,
+    ConfigureAppContext, Factor, PrepareContext, RuntimeFactors, SelfInstanceBuilder,
 };
 use spin_world::v2::mqtt::{self as v2, Error, Qos};
 use tokio::sync::Mutex;
@@ -49,11 +48,10 @@ impl Factor for OutboundMqttFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        _ctx: PrepareContext<Self>,
-        builders: &mut PreparedInstanceBuilders<T>,
+        mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
-        let allowed_hosts = builders
-            .get_mut::<OutboundNetworkingFactor>()?
+        let allowed_hosts = ctx
+            .instance_builder::<OutboundNetworkingFactor>()?
             .allowed_hosts();
         Ok(InstanceState::new(
             allowed_hosts,

--- a/crates/factor-outbound-mysql/src/lib.rs
+++ b/crates/factor-outbound-mysql/src/lib.rs
@@ -32,11 +32,10 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundMysqlFactor<C> {
 
     fn prepare<T: spin_factors::RuntimeFactors>(
         &self,
-        _ctx: spin_factors::PrepareContext<Self>,
-        builders: &mut spin_factors::PreparedInstanceBuilders<T>,
+        mut ctx: spin_factors::PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
-        let allowed_hosts = builders
-            .get_mut::<OutboundNetworkingFactor>()?
+        let allowed_hosts = ctx
+            .instance_builder::<OutboundNetworkingFactor>()?
             .allowed_hosts();
         Ok(InstanceState {
             allowed_hosts,

--- a/crates/factor-outbound-pg/src/lib.rs
+++ b/crates/factor-outbound-pg/src/lib.rs
@@ -4,8 +4,7 @@ mod host;
 use client::Client;
 use spin_factor_outbound_networking::{OutboundAllowedHosts, OutboundNetworkingFactor};
 use spin_factors::{
-    anyhow, ConfigureAppContext, Factor, PrepareContext, PreparedInstanceBuilders, RuntimeFactors,
-    SelfInstanceBuilder,
+    anyhow, ConfigureAppContext, Factor, PrepareContext, RuntimeFactors, SelfInstanceBuilder,
 };
 use tokio_postgres::Client as PgClient;
 
@@ -36,11 +35,10 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundPgFactor<C> {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        _ctx: PrepareContext<Self>,
-        builders: &mut PreparedInstanceBuilders<T>,
+        mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
-        let allowed_hosts = builders
-            .get_mut::<OutboundNetworkingFactor>()?
+        let allowed_hosts = ctx
+            .instance_builder::<OutboundNetworkingFactor>()?
             .allowed_hosts();
         Ok(InstanceState {
             allowed_hosts,

--- a/crates/factor-outbound-redis/src/lib.rs
+++ b/crates/factor-outbound-redis/src/lib.rs
@@ -3,8 +3,7 @@ mod host;
 use host::InstanceState;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factors::{
-    anyhow, ConfigureAppContext, Factor, PrepareContext, PreparedInstanceBuilders, RuntimeFactors,
-    SelfInstanceBuilder,
+    anyhow, ConfigureAppContext, Factor, PrepareContext, RuntimeFactors, SelfInstanceBuilder,
 };
 
 /// The [`Factor`] for `fermyon:spin/outbound-redis`.
@@ -42,11 +41,10 @@ impl Factor for OutboundRedisFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        _ctx: PrepareContext<Self>,
-        builders: &mut PreparedInstanceBuilders<T>,
+        mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
-        let allowed_hosts = builders
-            .get_mut::<OutboundNetworkingFactor>()?
+        let allowed_hosts = ctx
+            .instance_builder::<OutboundNetworkingFactor>()?
             .allowed_hosts();
         Ok(InstanceState {
             allowed_hosts,

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -86,8 +86,7 @@ impl Factor for SqliteFactor {
 
     fn prepare<T: spin_factors::RuntimeFactors>(
         &self,
-        ctx: spin_factors::PrepareContext<Self>,
-        _builders: &mut spin_factors::PreparedInstanceBuilders<T>,
+        ctx: spin_factors::PrepareContext<T, Self>,
     ) -> spin_factors::anyhow::Result<Self::InstanceBuilder> {
         let allowed_databases = ctx
             .app_state()

--- a/crates/factor-variables/src/lib.rs
+++ b/crates/factor-variables/src/lib.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use runtime_config::RuntimeConfig;
 use spin_expressions::{ProviderResolver as ExpressionResolver, Template};
 use spin_factors::{
-    anyhow, ConfigureAppContext, Factor, InitContext, PrepareContext, PreparedInstanceBuilders,
-    RuntimeFactors, SelfInstanceBuilder,
+    anyhow, ConfigureAppContext, Factor, InitContext, PrepareContext, RuntimeFactors,
+    SelfInstanceBuilder,
 };
 
 /// A factor for providing variables to components.
@@ -54,8 +54,7 @@ impl Factor for VariablesFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        ctx: PrepareContext<Self>,
-        _builders: &mut PreparedInstanceBuilders<T>,
+        ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<InstanceState> {
         let component_id = ctx.app_component().id().to_string();
         let expression_resolver = ctx.app_state().expression_resolver.clone();

--- a/crates/factor-wasi/src/lib.rs
+++ b/crates/factor-wasi/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 use io::{PipeReadStream, PipedWriteStream};
 use spin_factors::{
     anyhow, AppComponent, Factor, FactorInstanceBuilder, InitContext, PrepareContext,
-    PreparedInstanceBuilders, RuntimeFactors, RuntimeFactorsInstanceState,
+    RuntimeFactors, RuntimeFactorsInstanceState,
 };
 use wasmtime_wasi::{
     DirPerms, FilePerms, ResourceTable, StdinStream, StdoutStream, WasiCtx, WasiCtxBuilder,
@@ -109,8 +109,7 @@ impl Factor for WasiFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        ctx: PrepareContext<Self>,
-        _builders: &mut PreparedInstanceBuilders<T>,
+        ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<InstanceBuilder> {
         let mut wasi_ctx = WasiCtxBuilder::new();
 

--- a/crates/factors-derive/src/lib.rs
+++ b/crates/factors-derive/src/lib.rs
@@ -149,8 +149,8 @@ fn expand_factors(input: &DeriveInput) -> syn::Result<TokenStream> {
                             #factors_path::PrepareContext::new(
                                 configured_app.app_state::<#factor_types>().unwrap(),
                                 &app_component,
+                                &mut builders,
                             ),
-                            &mut #factors_path::PreparedInstanceBuilders::new(&mut builders),
                         ).map_err(#Error::factor_prepare_error::<#factor_types>)?
                     );
                 )*

--- a/crates/factors/src/factor.rs
+++ b/crates/factors/src/factor.rs
@@ -2,10 +2,7 @@ use std::any::Any;
 
 use wasmtime::component::{Linker, ResourceTable};
 
-use crate::{
-    prepare::FactorInstanceBuilder, App, Error, PrepareContext, PreparedInstanceBuilders,
-    RuntimeFactors,
-};
+use crate::{prepare::FactorInstanceBuilder, App, Error, PrepareContext, RuntimeFactors};
 
 /// A contained (i.e., "factored") piece of runtime functionality.
 pub trait Factor: Any + Sized {
@@ -65,8 +62,7 @@ pub trait Factor: Any + Sized {
     /// used.
     fn prepare<T: RuntimeFactors>(
         &self,
-        ctx: PrepareContext<Self>,
-        _builders: &mut PreparedInstanceBuilders<T>,
+        ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder>;
 }
 
@@ -150,12 +146,12 @@ impl<'a, T: RuntimeFactors, F: Factor> ConfigureAppContext<'a, T, F> {
     }
 
     /// Get the [`App`] being configured.
-    pub fn app(&self) -> &App {
+    pub fn app(&self) -> &'a App {
         self.app
     }
 
     /// Get the app state related to the given factor.
-    pub fn app_state<U: Factor>(&self) -> crate::Result<&U::AppState> {
+    pub fn app_state<U: Factor>(&self) -> crate::Result<&'a U::AppState> {
         T::app_state::<U>(self.app_state).ok_or(Error::no_such_factor::<U>())
     }
 

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -12,9 +12,7 @@ pub use spin_factors_derive::RuntimeFactors;
 
 pub use crate::{
     factor::{ConfigureAppContext, ConfiguredApp, Factor, FactorInstanceState, InitContext},
-    prepare::{
-        FactorInstanceBuilder, PrepareContext, PreparedInstanceBuilders, SelfInstanceBuilder,
-    },
+    prepare::{FactorInstanceBuilder, PrepareContext, SelfInstanceBuilder},
     runtime_config::{FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer},
     runtime_factors::{
         AsInstanceState, HasInstanceBuilder, RuntimeFactors, RuntimeFactorsInstanceState,

--- a/crates/factors/src/prepare.rs
+++ b/crates/factors/src/prepare.rs
@@ -39,42 +39,34 @@ impl<T: SelfInstanceBuilder> FactorInstanceBuilder for T {
 /// A PrepareContext is passed to [`Factor::prepare`].
 ///
 /// This gives the factor access to app state and the app component.
-pub struct PrepareContext<'a, F: Factor> {
+pub struct PrepareContext<'a, T: RuntimeFactors, F: Factor> {
     pub(crate) app_state: &'a F::AppState,
     pub(crate) app_component: &'a AppComponent<'a>,
+    pub(crate) instance_builders: &'a mut T::InstanceBuilders,
 }
 
-impl<'a, F: Factor> PrepareContext<'a, F> {
+impl<'a, T: RuntimeFactors, F: Factor> PrepareContext<'a, T, F> {
     #[doc(hidden)]
-    pub fn new(app_state: &'a F::AppState, app_component: &'a AppComponent) -> Self {
+    pub fn new(
+        app_state: &'a F::AppState,
+        app_component: &'a AppComponent,
+        instance_builders: &'a mut T::InstanceBuilders,
+    ) -> Self {
         Self {
             app_state,
             app_component,
+            instance_builders,
         }
     }
 
     /// Get the app state related to the factor.
-    pub fn app_state(&self) -> &F::AppState {
+    pub fn app_state(&self) -> &'a F::AppState {
         self.app_state
     }
 
     /// Get the app component.
-    pub fn app_component(&self) -> &AppComponent {
+    pub fn app_component(&self) -> &'a AppComponent {
         self.app_component
-    }
-}
-
-/// The collection of all the already prepared `InstanceBuilder`s.
-///
-/// Use `InstanceBuilders::get_mut` to get a mutable reference to a specific factor's instance builder.
-pub struct PreparedInstanceBuilders<'a, T: RuntimeFactors> {
-    pub(crate) inner: &'a mut T::InstanceBuilders,
-}
-
-impl<'a, T: RuntimeFactors> PreparedInstanceBuilders<'a, T> {
-    #[doc(hidden)]
-    pub fn new(inner: &'a mut T::InstanceBuilders) -> Self {
-        Self { inner }
     }
 
     /// Returns the prepared [`FactorInstanceBuilder`] for the given [`Factor`].
@@ -82,8 +74,8 @@ impl<'a, T: RuntimeFactors> PreparedInstanceBuilders<'a, T> {
     /// Fails if the current [`RuntimeFactors`] does not include the given
     /// [`Factor`] or if the given [`Factor`]'s builder has not been prepared
     /// yet (because it is sequenced after this factor).
-    pub fn get_mut<U: Factor>(&mut self) -> crate::Result<&mut U::InstanceBuilder> {
-        T::instance_builder_mut::<U>(self.inner)
+    pub fn instance_builder<U: Factor>(&mut self) -> crate::Result<&mut U::InstanceBuilder> {
+        T::instance_builder_mut::<U>(self.instance_builders)
             .ok_or(Error::no_such_factor::<U>())?
             .ok_or_else(|| {
                 Error::DependencyOrderingError(format!(


### PR DESCRIPTION
This was the design used in an early iteration of `Factor::prepare` but I screwed up the lifetimes and it made `PrepareContext` hard to use so I split out the separate `InstanceFactors`. I realized my mistake today and fixed it here.