### PR TITLE
Fix warning from redis crate.

### DIFF
--- a/crates/factor-outbound-redis/src/host.rs
+++ b/crates/factor-outbound-redis/src/host.rs
@@ -74,7 +74,10 @@ impl v2::HostConnection for crate::InstanceState {
         payload: Vec<u8>,
     ) -> Result<(), Error> {
         let conn = self.get_conn(connection).await.map_err(other_error)?;
-        conn.publish(&channel, &payload)
+        // The `let () =` syntax is needed to suppress a warning when the result type is inferred.
+        // You can read more about the issue here: <https://github.com/redis-rs/redis-rs/issues/1228>
+        let () = conn
+            .publish(&channel, &payload)
             .await
             .map_err(other_error)?;
         Ok(())
@@ -99,7 +102,9 @@ impl v2::HostConnection for crate::InstanceState {
         value: Vec<u8>,
     ) -> Result<(), Error> {
         let conn = self.get_conn(connection).await.map_err(other_error)?;
-        conn.set(&key, &value).await.map_err(other_error)?;
+        // The `let () =` syntax is needed to suppress a warning when the result type is inferred.
+        // You can read more about the issue here: <https://github.com/redis-rs/redis-rs/issues/1228>
+        let () = conn.set(&key, &value).await.map_err(other_error)?;
         Ok(())
     }
 


### PR DESCRIPTION
You can read about the warning here: https://github.com/redis-rs/redis-rs/issues/1228

Essentially, the functions in question are subject to a subtle change that will be coming in Rust 2024. To get ahead of this change, a warning is now produced in Rust 1.81. The fix is small even if it's unfortunately a bit awkward.