### PR TITLE
Pass loader into TriggerAppBuilder

### DIFF
--- a/crates/componentize/src/lib.rs
+++ b/crates/componentize/src/lib.rs
@@ -466,7 +466,7 @@ mod tests {
         let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
         let mut cmd = process::Command::new("cargo");
         cmd.arg("build")
-            .current_dir(&format!("tests/{name}"))
+            .current_dir(format!("tests/{name}"))
             .arg("--release")
             .arg("--target=wasm32-wasi")
             .env("CARGO_TARGET_DIR", out_dir);

--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -5,11 +5,17 @@ use spin_factors::AppComponent;
 
 #[derive(Default)]
 pub struct ComponentLoader {
+    _private: (),
     #[cfg(feature = "unsafe-aot-compilation")]
     aot_compilation_enabled: bool,
 }
 
 impl ComponentLoader {
+    /// Create a new `ComponentLoader`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Updates the TriggerLoader to load AOT precompiled components
     ///
     /// **Warning: This feature may bypass important security guarantees of the

--- a/tests/testing-framework/src/runtimes/in_process_spin.rs
+++ b/tests/testing-framework/src/runtimes/in_process_spin.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use spin_runtime_factors::{FactorsBuilder, TriggerAppArgs, TriggerFactors};
-use spin_trigger::cli::TriggerAppBuilder;
+use spin_trigger::{cli::TriggerAppBuilder, loader::ComponentLoader};
 use spin_trigger_http::{HttpServer, HttpTrigger};
 use test_environment::{
     http::{Request, Response},
@@ -111,6 +111,7 @@ async fn initialize_trigger(
             app,
             spin_trigger::cli::FactorsConfig::default(),
             TriggerAppArgs::default(),
+            &ComponentLoader::new(),
         )
         .await?;
     let server = builder.trigger.into_server(trigger_app)?;


### PR DESCRIPTION
This allows users of the `TriggerAppBuilder` (like the containerd-shim) to pass in whatever loader they want.