### PR TITLE
Don't require a `SocketAddr` to make a `SelfRequestOrigin`

### DIFF
--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -4,7 +4,7 @@ mod wasi;
 pub mod wasi_2023_10_18;
 pub mod wasi_2023_11_10;
 
-use std::{net::SocketAddr, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Context;
 use http::{
@@ -138,13 +138,12 @@ pub struct SelfRequestOrigin {
 }
 
 impl SelfRequestOrigin {
-    pub fn create(scheme: Scheme, addr: &SocketAddr) -> anyhow::Result<Self> {
+    pub fn create(scheme: Scheme, auth: &str) -> anyhow::Result<Self> {
         Ok(SelfRequestOrigin {
             scheme,
-            authority: addr
-                .to_string()
+            authority: auth
                 .parse()
-                .with_context(|| format!("address '{addr}' is not a valid authority"))?,
+                .with_context(|| format!("address '{auth}' is not a valid authority"))?,
         })
     }
 

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -244,7 +244,7 @@ impl<F: RuntimeFactors> HttpServer<F> {
             .context(
             "The wasi HTTP trigger was configured without the required wasi outbound http support",
         )?;
-        let origin = SelfRequestOrigin::create(server_scheme, &self.listen_addr)?;
+        let origin = SelfRequestOrigin::create(server_scheme, &self.listen_addr.to_string())?;
         outbound_http.set_self_request_origin(origin);
         outbound_http.set_request_interceptor(OutboundHttpInterceptor::new(self.clone()))?;
 


### PR DESCRIPTION
This was forcing consumers who only had a DNS authority to resolve to an IP address ahead of time instead of just passing the authority along.