### PR TITLE
chore(release.yml): bump artifact actions to v4; update usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,16 +156,16 @@ jobs:
 
       - name: upload binary as GitHub artifact
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: spin
+          name: spin-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
       - name: upload binary as GitHub artifact
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: spin
+          name: spin-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
 
       - name: Configure AWS Credentials
@@ -205,16 +205,17 @@ jobs:
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
       - name: download release assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: spin
+          pattern: spin-*
+          merge-multiple: true
 
       - name: generate checksums
         run: sha256sum * > checksums-${{ env.RELEASE_VERSION }}.txt
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: spin
+          name: spin-checksums
           path: checksums-${{ env.RELEASE_VERSION }}.txt
 
   create-gh-release:
@@ -227,10 +228,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: download release assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: spin
+          pattern: spin-*
           path: _dist
+          merge-multiple: true
 
       - name: check if pre-release
         shell: bash
@@ -362,9 +364,9 @@ jobs:
             spin-${{ env.RELEASE_VERSION }}-static-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz \
             crt.pem spin.sig README.md LICENSE spin
       - name: upload binary as GitHub artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: spin
+          name: spin-static-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/spin-${{ env.RELEASE_VERSION }}-static-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
   dispatch-homebrew-tap:
@@ -409,9 +411,10 @@ jobs:
           fi
 
       - name: download release assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: spin
+          pattern: spin-*
+          merge-multiple: true
 
       - name: extract binaries
         shell: bash


### PR DESCRIPTION
- Bump the `{upload|download}-artifact` action versions to v4 and update usage

Replaces https://github.com/fermyon/spin/pull/2796 which was created per https://github.com/advisories/GHSA-cxww-7g56-2vh6.  This vulnerability was first issued for any version less than 4.1.7 but was since updated to any version >= 4.0.0 and < 4.1.7, so technically v3 isn't susceptible _but_ v3 [will be deprecated soon](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) so now is a good time to bump.

Tested on fork via https://github.com/vdice/spin/actions/runs/10715842520
