### PR TITLE
Support interceptor in spin outbound http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6132,6 +6132,7 @@ version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -7314,7 +7315,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "ip_network",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "rustls 0.23.7",
  "spin-factor-outbound-networking",
  "spin-factor-variables",

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -10,7 +10,7 @@ http = "1.1.0"
 http-body-util = "0.1"
 hyper = "1.4.1"
 ip_network = "0.4"
-reqwest = { version = "0.11", features = ["gzip"] }
+reqwest = { version = "0.12", features = ["gzip"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }

--- a/crates/factor-outbound-http/src/intercept.rs
+++ b/crates/factor-outbound-http/src/intercept.rs
@@ -1,0 +1,107 @@
+use http::{Request, Response};
+use http_body_util::{BodyExt, Full};
+use spin_world::async_trait;
+use wasmtime_wasi_http::{body::HyperOutgoingBody, HttpResult};
+
+pub type HyperBody = HyperOutgoingBody;
+
+/// An outbound HTTP request interceptor to be used with
+/// [`InstanceState::set_request_interceptor`].
+#[async_trait]
+pub trait OutboundHttpInterceptor: Send + Sync {
+    /// Intercept an outgoing HTTP request.
+    ///
+    /// If this method returns [`InterceptedResponse::Continue`], the (possibly
+    /// updated) request will be passed on to the default outgoing request
+    /// handler.
+    ///
+    /// If this method returns [`InterceptedResponse::Intercepted`], the inner
+    /// result will be returned as the result of the request, bypassing the
+    /// default handler. The `request` will also be dropped immediately.
+    async fn intercept(&self, request: InterceptRequest) -> HttpResult<InterceptOutcome>;
+}
+
+/// The type returned by an [`OutboundHttpInterceptor`].
+pub enum InterceptOutcome {
+    /// The intercepted request will be passed on to the default outgoing
+    /// request handler.
+    Continue(InterceptRequest),
+    /// The given response will be returned as the result of the intercepted
+    /// request, bypassing the default handler.
+    Complete(Response<HyperBody>),
+}
+
+/// An intercepted outgoing HTTP request.
+///
+/// This is a wrapper that implements `DerefMut<Target = Request<()>>` for
+/// inspection and modification of the request envelope. If the body needs to be
+/// consumed, call [`Self::into_hyper_request`].
+pub struct InterceptRequest {
+    inner: Request<()>,
+    body: InterceptBody,
+}
+
+enum InterceptBody {
+    Hyper(HyperBody),
+    Vec(Vec<u8>),
+}
+
+impl InterceptRequest {
+    pub fn into_hyper_request(self) -> Request<HyperBody> {
+        let (parts, ()) = self.inner.into_parts();
+        Request::from_parts(parts, self.body.into())
+    }
+
+    pub(crate) fn into_vec_request(self) -> Option<Request<Vec<u8>>> {
+        let InterceptBody::Vec(bytes) = self.body else {
+            return None;
+        };
+        let (parts, ()) = self.inner.into_parts();
+        Some(Request::from_parts(parts, bytes))
+    }
+}
+
+impl std::ops::Deref for InterceptRequest {
+    type Target = Request<()>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for InterceptRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl From<Request<HyperBody>> for InterceptRequest {
+    fn from(req: Request<HyperBody>) -> Self {
+        let (parts, body) = req.into_parts();
+        Self {
+            inner: Request::from_parts(parts, ()),
+            body: InterceptBody::Hyper(body),
+        }
+    }
+}
+
+impl From<Request<Vec<u8>>> for InterceptRequest {
+    fn from(req: Request<Vec<u8>>) -> Self {
+        let (parts, body) = req.into_parts();
+        Self {
+            inner: Request::from_parts(parts, ()),
+            body: InterceptBody::Vec(body),
+        }
+    }
+}
+
+impl From<InterceptBody> for HyperBody {
+    fn from(body: InterceptBody) -> Self {
+        match body {
+            InterceptBody::Hyper(body) => body,
+            InterceptBody::Vec(bytes) => {
+                Full::new(bytes.into()).map_err(|err| match err {}).boxed()
+            }
+        }
+    }
+}

--- a/crates/factors-executor/src/lib.rs
+++ b/crates/factors-executor/src/lib.rs
@@ -145,9 +145,7 @@ impl<T: RuntimeFactors, U: Send + 'static> FactorsExecutorApp<T, U> {
             .with_context(|| format!("no such component {component_id:?}"))?;
         Ok(instance_pre.component())
     }
-}
 
-impl<T: RuntimeFactors, U: Send + 'static> FactorsExecutorApp<T, U> {
     /// Returns an instance builder for the given component ID.
     pub fn prepare(&self, component_id: &str) -> anyhow::Result<FactorsInstanceBuilder<T, U>> {
         let app_component = self

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -1746,6 +1746,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.12",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,7 +3159,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
@@ -3162,14 +3179,18 @@ version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -3185,6 +3206,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "system-configuration 0.6.0",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -3820,7 +3842,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "ip_network",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "rustls 0.23.12",
  "spin-factor-outbound-networking",
  "spin-factors",
@@ -4355,7 +4377,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+dependencies = [
+ "bitflags 2.4.2",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -4363,6 +4396,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",


### PR DESCRIPTION
- Update interceptor interface:
  - Move into new module
  - Add new `InterceptRequest` wrapper type to handle differences between spin and wasi requests
  - Make `intercept` request param owned to be returned in `InterceptOutcome::Continue` branch, replacing awkward `std::mem::take`