### PR TITLE
Adding the `spin plugins inspect` command

### DIFF
--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -41,7 +41,7 @@ pub enum PluginCommands {
     Update,
 
     /// Print information about a plugin.
-    Inspect(Inspect),
+    Show(Show),
 }
 
 impl PluginCommands {
@@ -53,7 +53,7 @@ impl PluginCommands {
             PluginCommands::Uninstall(cmd) => cmd.run().await,
             PluginCommands::Upgrade(cmd) => cmd.run().await,
             PluginCommands::Update => update().await,
-            PluginCommands::Inspect(cmd) => cmd.run().await,
+            PluginCommands::Show(cmd) => cmd.run().await,
         }
     }
 }
@@ -421,12 +421,12 @@ impl Upgrade {
 }
 
 #[derive(Parser, Debug)]
-pub struct Inspect {
+pub struct Show {
     /// Name of Spin plugin.
     pub name: String,
 }
 
-impl Inspect {
+impl Show {
     pub async fn run(self) -> Result<()> {
         let manager = PluginManager::try_default()?;
         let manifest = manager
@@ -438,13 +438,13 @@ impl Inspect {
             .await?;
 
         println!(
-            "{}: {} (License: {})\n{}\n\n{}",
+            "{}: {} (License: {})\n{}\n{}",
             manifest.name(),
             manifest.version(),
             manifest.license(),
             manifest
                 .homepage_url()
-                .map(|u| u.to_string())
+                .map(|u| format!("{u}\n"))
                 .unwrap_or_default(),
             manifest.description().unwrap_or("No description provided"),
         );

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -438,7 +438,7 @@ impl Inspect {
             .await?;
 
         println!(
-            "{}, {} (License: {})\n{}\n\n{}",
+            "{}: {} (License: {})\n{}\n\n{}",
             manifest.name(),
             manifest.version(),
             manifest.license(),

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -39,6 +39,9 @@ pub enum PluginCommands {
 
     /// Fetch the latest Spin plugins from the spin-plugins repository.
     Update,
+
+    /// Print information about a plugin.
+    Inspect(Inspect),
 }
 
 impl PluginCommands {
@@ -50,6 +53,7 @@ impl PluginCommands {
             PluginCommands::Uninstall(cmd) => cmd.run().await,
             PluginCommands::Upgrade(cmd) => cmd.run().await,
             PluginCommands::Update => update().await,
+            PluginCommands::Inspect(cmd) => cmd.run().await,
         }
     }
 }
@@ -412,6 +416,38 @@ impl Upgrade {
             &manifest_location,
         )
         .await?;
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct Inspect {
+    /// Name of Spin plugin.
+    pub name: String,
+}
+
+impl Inspect {
+    pub async fn run(self) -> Result<()> {
+        let manager = PluginManager::try_default()?;
+        let manifest = manager
+            .get_manifest(
+                &ManifestLocation::PluginsRepository(PluginLookup::new(&self.name, None)),
+                false,
+                SPIN_VERSION,
+            )
+            .await?;
+
+        println!(
+            "{}, {} (License: {})\n{}\n\n{}",
+            manifest.name(),
+            manifest.version(),
+            manifest.license(),
+            manifest
+                .homepage_url()
+                .map(|u| u.to_string())
+                .unwrap_or_default(),
+            manifest.description().unwrap_or("No description provided"),
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Allowing Spin users to print detailed information of plugins, before installing them on their machine


## Usage

```bash
spin plugins inspect otel
otel: 0.1.2 (License: Apache-2.0)
https://github.com/fermyon/otel-plugin

A plugin to make working with OTel in Spin easy
```