### PR TITLE
Enable running some commands from subdirectories

### DIFF
--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -8,6 +8,19 @@ use crate::ui::quoted_path;
 /// The name given to the default manifest file.
 pub const DEFAULT_MANIFEST_FILE: &str = "spin.toml";
 
+/// Attempts to find a manifest. If a path is provided, that path is resolved
+/// using `resolve_manifest_file_path`; otherwise, a directory search is carried out
+/// using `search_upwards_for_manifest`. If a manifest is found, a boolean is
+/// also returned indicating if it was the default: this can be used to
+/// notify the user that a non-default manifest is being used.
+pub fn find_manifest_file_path(provided_path: Option<impl AsRef<Path>>) -> Result<(PathBuf, bool)> {
+    match provided_path {
+        Some(provided_path) => resolve_manifest_file_path(provided_path).map(|p| (p, true)),
+        None => search_upwards_for_manifest()
+            .ok_or_else(|| anyhow!("\"{}\" not found", DEFAULT_MANIFEST_FILE)),
+    }
+}
+
 /// Resolves a manifest path provided by a user, which may be a file or
 /// directory, to a path to a manifest file.
 pub fn resolve_manifest_file_path(provided_path: impl AsRef<Path>) -> Result<PathBuf> {
@@ -33,6 +46,30 @@ pub fn resolve_manifest_file_path(provided_path: impl AsRef<Path>) -> Result<Pat
             Ok(true) => anyhow!("Path {pd} is neither a file nor a directory"),
         };
         Err(err)
+    }
+}
+
+/// Starting from the current directory, searches upward through
+/// the directory tree for a manifest (that is, a file with the default
+/// manifest name `spin.toml`). If found, the path to the manifest
+/// is returned, with a boolean flag indicating if the found path was
+/// the default (i.e. `spin.toml` in the current directory).
+/// If no matching file is found, the function returns None.
+pub fn search_upwards_for_manifest() -> Option<(PathBuf, bool)> {
+    let mut inferred_dir = std::env::current_dir().unwrap();
+    let mut is_default = true;
+
+    loop {
+        let candidate = inferred_dir.join(DEFAULT_MANIFEST_FILE);
+
+        if candidate.is_file() {
+            return Some((candidate, is_default));
+        }
+
+        is_default = false;
+        let parent = inferred_dir.parent()?;
+
+        inferred_dir = parent.to_owned();
     }
 }
 

--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -10,12 +10,16 @@ pub const DEFAULT_MANIFEST_FILE: &str = "spin.toml";
 
 /// Attempts to find a manifest. If a path is provided, that path is resolved
 /// using `resolve_manifest_file_path`; otherwise, a directory search is carried out
