### PR TITLE
Get `rustls` features under control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7984,7 +7984,6 @@ dependencies = [
  "spin-trigger",
  "spin-world",
  "terminal",
- "tls-listener",
  "tokio",
  "tokio-rustls 0.26.0",
  "tracing",
@@ -8464,19 +8463,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tls-listener"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce110c38c3c9b6e5cc4fe72e60feb5b327750388a10a276e3d5d7d431e3dc76c"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "thiserror",
- "tokio",
- "tokio-rustls 0.25.0",
-]
 
 [[package]]
 name = "tokenizers"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7986,7 +7986,7 @@ dependencies = [
  "terminal",
  "tls-listener",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tracing",
  "url",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7968,7 +7968,7 @@ dependencies = [
  "hyper-util",
  "indexmap 1.9.3",
  "percent-encoding",
- "rustls 0.22.4",
+ "rustls 0.23.7",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde 1.0.197",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,9 @@ conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev 
 http-body-util = "0.1.0"
 hyper = { version = "1.0.0", features = ["full"] }
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
+# In `rustls` turn off the `aws_lc_rs` default feature and turn on `ring`.
+# If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
 tracing = { version = "0.1", features = ["log"] }
 

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -18,9 +18,9 @@ toml = "0.8"
 tracing = { workspace = true }
 
 [dev-dependencies]
+spin-factors-test = { path = "../factors-test" }
 spin-key-value-redis = { path = "../key-value-redis" }
 spin-key-value-spin = { path = "../key-value-spin" }
-spin-factors-test = { path = "../factors-test" }
 tempfile = "3.12.0"
 tokio = { version = "1", features = ["macros", "rt"] }
 

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -11,7 +11,7 @@ http-body-util = "0.1"
 hyper = "1.4.1"
 ip_network = "0.4"
 reqwest = { version = "0.12", features = ["gzip"] }
-rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls = { workspace = true }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 futures-util = "0.3"
 http = "1.1.0"
 ipnet = "2.9.0"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls = { workspace = true }
 rustls-pemfile = { version = "2.1.2", optional = true }
 rustls-pki-types = "1.7.0"
 serde = { version = "1", features = ["derive"] }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -24,9 +24,9 @@ serde_json = "1.0"
 sha2 = "0.10.8"
 shellexpand = "3.1"
 spin-common = { path = "../common" }
+spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-locked-app = { path = "../locked-app" }
 spin-manifest = { path = "../manifest" }
-spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-serde = { path = "../serde" }
 tempfile = "3.8.0"
 terminal = { path = "../terminal" }

--- a/crates/runtime-config/Cargo.toml
+++ b/crates/runtime-config/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 spin-common = { path = "../common" }
 spin-factor-key-value = { path = "../factor-key-value" }
-spin-key-value-azure = { path = "../key-value-azure" }
-spin-key-value-redis = { path = "../key-value-redis" }
-spin-key-value-spin = { path = "../key-value-spin" }
 spin-factor-llm = { path = "../factor-llm" }
 spin-factor-outbound-http = { path = "../factor-outbound-http" }
 spin-factor-outbound-mqtt = { path = "../factor-outbound-mqtt" }
@@ -26,6 +23,9 @@ spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factor-wasi = { path = "../factor-wasi" }
 spin-factors = { path = "../factors" }
+spin-key-value-azure = { path = "../key-value-azure" }
+spin-key-value-redis = { path = "../key-value-redis" }
+spin-key-value-spin = { path = "../key-value-spin" }
 spin-sqlite = { path = "../sqlite" }
 spin-trigger = { path = "../trigger" }
 toml = "0.8"

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -37,7 +37,7 @@ spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
 tls-listener = { version = "0.10.0", features = ["rustls"] }
 tokio = { version = "1.23", features = ["full"] }
-tokio-rustls = { version = "0.25.0" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 tracing = { workspace = true }
 url = "2.4.1"
 wasmtime = { workspace = true }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -35,7 +35,6 @@ spin-telemetry = { path = "../telemetry" }
 spin-trigger = { path = "../trigger" }
 spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
-tls-listener = { version = "0.10.0", features = ["rustls"] }
 tokio = { version = "1.23", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 tracing = { workspace = true }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -19,7 +19,7 @@ hyper = { workspace = true }
 hyper-util = { version = "0.1.2", features = ["tokio"] }
 indexmap = "1"
 percent-encoding = "2"
-rustls = { version = "0.22.4" }
+rustls = { workspace = true }
 rustls-pemfile = "2.1.2"
 rustls-pki-types = "1.7"
 serde = { version = "1.0", features = ["derive"] }
@@ -27,10 +27,10 @@ serde_json = "1"
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-factor-outbound-http = { path = "../factor-outbound-http" }
+spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factor-wasi = { path = "../factor-wasi" }
 spin-factors = { path = "../factors" }
 spin-http = { path = "../http" }
-spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-telemetry = { path = "../telemetry" }
 spin-trigger = { path = "../trigger" }
 spin-world = { path = "../world" }


### PR DESCRIPTION
Unfortunately, `rustls` 0.23` has a somewhat large foot-gun where you will get a runtime panic if both the `aws_lc_rs` and `ring` features are both turned on. This is very easy to do since `aws_lc_rs` is turned on by default, but we want to use `ring`.