### PR TITLE
Simplify default database resolution in sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7448,7 +7448,6 @@ dependencies = [
  "spin-factors",
  "spin-factors-test",
  "spin-locked-app",
- "spin-sqlite",
  "spin-world",
  "table",
  "tokio",

--- a/crates/factor-sqlite/Cargo.toml
+++ b/crates/factor-sqlite/Cargo.toml
@@ -21,7 +21,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }
-spin-sqlite = { path = "../sqlite" }
 tokio = { version = "1", features = ["macros", "rt"] }
 
 [lints]

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -14,6 +14,7 @@ use spin_world::v2::sqlite as v2;
 
 pub use runtime_config::RuntimeConfig;
 
+#[derive(Default)]
 pub struct SqliteFactor {
     _priv: (),
 }
@@ -45,8 +46,8 @@ impl Factor for SqliteFactor {
     ) -> anyhow::Result<Self::AppState> {
         let connection_creators = ctx
             .take_runtime_config()
-            .map(|r| r.connection_creators)
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .connection_creators;
 
         let allowed_databases = ctx
             .app()

--- a/crates/factor-sqlite/src/runtime_config.rs
+++ b/crates/factor-sqlite/src/runtime_config.rs
@@ -5,6 +5,7 @@ use crate::ConnectionCreator;
 /// A runtime configuration for SQLite databases.
 ///
 /// Maps database labels to connection creators.
+#[derive(Default)]
 pub struct RuntimeConfig {
     pub connection_creators: HashMap<String, Arc<dyn ConnectionCreator>>,
 }

--- a/crates/factor-sqlite/tests/factor_test.rs
+++ b/crates/factor-sqlite/tests/factor_test.rs
@@ -17,9 +17,8 @@ struct TestFactors {
 
 #[tokio::test]
 async fn sqlite_works() -> anyhow::Result<()> {
-    let test_resolver = DefaultLabelResolver::new(Some("default"));
     let factors = TestFactors {
-        sqlite: SqliteFactor::new(test_resolver),
+        sqlite: SqliteFactor::new(),
     };
     let env = TestEnvironment::new(factors).extend_manifest(toml! {
         [component.test-component]
@@ -38,9 +37,8 @@ async fn sqlite_works() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn errors_when_non_configured_database_used() -> anyhow::Result<()> {
-    let test_resolver = DefaultLabelResolver::new(None);
     let factors = TestFactors {
-        sqlite: SqliteFactor::new(test_resolver),
+        sqlite: SqliteFactor::new(),
     };
     let env = TestEnvironment::new(factors).extend_manifest(toml! {
         [component.test-component]
@@ -60,9 +58,8 @@ async fn errors_when_non_configured_database_used() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn no_error_when_database_is_configured() -> anyhow::Result<()> {
-    let test_resolver = DefaultLabelResolver::new(None);
     let factors = TestFactors {
-        sqlite: SqliteFactor::new(test_resolver),
+        sqlite: SqliteFactor::new(),
     };
     let runtime_config = toml! {
         [sqlite_database.foo]
@@ -116,28 +113,6 @@ impl TryFrom<TomlRuntimeSource<'_>> for TestFactorsRuntimeConfig {
 
     fn try_from(value: TomlRuntimeSource<'_>) -> Result<Self, Self::Error> {
         Self::from_source(value)
-    }
-}
-
-/// Will return an `InvalidConnectionCreator` for the supplied default database.
-struct DefaultLabelResolver {
-    default: Option<String>,
-}
-
-impl DefaultLabelResolver {
-    fn new(default: Option<&str>) -> Self {
-        Self {
-            default: default.map(Into::into),
-        }
-    }
-}
-
-impl spin_factor_sqlite::DefaultLabelResolver for DefaultLabelResolver {
-    fn default(&self, label: &str) -> Option<Arc<dyn spin_factor_sqlite::ConnectionCreator>> {
-        let Some(default) = &self.default else {
-            return None;
-        };
-        (default == label).then_some(Arc::new(InvalidConnectionCreator))
     }
 }
 

--- a/crates/runtime-factors/src/build.rs
+++ b/crates/runtime-factors/src/build.rs
@@ -39,7 +39,6 @@ impl RuntimeFactorsBuilder for FactorsBuilder {
             config.working_dir.clone(),
             args.allow_transient_write,
             runtime_config.key_value_resolver.clone(),
-            runtime_config.sqlite_resolver.clone(),
             use_gpu,
         )
         .context("failed to create factors")?;

--- a/crates/runtime-factors/src/lib.rs
+++ b/crates/runtime-factors/src/lib.rs
@@ -41,7 +41,6 @@ impl TriggerFactors {
         working_dir: impl Into<PathBuf>,
         allow_transient_writes: bool,
         default_key_value_label_resolver: impl spin_factor_key_value::DefaultLabelResolver + 'static,
-        default_sqlite_label_resolver: impl spin_factor_sqlite::DefaultLabelResolver + 'static,
         use_gpu: bool,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -50,7 +49,7 @@ impl TriggerFactors {
             key_value: KeyValueFactor::new(default_key_value_label_resolver),
             outbound_networking: outbound_networking_factor(),
             outbound_http: OutboundHttpFactor::default(),
-            sqlite: SqliteFactor::new(default_sqlite_label_resolver),
+            sqlite: SqliteFactor::new(),
             redis: OutboundRedisFactor::new(),
             mqtt: OutboundMqttFactor::new(NetworkedMqttClient::creator()),
             pg: OutboundPgFactor::new(),

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use serde::Deserialize;
-use spin_factor_sqlite::{ConnectionCreator, DefaultLabelResolver};
+use spin_factor_sqlite::ConnectionCreator;
 use spin_factors::{
     anyhow::{self, Context as _},
     runtime_config::toml::GetTomlValue,
@@ -97,13 +97,9 @@ pub struct TomlRuntimeConfig {
     pub config: toml::Table,
 }
 
-impl DefaultLabelResolver for RuntimeConfigResolver {
-    fn default(&self, label: &str) -> Option<Arc<dyn ConnectionCreator>> {
-        // Only default the database labeled "default".
-        if label != "default" {
-            return None;
-        }
-
+impl RuntimeConfigResolver {
+    /// The [`ConnectionCreator`] for the 'default' label.
+    pub fn default(&self) -> Arc<dyn ConnectionCreator> {
         let path = self
             .default_database_dir
             .as_deref()
@@ -113,7 +109,7 @@ impl DefaultLabelResolver for RuntimeConfigResolver {
             let connection = spin_sqlite_inproc::InProcConnection::new(location)?;
             Ok(Box::new(connection) as _)
         };
-        Some(Arc::new(factory))
+        Arc::new(factory)
     }
 }
 


### PR DESCRIPTION
This greatly simplifies how labels are resolved to connection creators in `factor-sqlite`.

Instead of treating default labels as something special, the factor loses all knowledge of "default" labels. The label to connection creator mapping resides entirely inside of the factor's runtime config. The sqlite factor's runtime config was previously responsible for label to connection creator mapping for all database labels except for the default one. Now it handles the default one as well.

This removes the very notion of a "default" labeled database from the factor and instead moves that to a higher level concern (how the runtime configures each factors runtime config). 

The tests for the sqlite factor have also be massively simplified as they no longer use the Spin CLI's notion of runtime config toml and instead just supply the runtime config directly. This makes it much easier to understand the what the test is actually testing. 

If you're happy with this approach, I'd like to also do the same thing for key-value. 