### PR TITLE
manifest: fix serialization of component dependency section

### DIFF
--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -203,14 +203,6 @@ pub struct ComponentDependencies {
     pub inner: Map<DependencyName, ComponentDependency>,
 }
 
-impl TryFrom<Map<DependencyName, ComponentDependency>> for ComponentDependencies {
-    type Error = anyhow::Error;
-
-    fn try_from(value: Map<DependencyName, ComponentDependency>) -> Result<Self, Self::Error> {
-        Ok(ComponentDependencies { inner: value })
-    }
-}
-
 impl ComponentDependencies {
     /// This method validates the correct specification of dependencies in a
     /// component section of the manifest. See the documentation on the methods

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -197,7 +197,7 @@ pub struct Component {
 
 /// Component dependencies
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(try_from = "Map<DependencyName, ComponentDependency>")]
+#[serde(transparent)]
 pub struct ComponentDependencies {
     /// `dependencies = { "foo:bar" = ">= 0.1.0" }`
     pub inner: Map<DependencyName, ComponentDependency>,

--- a/crates/manifest/tests/ui/maximal.json
+++ b/crates/manifest/tests/ui/maximal.json
@@ -90,28 +90,26 @@
       },
       "dependencies_inherit_configuration": true,
       "dependencies": {
-        "inner": {
-          "a:b/c": {
-            "version": "^1.2.3",
-            "registry": "my-registry.com",
-            "package": "a:b",
-            "export": "foo"
-          },
-          "foo:bar/baz@0.1.0": {
-            "path": "path/to/component.wasm",
-            "export": null
-          },
-          "fib:fub/fob": {
-            "path": "path/to/component.wasm",
-            "export": "my-export"
-          },
-          "fizz:buzz": ">=0.1.0",
-          "abc:xyz@0.1.0": {
-            "version": "=0.1.0",
-            "registry": null,
-            "package": null,
-            "export": null
-          }
+        "a:b/c": {
+          "version": "^1.2.3",
+          "registry": "my-registry.com",
+          "package": "a:b",
+          "export": "foo"
+        },
+        "foo:bar/baz@0.1.0": {
+          "path": "path/to/component.wasm",
+          "export": null
+        },
+        "fib:fub/fob": {
+          "path": "path/to/component.wasm",
+          "export": "my-export"
+        },
+        "fizz:buzz": ">=0.1.0",
+        "abc:xyz@0.1.0": {
+          "version": "=0.1.0",
+          "registry": null,
+          "package": null,
+          "export": null
         }
       }
     }


### PR DESCRIPTION
This PR fixes the serialization of the `AppManifest` in regards to the component dependencies section. Previously using `try_from` meant that during serialization, the dependencies section had an extra nested `inner` field, leading to an invalid manifest where `spin up` will error out due to an unknown `inner` field.