-/// using `search_upwards_for_manifest`. If a manifest is found, a boolean is
-/// also returned indicating if it was the default: this can be used to
-/// notify the user that a non-default manifest is being used.
-pub fn find_manifest_file_path(provided_path: Option<impl AsRef<Path>>) -> Result<(PathBuf, bool)> {
+/// using `search_upwards_for_manifest`. If we had to search, and a manifest is found,
+/// a (non-zero) usize is returned indicating how far above the current directory it
+/// was found. (A usize of 0 indicates that the manifest was provided or found
+/// in the current directory.) This can be used to notify the user that a
+/// non-default manifest is being used.
+pub fn find_manifest_file_path(
+    provided_path: Option<impl AsRef<Path>>,
+) -> Result<(PathBuf, usize)> {
     match provided_path {
-        Some(provided_path) => resolve_manifest_file_path(provided_path).map(|p| (p, true)),
+        Some(provided_path) => resolve_manifest_file_path(provided_path).map(|p| (p, 0)),
         None => search_upwards_for_manifest()
             .ok_or_else(|| anyhow!("\"{}\" not found", DEFAULT_MANIFEST_FILE)),
     }
@@ -52,25 +56,38 @@ pub fn resolve_manifest_file_path(provided_path: impl AsRef<Path>) -> Result<Pat
 /// Starting from the current directory, searches upward through
 /// the directory tree for a manifest (that is, a file with the default
 /// manifest name `spin.toml`). If found, the path to the manifest
-/// is returned, with a boolean flag indicating if the found path was
-/// the default (i.e. `spin.toml` in the current directory).
+/// is returned, with a usize indicating how far above the current directory it
+/// was found. (A usize of 0 indicates that the manifest was provided or found
+/// in the current directory.) This can be used to notify the user that a
+/// non-default manifest is being used.
 /// If no matching file is found, the function returns None.
-pub fn search_upwards_for_manifest() -> Option<(PathBuf, bool)> {
-    let mut inferred_dir = std::env::current_dir().unwrap();
-    let mut is_default = true;
+///
+/// The search is abandoned if it reaches the root directory, or the
+/// root of a Git repository, without finding a 'spin.toml'.
+pub fn search_upwards_for_manifest() -> Option<(PathBuf, usize)> {
+    let candidate = PathBuf::from(DEFAULT_MANIFEST_FILE);
 
-    loop {
-        let candidate = inferred_dir.join(DEFAULT_MANIFEST_FILE);
+    if candidate.is_file() {
+        return Some((candidate, 0));
+    }
 
-        if candidate.is_file() {
-            return Some((candidate, is_default));
+    for distance in 1..20 {
+        let inferred_dir = PathBuf::from("../".repeat(distance));
+        if !inferred_dir.is_dir() {
+            return None;
         }
 
-        is_default = false;
-        let parent = inferred_dir.parent()?;
+        let candidate = inferred_dir.join(DEFAULT_MANIFEST_FILE);
+        if candidate.is_file() {
+            return Some((candidate, distance));
+        }
 
-        inferred_dir = parent.to_owned();
+        if is_git_root(&inferred_dir) {
+            return None;
+        }
     }
+
+    None
 }
 
 /// Resolves the parent directory of a path, returning an error if the path
@@ -84,6 +101,10 @@ pub fn parent_dir(path: impl AsRef<Path>) -> Result<PathBuf> {
         parent = Path::new(".");
     }
     Ok(parent.into())
+}
+
+fn is_git_root(dir: &Path) -> bool {
+    dir.join(".git").is_dir()
 }
 
 #[cfg(test)]

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -128,6 +128,16 @@ macro_rules! ceprint {
     };
 }
 
+#[macro_export]
+macro_rules! ceprintln {
+    ($color:expr, $($arg:tt)*) => {
+        use std::io::Write;
+        let mut out = $crate::ColorText::stderr($color);
+        let _ = writeln!(out, $($arg)*);
+        drop(out); // Reset colors
+    };
+}
+
 pub mod colors {
     use termcolor::{Color, ColorSpec};
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -2,9 +2,11 @@ use std::{ffi::OsString, path::PathBuf};
 
 use anyhow::Result;
 use clap::Parser;
-use spin_common::ui::quoted_path;
 
-use crate::opts::{APP_MANIFEST_FILE_OPT, BUILD_UP_OPT};
+use crate::{
+    directory_rels::notify_if_nondefault_rel,
+    opts::{APP_MANIFEST_FILE_OPT, BUILD_UP_OPT},
+};
 
 use super::up::UpCommand;
 
@@ -37,15 +39,9 @@ pub struct BuildCommand {
 
 impl BuildCommand {
     pub async fn run(self) -> Result<()> {
-        let (manifest_file, is_default) =
+        let (manifest_file, distance) =
             spin_common::paths::find_manifest_file_path(self.app_source.as_ref())?;
-        if !is_default {
-            terminal::einfo!(
-                "Using 'spin.toml' from parent directory:",
-                "{}",
-                quoted_path(&manifest_file)
-            );
-        }
+        notify_if_nondefault_rel(&manifest_file, distance);
 
         spin_build::build(&manifest_file, &self.component_id).await?;
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use dialoguer::{console::Emoji, Confirm, Select};
 use spin_doctor::{Diagnosis, DryRunNotSupported, PatientDiagnosis};
 
-use crate::opts::{APP_MANIFEST_FILE_OPT, DEFAULT_MANIFEST_FILE};
+use crate::opts::APP_MANIFEST_FILE_OPT;
 
 #[derive(Parser, Debug)]
 #[clap(about = "Detect and fix problems with Spin applications")]
@@ -18,21 +18,29 @@ pub struct DoctorCommand {
         short = 'f',
         long = "from",
         alias = "file",
-        default_value = DEFAULT_MANIFEST_FILE
     )]
-    pub app_source: PathBuf,
+    pub app_source: Option<PathBuf>,
 }
 
 impl DoctorCommand {
     pub async fn run(self) -> Result<()> {
-        let manifest_file = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
+        let (manifest_file, is_default) =
+            spin_common::paths::find_manifest_file_path(self.app_source.as_ref())?;
 
         println!("{icon}The Spin Doctor is in.", icon = Emoji("📟 ", ""));
-        println!(
-            "{icon}Checking {}...",
-            manifest_file.display(),
-            icon = Emoji("🩺 ", "")
-        );
+        if is_default {
+            println!(
+                "{icon}Checking {}...",
+                manifest_file.display(),
+                icon = Emoji("🩺 ", "")
+            );
+        } else {
+            println!(
+                "{icon}Checking file from parent directory {}...",
+                manifest_file.display(),
+                icon = Emoji("🩺 ", "")
+            );
+        }
 
         let mut checkup = spin_doctor::Checkup::new(manifest_file)?;
         let mut has_problems = false;

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -17,30 +17,28 @@ pub struct DoctorCommand {
         name = APP_MANIFEST_FILE_OPT,
         short = 'f',
         long = "from",
-        alias = "file",
+        alias = "file"
     )]
     pub app_source: Option<PathBuf>,
 }
 
 impl DoctorCommand {
     pub async fn run(self) -> Result<()> {
-        let (manifest_file, is_default) =
+        let (manifest_file, distance) =
             spin_common::paths::find_manifest_file_path(self.app_source.as_ref())?;
-
-        println!("{icon}The Spin Doctor is in.", icon = Emoji("📟 ", ""));
-        if is_default {
-            println!(
-                "{icon}Checking {}...",
-                manifest_file.display(),
-                icon = Emoji("🩺 ", "")
-            );
-        } else {
-            println!(
-                "{icon}Checking file from parent directory {}...",
-                manifest_file.display(),
-                icon = Emoji("🩺 ", "")
+        if distance > 0 {
+            anyhow::bail!(
+                "No spin.toml in current directory - did you mean '--from {}'?",
+                manifest_file.display()
             );
         }
+
+        println!("{icon}The Spin Doctor is in.", icon = Emoji("📟 ", ""));
+        println!(
+            "{icon}Checking {}...",
+            manifest_file.display(),
+            icon = Emoji("🩺 ", "")
+        );
 
         let mut checkup = spin_doctor::Checkup::new(manifest_file)?;
         let mut has_problems = false;

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -382,7 +382,19 @@ impl UpCommand {
             );
             AppSource::Unresolvable(msg)
         } else {
-            AppSource::None
+            match spin_common::paths::search_upwards_for_manifest() {
+                Some((manifest_path, is_default)) => {
+                    if !is_default {
+                        terminal::einfo!(
+                            "Using 'spin.toml' from parent directory:",
+                            "{}",
+                            quoted_path(&manifest_path)
+                        );
+                    }
+                    AppSource::File(manifest_path)
+                }
+                None => AppSource::None,
+            }
         }
     }
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -18,7 +18,7 @@ use spin_oci::OciLoader;
 use spin_trigger::cli::{LaunchMetadata, SPIN_LOCAL_APP_DIR, SPIN_LOCKED_URL, SPIN_WORKING_DIR};
 use tempfile::TempDir;
 
-use crate::opts::*;
+use crate::{directory_rels::notify_if_nondefault_rel, opts::*};
 
 use self::app_source::{AppSource, ResolvedAppSource};
 
@@ -383,14 +383,8 @@ impl UpCommand {
             AppSource::Unresolvable(msg)
         } else {
             match spin_common::paths::search_upwards_for_manifest() {
-                Some((manifest_path, is_default)) => {
-                    if !is_default {
-                        terminal::einfo!(
-                            "Using 'spin.toml' from parent directory:",
-                            "{}",
-                            quoted_path(&manifest_path)
-                        );
-                    }
+                Some((manifest_path, distance)) => {
+                    notify_if_nondefault_rel(&manifest_path, distance);
                     AppSource::File(manifest_path)
                 }
                 None => AppSource::None,

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -8,13 +8,12 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use itertools::Itertools;
 use path_absolutize::Absolutize;
-use spin_common::paths::parent_dir;
+use spin_common::{paths::parent_dir, ui::quoted_path};
 use uuid::Uuid;
 use watchexec::Watchexec;
 
 use crate::opts::{
-    APP_MANIFEST_FILE_OPT, DEFAULT_MANIFEST_FILE, WATCH_CLEAR_OPT, WATCH_DEBOUNCE_OPT,
-    WATCH_SKIP_BUILD_OPT,
+    APP_MANIFEST_FILE_OPT, WATCH_CLEAR_OPT, WATCH_DEBOUNCE_OPT, WATCH_SKIP_BUILD_OPT,
 };
 
 mod buildifier;
@@ -41,9 +40,8 @@ pub struct WatchCommand {
         short = 'f',
         long = "from",
         alias = "file",
-        default_value = DEFAULT_MANIFEST_FILE
     )]
-    pub app_source: PathBuf,
+    pub app_source: Option<PathBuf>,
 
     /// Clear the screen before each run.
     #[clap(
@@ -93,7 +91,15 @@ impl WatchCommand {
         //     has just done so.  Subsequent asset changes _do_ clear the screen.
 
         let spin_bin = std::env::current_exe()?;
-        let manifest_file = spin_common::paths::resolve_manifest_file_path(&self.app_source)?;
+        let (manifest_file, is_default) =
+            spin_common::paths::find_manifest_file_path(self.app_source.as_ref())?;
+        if !is_default {
+            terminal::einfo!(
+                "Using 'spin.toml' from parent directory:",
+                "{}",
+                quoted_path(&manifest_file)
+            );
+        }
         let manifest_file = manifest_file.absolutize()?.to_path_buf(); // or watchexec misses files in subdirectories
         let manifest_dir = parent_dir(&manifest_file)?;
 

--- a/src/directory_rels.rs
+++ b/src/directory_rels.rs
@@ -1,0 +1,37 @@
+//! Human-readable descriptions for directory relationships,
+//! and helpers for standard display.
+
+use std::path::Path;
+
+fn parent_rel(distance: usize) -> String {
+    match distance {
+        0 => "".to_owned(),
+        1 => "parent".to_owned(),
+        2 => "grandparent".to_owned(),
+        _ => format!("{}grandparent", "great-".repeat(distance - 2)),
+    }
+}
+
+pub fn notify_if_nondefault_rel(manifest_file: &Path, distance: usize) {
+    if distance > 0 {
+        terminal::einfo!(
+            "No 'spin.toml' in current directory.",
+            "Using 'spin.toml' from {} directory ({})",
+            parent_rel(distance),
+            manifest_file.display(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ancestry_text_is_correct() {
+        assert_eq!("parent", parent_rel(1));
+        assert_eq!("grandparent", parent_rel(2));
+        assert_eq!("great-grandparent", parent_rel(3));
+        assert_eq!("great-great-great-grandparent", parent_rel(5)); // I hope you're happy Lann
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod build_info;
 pub mod commands;
+mod directory_rels;
 pub(crate) mod opts;
 pub mod subprocess;
 


### PR DESCRIPTION
Fixes #2828.

@karthik2804 you asked me a couple of days ago about something related to this, so I am not sure if you were already working on it - there was nothing in GitHub and I saw you were working on something much cooler - if you did have something under way then feel free to close this.

The experience for running from a subdirectory looks like this:

![image](https://github.com/user-attachments/assets/14a56bd5-7615-4b7c-8131-d61d6ae68169)

(Exception: `spin doctor` where it integrates into an existing "this is the file you're partying on" notification.)

That output is not currently centralised - I thought about making the `spin_common` function print it, but `spin up` can't use that function anyway, and it would have required `spin_common` to depend on `terminal`, so I passed on that for now.  But we can do it if people prefer.  I certainly don't much love the internal API (loose booleans, oh the self-loathing) but thought I'd get feedback before I determined how to clean it up.

Also, the way I did it resulted in showing the absolute path (`/home/ivan/whatever/spin.toml`) rather than the relative path (`../spin.toml`).  The UX here seemed a little tricky - for one or two levels, the relative path is probably more helpful, but for more than that it just turns into a blur (../../../../../spin.toml).  For now I went with the absolute path because I had it to hand, but realistically the commonest case is one level down, maybe two, so there's a strong case for doing it the other way.  (Indeed, I'm thinking the terror and confusion of ../../../../../spin.toml would actually make it more noticeable that you were hitting some crazy random manifest you didn't intend.)

This PR adds the "run from subdirectory" behaviour to:
* build
* doctor
* registry push
* up
* watch

We _could_ add it to `spin add` but I think it might get confusing where the new component's directory got created.  We do already allow `spin add -f ../..` though, so maybe I'm being overly cautious.  Maybe not behaving like other commands is worse from a potential surprise POV.
