### PR TITLE
Convert from old allowed_http_hosts locked app value.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7389,6 +7389,7 @@ dependencies = [
  "spin-factors",
  "spin-factors-test",
  "spin-locked-app",
+ "spin-manifest",
  "spin-serde",
  "tempfile",
  "terminal",

--- a/crates/componentize/src/lib.rs
+++ b/crates/componentize/src/lib.rs
@@ -466,7 +466,7 @@ mod tests {
         let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
         let mut cmd = process::Command::new("cargo");
         cmd.arg("build")
-            .current_dir(&format!("tests/{name}"))
+            .current_dir(format!("tests/{name}"))
             .arg("--release")
             .arg("--target=wasm32-wasi")
             .env("CARGO_TARGET_DIR", out_dir);

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -18,6 +18,7 @@ spin-factor-variables = { path = "../factor-variables" }
 spin-factor-wasi = { path = "../factor-wasi" }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }
+spin-manifest = { path = "../manifest" }
 spin-serde = { path = "../serde" }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }

--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -3,7 +3,6 @@ pub mod runtime_config;
 
 use std::{collections::HashMap, sync::Arc};
 
-use config::ALLOWED_HOSTS_KEY;
 use futures_util::{
     future::{BoxFuture, Shared},
     FutureExt,
@@ -17,8 +16,8 @@ use spin_factors::{
 };
 
 pub use config::{
-    is_service_chaining_host, parse_service_chaining_target, AllowedHostConfig, AllowedHostsConfig,
-    HostConfig, OutboundUrl, SERVICE_CHAINING_DOMAIN_SUFFIX,
+    allowed_outbound_hosts, is_service_chaining_host, parse_service_chaining_target,
+    AllowedHostConfig, AllowedHostsConfig, HostConfig, OutboundUrl, SERVICE_CHAINING_DOMAIN_SUFFIX,
 };
 
 pub use runtime_config::ComponentTlsConfigs;
@@ -58,9 +57,7 @@ impl Factor for OutboundNetworkingFactor {
             .map(|component| {
                 Ok((
                     component.id().to_string(),
-                    component
-                        .get_metadata(ALLOWED_HOSTS_KEY)?
-                        .unwrap_or_default()
+                    allowed_outbound_hosts(&component)?
                         .into_boxed_slice()
                         .into(),
                 ))

--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -97,7 +97,11 @@ pub fn v1_to_v2_app(manifest: v1::AppManifestV1) -> Result<v2::AppManifest, Erro
     })
 }
 
-pub(crate) fn convert_allowed_http_to_allowed_hosts(
+/// Converts the old `allowed_http_hosts` field to the new `allowed_outbound_hosts` field.
+///
+/// If `allow_database_access` is `true`, the function will also allow access to all redis,
+/// mysql, and postgres databases as this was the default before `allowed_outbound_hosts` was introduced.
+pub fn convert_allowed_http_to_allowed_hosts(
     allowed_http_hosts: &[impl AsRef<str>],
     allow_database_access: bool,
 ) -> anyhow::Result<Vec<String>> {


### PR DESCRIPTION
This should fix any issues for runtimes that are reading old locked apps that hadn't previously converted away from `allowed_http_hosts`.

Fixes https://github.com/fermyon/spin/issues/2831