### PR TITLE
Chore: Dependency Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,15 +2001,6 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
@@ -7657,7 +7648,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "dirs 4.0.0",
+ "dirs 5.0.1",
  "futures",
  "glob",
  "indexmap 1.9.3",
@@ -7729,7 +7720,7 @@ dependencies = [
  "async-tar",
  "base64 0.21.7",
  "chrono",
- "dirs 4.0.0",
+ "dirs 5.0.1",
  "dkregistry",
  "docker_credential",
  "futures-util",
@@ -7756,7 +7747,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
- "dirs 4.0.0",
+ "dirs 5.0.1",
  "fd-lock 3.0.13",
  "flate2",
  "is-terminal",
@@ -7917,7 +7908,7 @@ dependencies = [
  "bytes",
  "console",
  "dialoguer 0.10.4",
- "dirs 3.0.2",
+ "dirs 5.0.1",
  "fs_extra",
  "heck 0.4.1",
  "indexmap 1.9.3",
@@ -8956,7 +8947,7 @@ name = "ui-testing"
 version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
- "dirs 4.0.0",
+ "dirs 5.0.1",
  "libtest-mimic 0.6.1",
  "snapbox",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static 1.4.0",
  "lazycell",
  "proc-macro2",
@@ -2352,17 +2352,6 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
-dependencies = [
- "cfg-if",
- "rustix 0.38.32",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "fd-lock"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
@@ -3909,7 +3898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4243,15 +4232,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "lru"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
@@ -4496,9 +4476,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "mysql_async"
-version = "0.33.0"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6750b17ce50f8f112ef1a8394121090d47c596b56a6a17569ca680a9626e2ef2"
+checksum = "a0b66e411c31265e879d9814d03721f2daa7ad07337b6308cb4bb0cde7e6fd47"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -4507,12 +4487,9 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lazy_static 1.4.0",
- "lru 0.12.3",
- "mio 0.8.11",
+ "lru",
  "mysql_common",
  "native-tls",
- "once_cell",
  "pem",
  "percent-encoding",
  "pin-project",
@@ -4530,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.31.0"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f19e4cfa0ab5a76b627cec2d81331c49b034988eaf302c3bafeada684eadef"
+checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.7",
  "bindgen",
@@ -4558,7 +4535,7 @@ dependencies = [
  "subprocess",
  "thiserror",
  "uuid",
- "zstd 0.12.4",
+ "zstd 0.13.1",
 ]
 
 [[package]]
@@ -5629,7 +5606,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -5649,7 +5626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -7217,7 +7194,6 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "dotenvy",
  "serde 1.0.210",
  "spin-locked-app",
  "thiserror",
@@ -7230,7 +7206,7 @@ name = "spin-factor-key-value"
 version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
- "lru 0.9.0",
+ "lru",
  "serde 1.0.210",
  "spin-core",
  "spin-factors",
@@ -7567,7 +7543,7 @@ dependencies = [
  "candle-nn",
  "chrono",
  "llm",
- "lru 0.9.0",
+ "lru",
  "num_cpus",
  "rand 0.8.5",
  "safetensors",
@@ -7671,7 +7647,7 @@ dependencies = [
  "anyhow",
  "async-compression",
  "async-tar",
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "dkregistry",
@@ -7701,7 +7677,7 @@ dependencies = [
  "bytes",
  "chrono",
  "dirs 5.0.1",
- "fd-lock 3.0.13",
+ "fd-lock",
  "flate2",
  "is-terminal",
  "path-absolutize",
@@ -7879,7 +7855,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.8.14",
- "toml_edit 0.20.7",
+ "toml_edit 0.22.14",
  "url",
  "walkdir",
 ]
@@ -8187,7 +8163,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cap-fs-ext",
  "cap-std 3.0.0",
- "fd-lock 4.0.2",
+ "fd-lock",
  "io-lifetimes 2.0.3",
  "rustix 0.38.32",
  "windows-sys 0.52.0",
@@ -8652,17 +8628,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.5.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
@@ -8854,7 +8819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -10782,15 +10747,6 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
@@ -10803,16 +10759,6 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8337,7 +8337,7 @@ name = "test-components"
 version = "0.1.0"
 dependencies = [
  "cargo_toml",
- "wit-component 0.19.1",
+ "wit-component 0.217.0",
 ]
 
 [[package]]
@@ -9446,15 +9446,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111495d6204760238512f57a9af162f45086504da332af210f2f75dd80b34f1d"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.41.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f97a5d8318f908dded23594188a90bcd09365986b1163e66d70170e5287ae"
@@ -9491,19 +9482,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.10.20"
+name = "wasm-encoder"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ebaa7bd0f9e7a5e5dd29b9a998acf21c4abed74265524dd7e85934597bfb10"
+checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
 dependencies = [
- "anyhow",
- "indexmap 2.2.6",
- "serde 1.0.210",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.41.2",
- "wasmparser 0.121.2",
+ "leb128",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -9552,6 +9537,22 @@ dependencies = [
  "spdx",
  "wasm-encoder 0.209.1",
  "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.217.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65a146bf9a60e9264f0548a2599aa9656dba9a641eff9ab88299dc2a637e483c"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde 1.0.210",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -9618,17 +9619,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.119.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c35daf77afb4f9b14016625144a391085ec2ca99ca9cc53ed291bb53ab5278d"
-dependencies = [
- "bitflags 2.5.0",
- "indexmap 2.2.6",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
@@ -9672,6 +9662,19 @@ dependencies = [
  "indexmap 2.2.6",
  "semver",
  "serde 1.0.210",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.217.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
+dependencies = [
+ "ahash",
+ "bitflags 2.5.0",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.6",
+ "semver",
 ]
 
 [[package]]
@@ -10557,25 +10560,6 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429e3c06fba3a7566aab724ae3ffff3152ede5399d44789e7dd11f5421292859"
-dependencies = [
- "anyhow",
- "bitflags 2.5.0",
- "indexmap 2.2.6",
- "log",
- "serde 1.0.210",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.39.0",
- "wasm-metadata 0.10.20",
- "wasmparser 0.119.0",
- "wit-parser 0.13.2",
-]
-
-[[package]]
-name = "wit-component"
 version = "0.200.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39979723340baea490b87b11b2abae05f149d86f2b55c18d41d78a2a2b284c16"
@@ -10613,20 +10597,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-parser"
-version = "0.13.2"
+name = "wit-component"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316b36a9f0005f5aa4b03c39bc3728d045df136f8c13a73b7db4510dec725e08"
+checksum = "d7117809905e49db716d81e794f79590c052bf2fdbbcda1731ca0fb28f6f3ddf"
 dependencies = [
  "anyhow",
- "id-arena",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
- "semver",
  "serde 1.0.210",
  "serde_derive",
  "serde_json",
- "unicode-xid",
+ "wasm-encoder 0.217.0",
+ "wasm-metadata 0.217.0",
+ "wasmparser 0.217.0",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -10663,6 +10649,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.217.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb893dcd6d370cfdf19a0d9adfcd403efb8e544e1a0ea3a8b81a21fe392eaa78"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "serde 1.0.210",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,7 +2721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "stable_deref_trait",
 ]
 
@@ -3005,7 +3005,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -3024,7 +3024,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -3274,7 +3274,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -3516,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3777,7 +3777,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
 ]
 
 [[package]]
@@ -3909,7 +3909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3976,7 +3976,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cc",
  "fallible-iterator 0.3.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "memchr",
  "phf",
@@ -4350,15 +4350,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -4586,18 +4577,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -4851,7 +4830,7 @@ checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "memchr",
 ]
 
@@ -5347,7 +5326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
 ]
 
 [[package]]
@@ -5932,21 +5911,6 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
-dependencies = [
- "combine",
- "itoa",
- "percent-encoding",
- "ryu",
- "sha1_smol",
- "socket2 0.4.10",
- "url",
-]
-
-[[package]]
-name = "redis"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
@@ -5965,6 +5929,23 @@ dependencies = [
  "socket2 0.5.6",
  "tokio",
  "tokio-util 0.7.10",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e86f5670bd8b028edfb240f0616cad620705b31ec389d55e4f3da2c38dcd48"
+dependencies = [
+ "arc-swap",
+ "combine",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.6",
  "url",
 ]
 
@@ -6745,7 +6726,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_derive",
  "serde_json",
@@ -6771,7 +6752,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde 1.0.210",
@@ -7090,11 +7071,11 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static 1.4.0",
  "levenshtein",
- "nix 0.24.3",
+ "nix 0.29.0",
  "openssl",
  "path-absolutize",
  "rand 0.8.5",
- "redis 0.24.0",
+ "redis 0.27.2",
  "regex",
  "reqwest 0.12.7",
  "rpassword",
@@ -7136,7 +7117,6 @@ dependencies = [
  "wasmtime",
  "watchexec",
  "watchexec-filterer-globset",
- "which",
 ]
 
 [[package]]
@@ -7183,7 +7163,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver",
  "spin-app",
  "spin-componentize",
@@ -8328,7 +8308,7 @@ dependencies = [
  "http 1.1.0",
  "http-body-util",
  "log",
- "nix 0.26.4",
+ "nix 0.29.0",
  "regex",
  "reqwest 0.12.7",
  "spin-app",
@@ -8648,7 +8628,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_spanned",
  "toml_datetime",
@@ -8670,7 +8650,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -8681,7 +8661,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_spanned",
  "toml_datetime",
@@ -8694,7 +8674,7 @@ version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_spanned",
  "toml_datetime",
@@ -8881,7 +8861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -9111,13 +9091,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wac-graph"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d62ffef518aba9d62dc1532960702a67a62ca1b0ffb3cf152391d477bc7e11"
+checksum = "86f708c892ce0ebc06de9915f3da2da9b4e482a8b7d417fa447263b110d0a244"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "petgraph",
  "semver",
@@ -9130,13 +9110,13 @@ dependencies = [
 
 [[package]]
 name = "wac-types"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe3e5531080631b8d14f355119f4b3bac92bdacaad6786599cf474958eee01f"
+checksum = "b96fe715180f72ab776d90e8c4f47f8e4297e0e61ab263567a31f73c77d45d8d"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver",
  "wasm-encoder 0.202.0",
  "wasmparser 0.202.0",
@@ -9173,7 +9153,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a22d3c9026f2f6a628cf386963844cdb7baea3b3419ba090c9096da114f977d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "serde 1.0.210",
  "serde_with",
@@ -9196,7 +9176,7 @@ dependencies = [
  "dialoguer 0.11.0",
  "dirs 5.0.1",
  "futures-util",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "keyring",
  "libc",
@@ -9277,7 +9257,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "hex",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "pbjson-types",
  "prost 0.12.4",
  "prost-types",
@@ -9298,7 +9278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513ef81a5bb1ac5d7bd04f90d3c192dad8f590f4c02b3ef68d3ae4fbbb53c1d7"
 dependencies = [
  "anyhow",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "prost 0.12.4",
  "thiserror",
  "warg-crypto",
@@ -9398,7 +9378,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "im-rc",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "petgraph",
  "serde 1.0.210",
@@ -9464,7 +9444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b8cc0c21f46d55b0aaa419cacce1eadcf28eaebd0e1488d6a6313ee71a586"
 dependencies = [
  "anyhow",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_derive",
  "serde_json",
@@ -9480,7 +9460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
 dependencies = [
  "anyhow",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_derive",
  "serde_json",
@@ -9496,7 +9476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
 dependencies = [
  "anyhow",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_derive",
  "serde_json",
@@ -9512,7 +9492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65a146bf9a60e9264f0548a2599aa9656dba9a641eff9ab88299dc2a637e483c"
 dependencies = [
  "anyhow",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_derive",
  "serde_json",
@@ -9590,7 +9570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver",
 ]
 
@@ -9601,7 +9581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a03f65ac876612140c57ff6c3b8fe4990067cce97c2cfdb07368a3cc3354b062"
 dependencies = [
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver",
 ]
 
@@ -9612,7 +9592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
 dependencies = [
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver",
 ]
 
@@ -9625,7 +9605,7 @@ dependencies = [
  "ahash",
  "bitflags 2.5.0",
  "hashbrown 0.14.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver",
  "serde 1.0.210",
 ]
@@ -9639,7 +9619,7 @@ dependencies = [
  "ahash",
  "bitflags 2.5.0",
  "hashbrown 0.14.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver",
 ]
 
@@ -9679,7 +9659,7 @@ dependencies = [
  "fxprof-processed-profile",
  "gimli",
  "hashbrown 0.14.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "ittapi",
  "libc",
  "libm",
@@ -9803,7 +9783,7 @@ dependencies = [
  "cpp_demangle",
  "cranelift-entity",
  "gimli",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "object 0.36.0",
  "postcard",
@@ -9966,7 +9946,7 @@ checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "wit-parser 0.209.1",
 ]
 
@@ -10532,7 +10512,7 @@ checksum = "39979723340baea490b87b11b2abae05f149d86f2b55c18d41d78a2a2b284c16"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "serde 1.0.210",
  "serde_derive",
@@ -10551,7 +10531,7 @@ checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "serde 1.0.210",
  "serde_derive",
@@ -10570,7 +10550,7 @@ checksum = "d7117809905e49db716d81e794f79590c052bf2fdbbcda1731ca0fb28f6f3ddf"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "serde 1.0.210",
  "serde_derive",
@@ -10589,7 +10569,7 @@ checksum = "7f717576b37f01c15696bda7f6f13868367b9c5913485f9f0ec8e59fd28c8e13"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "semver",
  "serde 1.0.210",
@@ -10607,7 +10587,7 @@ checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "semver",
  "serde 1.0.210",
@@ -10625,7 +10605,7 @@ checksum = "fb893dcd6d370cfdf19a0d9adfcd403efb8e544e1a0ea3a8b81a21fe392eaa78"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "log",
  "semver",
  "serde 1.0.210",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 dependencies = [
  "backtrace",
 ]
@@ -543,7 +543,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.197",
+ "serde 1.0.210",
  "sync_wrapper 1.0.1",
  "tower",
  "tower-layer",
@@ -589,7 +589,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.12.7",
  "rustc_version",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "time",
@@ -607,7 +607,7 @@ dependencies = [
  "azure_core",
  "bytes",
  "futures",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "thiserror",
  "time",
@@ -628,7 +628,7 @@ dependencies = [
  "futures",
  "oauth2",
  "pin-project",
- "serde 1.0.197",
+ "serde 1.0.210",
  "time",
  "tracing",
  "tz-rs",
@@ -644,7 +644,7 @@ dependencies = [
  "async-trait",
  "azure_core",
  "futures",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "time",
 ]
@@ -799,7 +799,7 @@ checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "regex-automata 0.4.6",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -835,7 +835,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -872,7 +872,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "reqwest 0.11.27",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "tar",
@@ -887,7 +887,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -1154,7 +1154,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "thiserror",
 ]
@@ -1185,7 +1185,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a969e13a7589e9e3e4207e153bae624ade2b5622fb4684a4923b23ec3d57719"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "toml 0.8.14",
 ]
 
@@ -1231,7 +1231,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.18",
- "serde 1.0.197",
+ "serde 1.0.210",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -1435,7 +1435,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 5.1.3",
  "rust-ini",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde-hjson",
  "serde_json",
  "toml 0.5.11",
@@ -1462,7 +1462,7 @@ dependencies = [
  "json5",
  "libtest-mimic 0.7.3",
  "reqwest 0.12.7",
- "serde 1.0.197",
+ "serde 1.0.210",
  "tar",
  "test-environment",
 ]
@@ -1593,7 +1593,7 @@ version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
 ]
 
@@ -1867,7 +1867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -2075,7 +2075,7 @@ dependencies = [
  "pin-project",
  "regex",
  "reqwest 0.11.27",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_ignored",
  "serde_json",
  "sha2",
@@ -2100,7 +2100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31951f49556e34d90ed28342e1df7e1cb7a229c4cab0aecc627b5d91edd41d07"
 dependencies = [
  "base64 0.21.7",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
 ]
 
@@ -2194,7 +2194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
 dependencies = [
  "enumflags2_derive",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -2666,7 +2666,7 @@ dependencies = [
  "bitflags 2.5.0",
  "debugid",
  "fxhash",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
 ]
 
@@ -3076,7 +3076,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -3235,7 +3235,7 @@ dependencies = [
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "serde_qs",
  "serde_urlencoded",
@@ -3514,7 +3514,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -3525,7 +3525,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -3756,7 +3756,7 @@ checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
 dependencies = [
  "pest",
  "pest_derive",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -3769,7 +3769,7 @@ dependencies = [
  "crypto-common",
  "digest",
  "hmac",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
 ]
@@ -3823,7 +3823,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -3948,7 +3948,7 @@ dependencies = [
  "hyper-rustls 0.25.0",
  "libsql-hrana",
  "libsql-sqlite3-parser",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3966,7 +3966,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "prost 0.12.4",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -4061,7 +4061,7 @@ dependencies = [
  "liquid-core",
  "liquid-derive",
  "liquid-lib",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -4078,7 +4078,7 @@ dependencies = [
  "num-traits 0.2.18",
  "pest",
  "pest_derive",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -4115,7 +4115,7 @@ source = "git+https://github.com/rustformers/llm?rev=2f6ffd4435799ceaa1d1bcb5a87
 dependencies = [
  "llm-base",
  "llm-llama",
- "serde 1.0.197",
+ "serde 1.0.210",
  "tracing",
 ]
 
@@ -4132,7 +4132,7 @@ dependencies = [
  "partial_sort",
  "rand 0.8.5",
  "regex",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_bytes",
  "thiserror",
  "tokenizers",
@@ -4486,7 +4486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c2a1f1c70e5724fa28f101ca787b6a7e8ad5c5e4ae4ca3b0fa4a419fa9075"
 dependencies = [
  "monostate-impl",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -4529,7 +4529,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rand 0.8.5",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "socket2 0.5.6",
  "thiserror",
@@ -4562,7 +4562,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "saturating",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha1 0.10.6",
  "sha2",
@@ -4829,7 +4829,7 @@ dependencies = [
  "getrandom 0.2.12",
  "http 0.2.12",
  "rand 0.8.5",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "serde_path_to_error",
  "sha2",
@@ -4874,7 +4874,7 @@ dependencies = [
  "olpc-cjson",
  "regex",
  "reqwest 0.12.7",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "thiserror",
@@ -4898,7 +4898,7 @@ dependencies = [
  "olpc-cjson",
  "regex",
  "reqwest 0.12.7",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "thiserror",
@@ -4916,7 +4916,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "oci-distribution 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "tokio",
@@ -4930,7 +4930,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d637c9c15b639ccff597da8f4fa968300651ad2f1e968aefc3b4927a6fb2027a"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "unicode-normalization",
 ]
@@ -5231,7 +5231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
  "base64 0.21.7",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -5258,7 +5258,7 @@ dependencies = [
  "pbjson-build",
  "prost 0.12.4",
  "prost-build",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -5280,7 +5280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
  "base64 0.21.7",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -5496,7 +5496,7 @@ checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
  "embedded-io",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -5791,7 +5791,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde-value",
  "tint",
 ]
@@ -6121,7 +6121,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.10",
  "rustls-pemfile 1.0.4",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
@@ -6170,7 +6170,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pemfile 2.1.2",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
@@ -6334,7 +6334,7 @@ dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
  "rustify_derive",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "serde_urlencoded",
  "thiserror",
@@ -6503,7 +6503,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93279b86b3de76f820a8854dd06cbc33cfa57a417b19c47f6a25280112fb1df"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
 ]
 
@@ -6577,7 +6577,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "zeroize",
 ]
 
@@ -6595,7 +6595,7 @@ dependencies = [
  "num",
  "once_cell",
  "rand 0.8.5",
- "serde 1.0.197",
+ "serde 1.0.210",
  "sha2",
  "zbus",
 ]
@@ -6629,7 +6629,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -6646,9 +6646,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -6672,7 +6672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -6681,14 +6681,14 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6701,18 +6701,19 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -6722,7 +6723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -6732,7 +6733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding",
- "serde 1.0.197",
+ "serde 1.0.210",
  "thiserror",
 ]
 
@@ -6753,7 +6754,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -6765,7 +6766,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -6779,7 +6780,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "serde_with_macros",
@@ -6807,7 +6808,7 @@ dependencies = [
  "indexmap 2.2.6",
  "itoa",
  "ryu",
- "serde 1.0.197",
+ "serde 1.0.210",
  "unsafe-libyaml",
 ]
 
@@ -6983,7 +6984,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -7072,7 +7073,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-locked-app",
  "thiserror",
@@ -7084,7 +7085,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-common",
  "spin-manifest",
  "subprocess",
@@ -7133,7 +7134,7 @@ dependencies = [
  "rpassword",
  "runtime-tests",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "spin-app",
@@ -7194,7 +7195,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "tempfile",
  "tokio",
@@ -7252,7 +7253,7 @@ dependencies = [
  "async-trait",
  "glob",
  "reqwest 0.11.27",
- "serde 1.0.197",
+ "serde 1.0.210",
  "similar",
  "spin-common",
  "spin-manifest",
@@ -7273,7 +7274,7 @@ dependencies = [
  "async-trait",
  "dotenvy",
  "once_cell",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-locked-app",
  "thiserror",
  "tokio",
@@ -7286,7 +7287,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-core",
  "spin-factors",
  "spin-factors-test",
@@ -7307,7 +7308,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-factors",
  "spin-factors-test",
  "spin-llm-local",
@@ -7396,7 +7397,7 @@ dependencies = [
  "rustls 0.23.7",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-expressions",
  "spin-factor-variables",
  "spin-factor-wasi",
@@ -7457,7 +7458,7 @@ name = "spin-factor-sqlite"
 version = "2.8.0-pre0"
 dependencies = [
  "async-trait",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-factors",
  "spin-factors-test",
  "spin-locked-app",
@@ -7476,7 +7477,7 @@ dependencies = [
  "azure_identity",
  "azure_security_keyvault",
  "dotenvy",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-expressions",
  "spin-factors",
  "spin-factors-test",
@@ -7507,7 +7508,7 @@ name = "spin-factors"
 version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-app",
  "spin-factors-derive",
  "thiserror",
@@ -7543,7 +7544,7 @@ dependencies = [
 name = "spin-factors-test"
 version = "2.8.0-pre0"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-app",
  "spin-factors",
  "spin-factors-derive",
@@ -7563,7 +7564,7 @@ dependencies = [
  "indexmap 1.9.3",
  "percent-encoding",
  "routefinder",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-app",
  "spin-locked-app",
  "toml 0.8.14",
@@ -7579,7 +7580,7 @@ dependencies = [
  "azure_data_cosmos",
  "azure_identity",
  "futures",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-core",
  "spin-factor-key-value",
  "tokio",
@@ -7592,7 +7593,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "redis 0.21.7",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-core",
  "spin-factor-key-value",
  "spin-world",
@@ -7607,7 +7608,7 @@ dependencies = [
  "anyhow",
  "once_cell",
  "rusqlite",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-core",
  "spin-factor-key-value",
  "spin-world",
@@ -7627,7 +7628,7 @@ dependencies = [
  "num_cpus",
  "rand 0.8.5",
  "safetensors",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-common",
  "spin-core",
  "spin-world",
@@ -7642,9 +7643,9 @@ name = "spin-llm-remote-http"
 version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
- "http 0.2.12",
+ "http 1.1.0",
  "reqwest 0.11.27",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-telemetry",
  "spin-world",
@@ -7669,7 +7670,7 @@ dependencies = [
  "regex",
  "reqwest 0.11.27",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "shellexpand 3.1.0",
@@ -7696,7 +7697,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-serde",
  "thiserror",
@@ -7710,7 +7711,7 @@ dependencies = [
  "glob",
  "indexmap 1.9.3",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-serde",
  "terminal",
@@ -7737,7 +7738,7 @@ dependencies = [
  "itertools 0.12.1",
  "oci-distribution 0.11.0 (git+https://github.com/fermyon/oci-distribution?rev=7e4ce9be9bcd22e78a28f06204931f10c44402ba)",
  "reqwest 0.11.27",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-common",
  "spin-loader",
@@ -7764,7 +7765,7 @@ dependencies = [
  "path-absolutize",
  "reqwest 0.11.27",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-common",
  "tar",
@@ -7840,7 +7841,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "wasm-pkg-common",
 ]
 
@@ -7849,7 +7850,7 @@ name = "spin-sqlite"
 version = "2.8.0-pre0"
 dependencies = [
  "async-trait",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-factor-sqlite",
  "spin-factors",
  "spin-locked-app",
@@ -7932,7 +7933,7 @@ dependencies = [
  "pathdiff",
  "regex",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-common",
  "spin-manifest",
  "tempfile",
@@ -7952,7 +7953,7 @@ dependencies = [
  "ctrlc",
  "futures",
  "sanitize-filename",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-app",
  "spin-common",
@@ -7990,7 +7991,7 @@ dependencies = [
  "rustls 0.23.7",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spin-app",
  "spin-core",
@@ -8021,7 +8022,7 @@ dependencies = [
  "async-trait",
  "futures",
  "redis 0.26.1",
- "serde 1.0.197",
+ "serde 1.0.210",
  "spin-factor-variables",
  "spin-factors",
  "spin-telemetry",
@@ -8057,7 +8058,7 @@ checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
 dependencies = [
  "base64 0.13.1",
  "nom 7.1.3",
- "serde 1.0.197",
+ "serde 1.0.210",
  "unicode-segmentation",
 ]
 
@@ -8388,18 +8389,18 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8438,7 +8439,7 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde 1.0.197",
+ "serde 1.0.210",
  "time-core",
  "time-macros",
 ]
@@ -8510,7 +8511,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.7.5",
  "reqwest 0.11.27",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "spm_precompiled",
  "thiserror",
@@ -8674,7 +8675,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -8684,7 +8685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_spanned",
  "toml_datetime",
  "toml_edit 0.22.14",
@@ -8696,7 +8697,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -8717,7 +8718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
@@ -8730,7 +8731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_spanned",
  "toml_datetime",
  "winnow 0.6.5",
@@ -8878,7 +8879,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "tracing-core",
 ]
 
@@ -8892,7 +8893,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -9062,7 +9063,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -9111,7 +9112,7 @@ dependencies = [
  "reqwest 0.11.27",
  "rustify",
  "rustify_derive",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "thiserror",
  "tracing",
@@ -9210,7 +9211,7 @@ checksum = "6a22d3c9026f2f6a628cf386963844cdb7baea3b3419ba090c9096da114f977d"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_with",
  "thiserror",
  "warg-crypto",
@@ -9242,7 +9243,7 @@ dependencies = [
  "reqwest 0.12.7",
  "secrecy",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha256",
  "tempfile",
@@ -9278,7 +9279,7 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "secrecy",
- "serde 1.0.197",
+ "serde 1.0.210",
  "sha2",
  "signature",
  "thiserror",
@@ -9299,7 +9300,7 @@ dependencies = [
  "prost-types",
  "protox",
  "regex",
- "serde 1.0.197",
+ "serde 1.0.210",
  "warg-crypto",
 ]
 
@@ -9317,7 +9318,7 @@ dependencies = [
  "prost 0.12.4",
  "prost-types",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_with",
  "thiserror",
  "warg-crypto",
@@ -9436,7 +9437,7 @@ dependencies = [
  "indexmap 2.2.6",
  "log",
  "petgraph",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_yaml",
  "smallvec",
@@ -9499,7 +9500,7 @@ checksum = "18ebaa7bd0f9e7a5e5dd29b9a998acf21c4abed74265524dd7e85934597bfb10"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "spdx",
@@ -9515,7 +9516,7 @@ checksum = "c31b8cc0c21f46d55b0aaa419cacce1eadcf28eaebd0e1488d6a6313ee71a586"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "spdx",
@@ -9531,7 +9532,7 @@ checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "spdx",
@@ -9547,7 +9548,7 @@ checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "spdx",
@@ -9566,7 +9567,7 @@ dependencies = [
  "http 1.1.0",
  "reqwest 0.12.7",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "thiserror",
  "toml 0.8.14",
@@ -9589,7 +9590,7 @@ dependencies = [
  "oci-distribution 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "oci-wasm",
  "secrecy",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_json",
  "sha2",
  "thiserror",
@@ -9672,7 +9673,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
 ]
 
 [[package]]
@@ -9727,7 +9728,7 @@ dependencies = [
  "rayon",
  "rustix 0.38.32",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "smallvec",
@@ -9772,7 +9773,7 @@ dependencies = [
  "log",
  "postcard",
  "rustix 0.38.32",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "sha2",
  "toml 0.8.14",
@@ -9840,7 +9841,7 @@ dependencies = [
  "object 0.36.0",
  "postcard",
  "rustc-demangle",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "target-lexicon",
  "wasm-encoder 0.209.1",
@@ -9902,7 +9903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
 dependencies = [
  "cranelift-entity",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "smallvec",
  "wasmparser 0.209.1",
@@ -10566,7 +10567,7 @@ dependencies = [
  "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.39.0",
@@ -10585,7 +10586,7 @@ dependencies = [
  "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.200.0",
@@ -10604,7 +10605,7 @@ dependencies = [
  "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.209.1",
@@ -10624,7 +10625,7 @@ dependencies = [
  "indexmap 2.2.6",
  "log",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "unicode-xid",
@@ -10641,7 +10642,7 @@ dependencies = [
  "indexmap 2.2.6",
  "log",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "unicode-xid",
@@ -10659,7 +10660,7 @@ dependencies = [
  "indexmap 2.2.6",
  "log",
  "semver",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_derive",
  "serde_json",
  "unicode-xid",
@@ -10745,7 +10746,7 @@ dependencies = [
  "once_cell",
  "ordered-stream",
  "rand 0.8.5",
- "serde 1.0.197",
+ "serde 1.0.210",
  "serde_repr",
  "sha1 0.10.6",
  "static_assertions",
@@ -10778,7 +10779,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
 dependencies = [
- "serde 1.0.197",
+ "serde 1.0.210",
  "static_assertions",
  "zvariant",
 ]
@@ -10904,7 +10905,7 @@ dependencies = [
  "byteorder",
  "enumflags2",
  "libc",
- "serde 1.0.197",
+ "serde 1.0.210",
  "static_assertions",
  "zvariant_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,15 +3670,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -3691,6 +3682,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3810,11 +3810,12 @@ dependencies = [
 
 [[package]]
 name = "kstring"
-version = "1.0.6"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "serde 1.0.210",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4043,12 +4044,11 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "liquid"
-version = "0.23.1"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e930310cf4334c4936ae18737500a57739c69442b5c42bae114d619af54b82"
+checksum = "7cdcc72b82748f47c2933c172313f5a9aea5b2c4eb3fa4c66b4ea55bb60bb4b1"
 dependencies = [
  "doc-comment",
- "kstring",
  "liquid-core",
  "liquid-derive",
  "liquid-lib",
@@ -4057,45 +4057,45 @@ dependencies = [
 
 [[package]]
 name = "liquid-core"
-version = "0.23.2"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eae470f061bfc53607283906de925ab67ed57a341e827146e3b241699a1dcde"
+checksum = "2752e978ffc53670f3f2e8b3ef09f348d6f7b5474a3be3f8a5befe5382e4effb"
 dependencies = [
  "anymap2",
- "chrono",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "kstring",
  "liquid-derive",
  "num-traits 0.2.18",
  "pest",
  "pest_derive",
+ "regex",
  "serde 1.0.210",
+ "time",
 ]
 
 [[package]]
 name = "liquid-derive"
-version = "0.23.1"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6510e456700da1afe07603913b0da5a2595f2482656ade07abf719aae7501f0a"
+checksum = "3b51f1d220e3fa869e24cfd75915efe3164bd09bb11b3165db3f37f57bf673e3"
 dependencies = [
  "proc-macro2",
- "proc-quote",
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "liquid-lib"
-version = "0.23.1"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6341259f779ff663bdf1fc478bddb2ca51fda25414006dc69395eddfac07e0a4"
+checksum = "59b1a298d3d2287ee5b1e43840d885b8fdfc37d3f4e90d82aacfd04d021618da"
 dependencies = [
- "chrono",
- "itertools 0.10.5",
- "kstring",
+ "itertools 0.13.0",
  "liquid-core",
  "once_cell",
  "percent-encoding",
  "regex",
+ "time",
  "unicode-segmentation",
 ]
 
@@ -5598,42 +5598,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-quote"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e84ab161de78c915302ca325a19bee6df272800e2ae1a43fe3ef430bab2a100"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "proc-quote-impl",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "proc-quote-impl"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb3ec628b063cdbcf316e06a8b8c1a541d28fa6c0a8eacd2bfb2b7f49e88aa0"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -5707,7 +5677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -7111,7 +7081,7 @@ dependencies = [
  "hyper-util",
  "indicatif 0.17.8",
  "is-terminal",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "lazy_static 1.4.0",
  "levenshtein",
  "nix 0.24.3",
@@ -7652,7 +7622,7 @@ dependencies = [
  "futures",
  "glob",
  "indexmap 1.9.3",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "lazy_static 1.4.0",
  "mime_guess",
  "path-absolutize",
@@ -7724,7 +7694,7 @@ dependencies = [
  "dkregistry",
  "docker_credential",
  "futures-util",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "oci-distribution 0.11.0 (git+https://github.com/fermyon/oci-distribution?rev=7e4ce9be9bcd22e78a28f06204931f10c44402ba)",
  "reqwest 0.12.7",
  "serde 1.0.210",
@@ -7912,7 +7882,7 @@ dependencies = [
  "fs_extra",
  "heck 0.4.1",
  "indexmap 1.9.3",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "lazy_static 1.4.0",
  "liquid",
  "liquid-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6099,7 +6099,6 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64 0.21.7",
  "bytes",
  "encoding_rs",
@@ -7252,7 +7251,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "glob",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "serde 1.0.210",
  "similar",
  "spin-common",
@@ -7643,8 +7642,7 @@ name = "spin-llm-remote-http"
 version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
- "http 1.1.0",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "serde 1.0.210",
  "serde_json",
  "spin-telemetry",
@@ -7668,7 +7666,7 @@ dependencies = [
  "mime_guess",
  "path-absolutize",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "semver",
  "serde 1.0.210",
  "serde_json",
@@ -7737,7 +7735,7 @@ dependencies = [
  "futures-util",
  "itertools 0.12.1",
  "oci-distribution 0.11.0 (git+https://github.com/fermyon/oci-distribution?rev=7e4ce9be9bcd22e78a28f06204931f10c44402ba)",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "serde 1.0.210",
  "serde_json",
  "spin-common",
@@ -7763,7 +7761,7 @@ dependencies = [
  "flate2",
  "is-terminal",
  "path-absolutize",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "semver",
  "serde 1.0.210",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7090,7 +7090,7 @@ dependencies = [
  "subprocess",
  "terminal",
  "tokio",
- "toml 0.5.11",
+ "toml 0.8.14",
  "tracing",
 ]
 
@@ -7277,7 +7277,7 @@ dependencies = [
  "spin-locked-app",
  "thiserror",
  "tokio",
- "toml 0.5.11",
+ "toml 0.8.14",
 ]
 
 [[package]]
@@ -7937,7 +7937,7 @@ dependencies = [
  "spin-manifest",
  "tempfile",
  "tokio",
- "toml 0.5.11",
+ "toml 0.8.14",
  "toml_edit 0.20.7",
  "url",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7218,7 +7218,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "dotenvy",
- "once_cell",
  "serde 1.0.210",
  "spin-locked-app",
  "thiserror",
@@ -7551,7 +7550,6 @@ name = "spin-key-value-spin"
 version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
- "once_cell",
  "rusqlite",
  "serde 1.0.210",
  "spin-core",
@@ -7812,7 +7810,6 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "once_cell",
  "rand 0.8.5",
  "rusqlite",
  "spin-factor-sqlite",
@@ -7841,7 +7838,6 @@ dependencies = [
  "anyhow",
  "http 0.2.12",
  "http 1.1.0",
- "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -8252,7 +8248,6 @@ name = "terminal"
 version = "2.8.0-pre0"
 dependencies = [
  "atty",
- "once_cell",
  "termcolor",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2997,7 +2997,7 @@ dependencies = [
  "indexmap 2.5.0",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3016,7 +3016,7 @@ dependencies = [
  "indexmap 2.5.0",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3939,7 +3939,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tower",
  "tracing",
 ]
@@ -4499,7 +4499,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.10",
+ "tokio-util",
  "twox-hash",
  "url",
 ]
@@ -5881,7 +5881,7 @@ dependencies = [
  "sha1 0.6.1",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.10",
+ "tokio-util",
  "url",
 ]
 
@@ -5904,7 +5904,7 @@ dependencies = [
  "sha1_smol",
  "socket2 0.5.6",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "url",
 ]
 
@@ -6052,7 +6052,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6101,7 +6101,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-socks",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7579,7 +7579,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "glob",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static 1.4.0",
  "mime_guess",
@@ -7600,7 +7600,7 @@ dependencies = [
  "terminal",
  "thiserror",
  "tokio",
- "tokio-util 0.6.10",
+ "tokio-util",
  "toml 0.8.14",
  "tracing",
  "ui-testing",
@@ -7663,7 +7663,7 @@ dependencies = [
  "spin-manifest",
  "tempfile",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tracing",
  "walkdir",
 ]
@@ -8495,7 +8495,7 @@ dependencies = [
  "rand 0.8.5",
  "socket2 0.5.6",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "whoami",
 ]
 
@@ -8550,20 +8550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -8682,7 +8668,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9150,7 +9136,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "tracing",
  "url",
  "walkdir",
@@ -9497,7 +9483,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util",
  "toml 0.8.14",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7206,7 +7206,7 @@ dependencies = [
  "terminal",
  "tokio",
  "toml 0.8.14",
- "toml_edit 0.20.7",
+ "toml_edit 0.22.14",
  "tracing",
  "ui-testing",
 ]
@@ -8662,8 +8662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.5.0",
- "serde 1.0.210",
- "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5887,9 +5887,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
+checksum = "a7e86f5670bd8b028edfb240f0616cad620705b31ec389d55e4f3da2c38dcd48"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5905,23 +5905,6 @@ dependencies = [
  "socket2 0.5.6",
  "tokio",
  "tokio-util",
- "url",
-]
-
-[[package]]
-name = "redis"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e86f5670bd8b028edfb240f0616cad620705b31ec389d55e4f3da2c38dcd48"
-dependencies = [
- "arc-swap",
- "combine",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "ryu",
- "sha1_smol",
- "socket2 0.5.6",
  "url",
 ]
 
@@ -7936,7 +7919,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "redis 0.26.1",
+ "redis 0.27.2",
  "serde 1.0.210",
  "spin-factor-variables",
  "spin-factors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,10 +706,10 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static 1.4.0",
  "lazycell",
  "proc-macro2",
@@ -728,9 +728,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitmaps"
@@ -2643,7 +2643,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "debugid",
  "fxhash",
  "serde 1.0.210",
@@ -3061,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -3898,7 +3898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3913,20 +3913,20 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
 [[package]]
 name = "libsql"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3879a4ed80a245fd4dd8c8fa139245653e86184ed3ab97a6d6ea592045d25793"
+checksum = "cc44962384bd2223269a81cd0d4a1683182b7bf0408b1d87e731c43e8c501270"
 dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "fallible-iterator 0.3.0",
  "futures",
@@ -3946,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "libsql-hrana"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f256c5c98e84808e067133253471d6f5961c670f0127150694210fb8e6116a"
+checksum = "aeaf5d19e365465e1c23d687a28c805d7462531b3f619f0ba49d3cf369890a3e"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -3958,11 +3958,11 @@ dependencies = [
 
 [[package]]
 name = "libsql-sqlite3-parser"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095d2cf702a5c9c152e48b369f69da30cc44351fa9432621dd8976834abc1752"
+checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cc",
  "fallible-iterator 0.3.0",
  "indexmap 2.5.0",
@@ -3971,15 +3971,14 @@ dependencies = [
  "phf",
  "phf_codegen",
  "phf_shared",
- "smallvec",
  "uncased",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.26.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4021,7 +4020,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -4513,7 +4512,7 @@ checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.7",
  "bindgen",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "btoi",
  "byteorder",
  "bytes",
@@ -4575,7 +4574,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4928,7 +4927,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5606,7 +5605,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -5626,7 +5625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -6207,12 +6206,12 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.29.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.5.0",
- "fallible-iterator 0.2.0",
+ "bitflags 2.6.0",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -6300,7 +6299,7 @@ version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "itoa",
  "libc",
@@ -7986,9 +7985,9 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlparser"
-version = "0.34.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
+checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
 dependencies = [
  "log",
 ]
@@ -8129,7 +8128,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
 ]
@@ -8160,7 +8159,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b858526d22750088a9b3cf2e3c2aacebd5377f13adeec02860c30d09113010a6"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cap-fs-ext",
  "cap-std 3.0.0",
  "fd-lock",
@@ -8819,7 +8818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -9527,7 +9526,7 @@ version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "indexmap 2.5.0",
  "semver",
 ]
@@ -9538,7 +9537,7 @@ version = "0.200.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a03f65ac876612140c57ff6c3b8fe4990067cce97c2cfdb07368a3cc3354b062"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "indexmap 2.5.0",
  "semver",
 ]
@@ -9549,7 +9548,7 @@ version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "indexmap 2.5.0",
  "semver",
 ]
@@ -9561,7 +9560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
 dependencies = [
  "ahash",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "hashbrown 0.14.3",
  "indexmap 2.5.0",
  "semver",
@@ -9575,7 +9574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
 dependencies = [
  "ahash",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "hashbrown 0.14.3",
  "indexmap 2.5.0",
  "semver",
@@ -9833,7 +9832,7 @@ checksum = "8abb1301089ed8e0b4840f539cba316a73ac382090f1b25d22d8c8eed8df49c7"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
@@ -10074,7 +10073,7 @@ checksum = "29830e5d01c182d24b94092c697aa7ab0ee97d22e78a2bf40ca91eae6ebca5c2"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -10458,7 +10457,7 @@ version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "windows-sys 0.52.0",
 ]
 
@@ -10469,7 +10468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39979723340baea490b87b11b2abae05f149d86f2b55c18d41d78a2a2b284c16"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "indexmap 2.5.0",
  "log",
  "serde 1.0.210",
@@ -10488,7 +10487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "indexmap 2.5.0",
  "log",
  "serde 1.0.210",
@@ -10507,7 +10506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7117809905e49db716d81e794f79590c052bf2fdbbcda1731ca0fb28f6f3ddf"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "indexmap 2.5.0",
  "log",
  "serde 1.0.210",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -831,9 +831,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde 1.0.210",
 ]
@@ -1217,15 +1217,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1762,12 +1762,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
- "nix 0.28.0",
- "windows-sys 0.52.0",
+ "nix 0.29.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3116,6 +3116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,7 +3274,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3389,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3641,11 +3647,11 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3872,9 +3878,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libflate"
@@ -3903,7 +3909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4609,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -4962,9 +4968,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -4994,9 +5000,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -6006,9 +6012,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick 1.1.3",
  "memchr",
@@ -7072,7 +7078,7 @@ dependencies = [
  "conformance-tests",
  "ctrlc",
  "dialoguer 0.10.4",
- "dirs 4.0.0",
+ "dirs 5.0.1",
  "futures",
  "glob",
  "hex",
@@ -7183,7 +7189,6 @@ dependencies = [
  "spin-componentize",
  "spin-serde",
  "thiserror",
- "tokio",
  "wac-graph",
 ]
 
@@ -8481,9 +8486,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8876,7 +8881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -9039,9 +9044,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7626,7 +7626,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "glob",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "semver",
  "serde 1.0.210",
  "serde_json",
@@ -7836,8 +7836,8 @@ dependencies = [
  "dialoguer 0.10.4",
  "dirs 5.0.1",
  "fs_extra",
- "heck 0.4.1",
- "indexmap 1.9.3",
+ "heck 0.5.0",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static 1.4.0",
  "liquid",
@@ -7901,7 +7901,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-util",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "percent-encoding",
  "rustls 0.23.7",
  "rustls-pemfile 2.1.2",
@@ -8243,7 +8243,7 @@ dependencies = [
 name = "test-codegen-macro"
 version = "0.0.0"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "quote",
  "syn 2.0.58",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a969e13a7589e9e3e4207e153bae624ade2b5622fb4684a4923b23ec3d57719"
 dependencies = [
  "serde 1.0.210",
- "toml 0.8.14",
+ "toml 0.8.15",
 ]
 
 [[package]]
@@ -1214,6 +1214,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1354,7 +1360,20 @@ dependencies = [
  "nix 0.26.4",
  "terminfo",
  "thiserror",
- "which",
+ "which 4.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "clearscreen"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8c93eb5f77c9050c7750e14f13ef1033a40a0aac70c6371535b6763a01438c"
+dependencies = [
+ "nix 0.28.0",
+ "terminfo",
+ "thiserror",
+ "which 6.0.3",
  "winapi",
 ]
 
@@ -1395,13 +1414,13 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "5.0.1"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width",
 ]
 
@@ -1460,7 +1479,7 @@ dependencies = [
  "anyhow",
  "flate2",
  "json5",
- "libtest-mimic 0.7.3",
+ "libtest-mimic",
  "reqwest 0.12.7",
  "serde 1.0.210",
  "tar",
@@ -1709,17 +1728,14 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "crossterm_winapi",
  "libc",
- "mio 0.8.11",
  "parking_lot",
- "signal-hook",
- "signal-hook-mio",
  "winapi",
 ]
 
@@ -2070,8 +2086,8 @@ dependencies = [
  "serde_ignored",
  "serde_json",
  "sha2",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "tar",
  "thiserror",
  "tokio",
@@ -3987,17 +4003,6 @@ dependencies = [
 
 [[package]]
 name = "libtest-mimic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
-dependencies = [
- "clap 4.5.4",
- "termcolor",
- "threadpool",
-]
-
-[[package]]
-name = "libtest-mimic"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58"
@@ -4435,18 +4440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "monostate"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,13 +4563,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -4635,7 +4640,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.8.11",
+ "mio",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -4967,9 +4972,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+checksum = "803801d3d3b71cd026851a53f974ea03df3d179cb758b260136a6c9e22e196af"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4981,9 +4986,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.13.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
+checksum = "88d8c2b76e5f7848a289aa9666dbe56b16f8a22a4c5246ef37a14941818d2913"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4994,9 +4999,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.17.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b925a602ffb916fb7421276b86756027b37ee708f9dce2dbdcc51739f07e727"
+checksum = "596b1719b3cab83addb20bcbffdf21575279d9436d9ccccfe651a3bf0ab5ab06"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -5014,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.7.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+checksum = "2c43620e8f93359eb7e627a3b16ee92d8585774986f24f2ab010817426c5ce61"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -5026,15 +5031,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+checksum = "9b8e442487022a943e2315740e443dc5ee95fd541c18f509a5a6251b408a9f95"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+checksum = "e0da0d6b47a3dbc6e9c9e36a0520e25cf943e046843818faaa3f87365a548c82"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -6808,27 +6813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio 0.8.11",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6997,7 +6981,7 @@ dependencies = [
  "subprocess",
  "terminal",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
 ]
 
@@ -7011,7 +6995,7 @@ dependencies = [
  "cargo-target-dep",
  "chrono",
  "clap 3.2.25",
- "clearscreen",
+ "clearscreen 3.0.0",
  "comfy-table",
  "command-group",
  "conformance",
@@ -7068,7 +7052,7 @@ dependencies = [
  "test-environment",
  "testing-framework",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "url",
  "uuid",
@@ -7104,7 +7088,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "wasm-encoder 0.200.0",
  "wasm-metadata 0.200.0",
@@ -7164,8 +7148,8 @@ dependencies = [
  "tempfile",
  "terminal",
  "tokio",
- "toml 0.8.14",
- "toml_edit 0.22.14",
+ "toml 0.8.15",
+ "toml_edit 0.22.16",
  "tracing",
  "ui-testing",
 ]
@@ -7180,7 +7164,7 @@ dependencies = [
  "spin-locked-app",
  "thiserror",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
 ]
 
 [[package]]
@@ -7200,7 +7184,7 @@ dependencies = [
  "table",
  "tempfile",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
 ]
 
@@ -7218,7 +7202,7 @@ dependencies = [
  "spin-locked-app",
  "spin-world",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "url",
 ]
@@ -7311,7 +7295,7 @@ dependencies = [
  "tempfile",
  "terminal",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "url",
  "urlencoding",
@@ -7367,7 +7351,7 @@ dependencies = [
  "spin-world",
  "table",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
 ]
 
@@ -7385,7 +7369,7 @@ dependencies = [
  "spin-factors-test",
  "spin-world",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "vaultrs",
 ]
@@ -7414,7 +7398,7 @@ dependencies = [
  "spin-app",
  "spin-factors-derive",
  "thiserror",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "wasmtime",
 ]
@@ -7452,7 +7436,7 @@ dependencies = [
  "spin-factors-derive",
  "spin-loader",
  "tempfile",
- "toml 0.8.14",
+ "toml 0.8.15",
 ]
 
 [[package]]
@@ -7469,7 +7453,7 @@ dependencies = [
  "serde 1.0.210",
  "spin-app",
  "spin-locked-app",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "wasmtime-wasi-http",
 ]
@@ -7584,7 +7568,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "ui-testing",
  "walkdir",
@@ -7616,7 +7600,7 @@ dependencies = [
  "spin-serde",
  "terminal",
  "thiserror",
- "toml 0.8.14",
+ "toml 0.8.15",
  "ui-testing",
  "url",
  "wasm-pkg-common",
@@ -7704,7 +7688,7 @@ dependencies = [
  "spin-world",
  "tempfile",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
 ]
 
 [[package]]
@@ -7759,7 +7743,7 @@ dependencies = [
  "spin-world",
  "table",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
 ]
 
 [[package]]
@@ -7836,8 +7820,8 @@ dependencies = [
  "spin-manifest",
  "tempfile",
  "tokio",
- "toml 0.8.14",
- "toml_edit 0.22.14",
+ "toml 0.8.15",
+ "toml_edit 0.22.16",
  "url",
  "walkdir",
 ]
@@ -7867,7 +7851,7 @@ dependencies = [
  "spin-world",
  "tempfile",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
 ]
 
@@ -8017,6 +8001,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8027,6 +8017,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8274,7 +8277,7 @@ dependencies = [
  "temp-dir",
  "test-environment",
  "tokio",
- "toml 0.8.14",
+ "toml 0.8.15",
  "wasmtime-wasi-http",
 ]
 
@@ -8419,27 +8422,28 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.2",
+ "mio",
+ "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.6",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8563,15 +8567,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
 dependencies = [
  "indexmap 2.5.0",
  "serde 1.0.210",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.16",
 ]
 
 [[package]]
@@ -8596,9 +8600,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
 dependencies = [
  "indexmap 2.5.0",
  "serde 1.0.210",
@@ -8727,9 +8731,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
+checksum = "5eabc56d23707ad55ba2a0750fc24767125d5a0f51993ba41ad2c441cc7b8dea"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -8829,7 +8833,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
- "libtest-mimic 0.6.1",
+ "libtest-mimic",
  "snapbox",
  "tokio",
 ]
@@ -8926,9 +8930,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -9441,7 +9445,7 @@ dependencies = [
  "serde 1.0.210",
  "serde_json",
  "thiserror",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
 ]
 
@@ -9467,7 +9471,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "toml 0.8.14",
+ "toml 0.8.15",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -9649,7 +9653,7 @@ dependencies = [
  "serde 1.0.210",
  "serde_derive",
  "sha2",
- "toml 0.8.14",
+ "toml 0.8.15",
  "windows-sys 0.52.0",
  "zstd 0.13.1",
 ]
@@ -9915,7 +9919,7 @@ dependencies = [
  "async-priority-channel",
  "async-recursion",
  "atomic-take",
- "clearscreen",
+ "clearscreen 2.0.1",
  "command-group",
  "futures",
  "ignore-files",
@@ -10021,6 +10025,18 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.32",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.32",
+ "winsafe",
 ]
 
 [[package]]
@@ -10419,6 +10435,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = "0.4"
 clap = { version = "3.2.24", features = ["derive", "env"] }
-clearscreen = "2.0.1"
-comfy-table = "5.0"
-command-group = "2.1"
+clearscreen = "3"
+comfy-table = "7"
+command-group = "2"
 ctrlc = { version = "3.4", features = ["termination"] }
 dialoguer = "0.10"
 dirs = { workspace = true }
@@ -132,23 +132,23 @@ http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 itertools = "0.13"
-opentelemetry = { version = "0.24.0", features = ["metrics", "trace", "logs"] }
-opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio", "logs_level_enabled", "metrics"] }
+opentelemetry = { version = "0.25", features = ["metrics", "trace", "logs"] }
+opentelemetry_sdk = { version = "0.25", features = ["rt-tokio", "logs_level_enabled", "metrics"] }
 rand = "0.8"
 regex = "1"
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
 # In `rustls` turn off the `aws_lc_rs` default feature and turn on `ring`.
 # If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"
 sha2 = "0.10"
-tempfile = "3.8"
+tempfile = "3"
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
 thiserror = "1"
 toml = "0.8"
 tracing = { version = "0.1", features = ["log"] }
-tracing-opentelemetry = { version = "0.25.0", default-features = false, features = ["metrics"] }
+tracing-opentelemetry = { version = "0.26", default-features = false, features = ["metrics"] }
 url = "2"
 
 wasi-common-preview1 = { version = "22.0.0", package = "wasi-common", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ reqwest = { workspace = true }
 rpassword = "7.0"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.82"
+serde_json = { workspace = true }
 sha2 = "0.10.2"
 spin-app = { path = "crates/app" }
 spin-build = { path = "crates/build" }
@@ -123,18 +123,23 @@ members = [
 ]
 
 [workspace.dependencies]
-anyhow = "1.0.75"
+anyhow = "1"
+async-trait = "0.1"
 conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
-http-body-util = "0.1.0"
-hyper = { version = "1.0.0", features = ["full"] }
+http = "1"
+http-body-util = "0.1"
+hyper = { version = "1", features = ["full"] }
 opentelemetry = { version = "0.24.0", features = ["metrics", "trace", "logs"] }
 opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio", "logs_level_enabled", "metrics"] }
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
 # In `rustls` turn off the `aws_lc_rs` default feature and turn on `ring`.
 # If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
+serde_json = "1.0.128"
+serde = { version = "1.0.210", features = ["derive", "rc"] }
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
 toml = "0.8"
+thiserror = "1"
 tracing = { version = "0.1", features = ["log"] }
 tracing-opentelemetry = { version = "0.25.0", default-features = false, features = ["metrics"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ is-terminal = "0.4"
 itertools = { workspace = true }
 lazy_static = "1.4.0"
 levenshtein = "1.0.5"
-nix = { version = "0.24", features = ["signal"] }
+nix = { version = "0.29", features = ["signal"] }
 path-absolutize = "3.0.11"
 rand = { workspace = true }
 regex = { workspace = true }
@@ -43,7 +43,7 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-subprocess = "0.2.9"
+subprocess = "0.2"
 tempfile = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 toml = { workspace = true }
@@ -84,17 +84,16 @@ openssl = { version = "0.10" }
 anyhow = { workspace = true, features = ["backtrace"] }
 conformance = { path = "tests/conformance-tests" }
 conformance-tests = { workspace = true }
-hex = "0.4.3"
+hex = "0.4"
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { version = "0.1", features = ["tokio"] }
-redis = "0.24"
+redis = "0.27"
 runtime-tests = { path = "tests/runtime-tests" }
 test-codegen-macro = { path = "crates/test-codegen-macro" }
 test-components = { path = "tests/test-components" }
 test-environment = { workspace = true }
 testing-framework = { path = "tests/testing-framework" }
-which = "4.2.5"
 
 [build-dependencies]
 cargo-target-dep = { git = "https://github.com/fermyon/cargo-target-dep", rev = "482f269eceb7b1a7e8fc618bf8c082dd24979cf1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ members = [
 anyhow = "1"
 async-trait = "0.1"
 conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
+futures = "0.3"
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3"
 glob = "0.3.1"
 indicatif = "0.17.3"
 is-terminal = "0.4"
-itertools = "0.11.0"
+itertools = { workspace = true }
 lazy_static = "1.4.0"
 levenshtein = "1.0.5"
 nix = { version = "0.24", features = ["signal"] }
@@ -130,6 +130,7 @@ futures = "0.3"
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
+itertools = "0.13"
 opentelemetry = { version = "0.24.0", features = ["metrics", "trace", "logs"] }
 opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio", "logs_level_enabled", "metrics"] }
 reqwest = { version = "0.12", features = ["stream", "blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rpassword = "7.0"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
-sha2 = "0.10.2"
+sha2 = { workspace = true }
 spin-app = { path = "crates/app" }
 spin-build = { path = "crates/build" }
 spin-common = { path = "crates/common" }
@@ -65,11 +65,11 @@ spin-trigger-redis = { path = "crates/trigger-redis" }
 terminal = { path = "crates/terminal" }
 
 subprocess = "0.2.9"
-tempfile = "3.8.0"
+tempfile = { workspace = true }
 tokio = { version = "1.23", features = ["full"] }
 toml = { workspace = true }
 tracing = { workspace = true }
-url = "2.2.2"
+url = { workspace = true }
 uuid = { version = "^1.0", features = ["v4"] }
 wasmtime = { workspace = true }
 watchexec = { git = "https://github.com/watchexec/watchexec.git", rev = "8e91d26ef6400c1e60b32a8314cbb144fa33f288" }
@@ -90,7 +90,6 @@ hyper = { workspace = true }
 hyper-util = { version = "0.1.2", features = ["tokio"] }
 redis = "0.24"
 runtime-tests = { path = "tests/runtime-tests" }
-sha2 = "0.10.1"
 test-codegen-macro = { path = "crates/test-codegen-macro" }
 test-components = { path = "tests/test-components" }
 test-environment = { workspace = true }
@@ -126,6 +125,7 @@ members = [
 anyhow = "1"
 async-trait = "0.1"
 conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
+dirs = "5.0"
 futures = "0.3"
 http = "1"
 http-body-util = "0.1"
@@ -138,11 +138,14 @@ reqwest = { version = "0.12", features = ["stream", "blocking"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 serde_json = "1.0.128"
 serde = { version = "1.0.210", features = ["derive", "rc"] }
+sha2 = "0.10"
+tempfile = "3.8"
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
 toml = "0.8"
 thiserror = "1"
 tracing = { version = "0.1", features = ["log"] }
 tracing-opentelemetry = { version = "0.25.0", default-features = false, features = ["metrics"] }
+url = "2"
 
 wasi-common-preview1 = { version = "22.0.0", package = "wasi-common", features = [
   "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ terminal = { path = "crates/terminal" }
 subprocess = "0.2.9"
 tempfile = "3.8.0"
 tokio = { version = "1.23", features = ["full"] }
-toml = "0.8"
+toml = { workspace = true }
 tracing = { workspace = true }
 url = "2.2.2"
 uuid = { version = "^1.0", features = ["v4"] }
@@ -134,6 +134,7 @@ reqwest = { version = "0.12", features = ["stream", "blocking"] }
 # If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
+toml = "0.8"
 tracing = { version = "0.1", features = ["log"] }
 tracing-opentelemetry = { version = "0.25.0", default-features = false, features = ["metrics"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,33 +16,44 @@ rust-version = "1.79"
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1"
-bytes = "1.1"
+async-trait = { workspace = true }
+bytes = { workspace = true }
 chrono = "0.4"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 clearscreen = "2.0.1"
 comfy-table = "5.0"
 command-group = "2.1"
-ctrlc = { version = "3.2", features = ["termination"] }
+ctrlc = { version = "3.4", features = ["termination"] }
 dialoguer = "0.10"
-dirs = "4.0"
-futures = "0.3"
-glob = "0.3.1"
-indicatif = "0.17.3"
+dirs = { workspace = true }
+futures = { workspace = true }
+glob = { workspace = true }
+indicatif = "0.17"
 is-terminal = "0.4"
 itertools = { workspace = true }
 lazy_static = "1.4.0"
 levenshtein = "1.0.5"
 nix = { version = "0.24", features = ["signal"] }
 path-absolutize = "3.0.11"
-rand = "0.8"
-regex = "1.5.5"
+rand = { workspace = true }
+regex = { workspace = true }
 reqwest = { workspace = true }
 rpassword = "7.0"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+subprocess = "0.2.9"
+tempfile = { workspace = true }
+tokio = { version = "1", features = ["full"] }
+toml = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+uuid = { version = "1.0", features = ["v4"] }
+wasmtime = { workspace = true }
+watchexec = { git = "https://github.com/watchexec/watchexec.git", rev = "8e91d26ef6400c1e60b32a8314cbb144fa33f288" }
+watchexec-filterer-globset = { git = "https://github.com/watchexec/watchexec.git", rev = "8e91d26ef6400c1e60b32a8314cbb144fa33f288" }
+
 spin-app = { path = "crates/app" }
 spin-build = { path = "crates/build" }
 spin-common = { path = "crates/common" }
@@ -64,17 +75,6 @@ spin-trigger-http = { path = "crates/trigger-http" }
 spin-trigger-redis = { path = "crates/trigger-redis" }
 terminal = { path = "crates/terminal" }
 
-subprocess = "0.2.9"
-tempfile = { workspace = true }
-tokio = { version = "1.23", features = ["full"] }
-toml = { workspace = true }
-tracing = { workspace = true }
-url = { workspace = true }
-uuid = { version = "^1.0", features = ["v4"] }
-wasmtime = { workspace = true }
-watchexec = { git = "https://github.com/watchexec/watchexec.git", rev = "8e91d26ef6400c1e60b32a8314cbb144fa33f288" }
-watchexec-filterer-globset = { git = "https://github.com/watchexec/watchexec.git", rev = "8e91d26ef6400c1e60b32a8314cbb144fa33f288" }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable
 # '--features openssl/vendored', which is used for Linux releases.
@@ -87,7 +87,7 @@ conformance-tests = { workspace = true }
 hex = "0.4.3"
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { version = "0.1.2", features = ["tokio"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 redis = "0.24"
 runtime-tests = { path = "tests/runtime-tests" }
 test-codegen-macro = { path = "crates/test-codegen-macro" }
@@ -124,26 +124,30 @@ members = [
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
+bytes = "1"
 conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
 dirs = "5.0"
 futures = "0.3"
+glob = "0.3"
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 itertools = "0.13"
 opentelemetry = { version = "0.24.0", features = ["metrics", "trace", "logs"] }
 opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio", "logs_level_enabled", "metrics"] }
+rand = "0.8"
+regex = "1"
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
 # In `rustls` turn off the `aws_lc_rs` default feature and turn on `ring`.
 # If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
-serde_json = "1.0.128"
-serde = { version = "1.0.210", features = ["derive", "rc"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json = "1.0"
 sha2 = "0.10"
 tempfile = "3.8"
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "387b7f375df59e6254a7c29cf4a53507a9f46d32" }
-toml = "0.8"
 thiserror = "1"
+toml = "0.8"
 tracing = { version = "0.1", features = ["log"] }
 tracing-opentelemetry = { version = "0.25.0", default-features = false, features = ["metrics"] }
 url = "2"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -5,9 +5,9 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 spin-locked-app = { path = "../locked-app" }
-thiserror = "1.0"
+thiserror = { workspace = true }

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-futures = "0.3.21"
+futures = { workspace = true }
 serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -13,5 +13,5 @@ spin-manifest = { path = "../manifest" }
 subprocess = "0.2.8"
 terminal = { path = "../terminal" }
 tokio = { version = "1.23", features = ["full"] }
-toml = "0.5"
+toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -10,8 +10,8 @@ futures = { workspace = true }
 serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
-subprocess = "0.2.8"
+subprocess = "0.2"
 terminal = { path = "../terminal" }
-tokio = { version = "1.23", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -5,9 +5,9 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
+anyhow = { workspace = true }
 futures = "0.3.21"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
 subprocess = "0.2.8"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -6,8 +6,8 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-dirs = "5.0.1"
-sha2 = "0.10"
-tempfile = "3.5"
+dirs = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
 tokio = { version = "1", features = ["rt", "time"] }
-url = "2"
+url = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 dirs = "5.0.1"
 sha2 = "0.10"
 tempfile = "3.5"

--- a/crates/componentize/Cargo.toml
+++ b/crates/componentize/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.10.0"
 tokio = { version = "1.36.0", features = ["macros", "rt", "fs"] }
-toml = "0.8.10"
+toml = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wat = "1.200.0"

--- a/crates/componentize/Cargo.toml
+++ b/crates/componentize/Cargo.toml
@@ -19,15 +19,15 @@ wit-parser = "0.200.0"
 
 [dev-dependencies]
 async-trait = { workspace = true }
-cap-std = "2.0.1"
+cap-std = "2.0"
 rand = { workspace = true }
-rand_chacha = "0.3.1"
-rand_core = "0.6.4"
+rand_chacha = "0.3"
+rand_core = "0.6"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-tokio = { version = "1.36.0", features = ["macros", "rt", "fs"] }
+tokio = { version = "1", features = ["macros", "rt", "fs"] }
 toml = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
-wat = "1.200.0"
+wat = "1"

--- a/crates/componentize/Cargo.toml
+++ b/crates/componentize/Cargo.toml
@@ -18,13 +18,13 @@ wit-component = "0.200.0"
 wit-parser = "0.200.0"
 
 [dev-dependencies]
-async-trait = "0.1.77"
+async-trait = { workspace = true }
 cap-std = "2.0.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 tempfile = "3.10.0"
 tokio = { version = "1.36.0", features = ["macros", "rt", "fs"] }
 toml = { workspace = true }

--- a/crates/componentize/Cargo.toml
+++ b/crates/componentize/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-tracing = "0.1"
+tracing = { workspace = true }
 wasm-encoder = "0.200.0"
 wasm-metadata = "0.200.0"
 wasmparser = "0.200.0"

--- a/crates/componentize/Cargo.toml
+++ b/crates/componentize/Cargo.toml
@@ -20,7 +20,7 @@ wit-parser = "0.200.0"
 [dev-dependencies]
 async-trait = { workspace = true }
 cap-std = "2.0.1"
-rand = "0.8.5"
+rand = { workspace = true }
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 serde = { workspace = true }

--- a/crates/componentize/Cargo.toml
+++ b/crates/componentize/Cargo.toml
@@ -25,7 +25,7 @@ rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
-tempfile = "3.10.0"
+tempfile = { workspace = true }
 tokio = { version = "1.36.0", features = ["macros", "rt", "fs"] }
 toml = { workspace = true }
 wasmtime = { workspace = true }

--- a/crates/componentize/tests/case-helper/Cargo.toml
+++ b/crates/componentize/tests/case-helper/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = "1"
 clap = { version = "~4.4", features = ["derive", "env"] }
 getrandom = "0.2.12"
 

--- a/crates/componentize/tests/case-helper/Cargo.toml
+++ b/crates/componentize/tests/case-helper/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.80"
+anyhow = { workspace = true }
 clap = { version = "~4.4", features = ["derive", "env"] }
 getrandom = "0.2.12"
 

--- a/crates/componentize/tests/rust-case-0.2/Cargo.toml
+++ b/crates/componentize/tests/rust-case-0.2/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.80"
+anyhow = { workspace = true }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 case-helper = { path = "../case-helper" }
 

--- a/crates/componentize/tests/rust-case-0.2/Cargo.toml
+++ b/crates/componentize/tests/rust-case-0.2/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = "1"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 case-helper = { path = "../case-helper" }
 

--- a/crates/componentize/tests/rust-case-0.8/Cargo.toml
+++ b/crates/componentize/tests/rust-case-0.8/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 case-helper = { path = "../case-helper" }
-anyhow = "1.0.80"
+anyhow = { workspace = true }
 wit-bindgen = "0.8"
 
 [workspace]

--- a/crates/componentize/tests/rust-case-0.8/Cargo.toml
+++ b/crates/componentize/tests/rust-case-0.8/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 case-helper = { path = "../case-helper" }
-anyhow = { workspace = true }
+anyhow = "1"
 wit-bindgen = "0.8"
 
 [workspace]

--- a/crates/compose/Cargo.toml
+++ b/crates/compose/Cargo.toml
@@ -10,13 +10,13 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 indexmap = "2.2.6"
 semver = "1"
 spin-app = { path = "../app" }
 spin-componentize = { workspace = true }
 spin-serde = { path = "../serde" }
-thiserror = "1"
+thiserror = { workspace = true }
 tokio = { version = "1.23", features = ["fs"] }
 wac-graph = "0.5.0"
 

--- a/crates/compose/Cargo.toml
+++ b/crates/compose/Cargo.toml
@@ -11,13 +11,13 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-indexmap = "2.2.6"
+indexmap = "2"
 semver = "1"
 spin-app = { path = "../app" }
 spin-componentize = { workspace = true }
 spin-serde = { path = "../serde" }
 thiserror = { workspace = true }
-wac-graph = "0.5.0"
+wac-graph = "0.6"
 
 [lints]
 workspace = true

--- a/crates/compose/Cargo.toml
+++ b/crates/compose/Cargo.toml
@@ -17,7 +17,6 @@ spin-app = { path = "../app" }
 spin-componentize = { workspace = true }
 spin-serde = { path = "../serde" }
 thiserror = { workspace = true }
-tokio = { version = "1.23", features = ["fs"] }
 wac-graph = "0.5.0"
 
 [lints]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,8 +5,8 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -5,10 +5,10 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 reqwest = { version = "0.11", features = ["stream"] }
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true }
 similar = "2"
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -20,7 +20,7 @@ toml_edit = { version = "0.20.2", features = ["serde"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-glob = "0.3.1"
+glob = { workspace = true }
 tempfile = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 ui-testing = { path = "../ui-testing" }

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -16,7 +16,7 @@ tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 tokio = { version = "1", features = ["process"] }
 toml = { workspace = true }
-toml_edit = { version = "0.20.2", features = ["serde"] }
+toml_edit = { version = "0.22", features = ["serde"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-reqwest = { version = "0.11", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream"] }
 serde = { workspace = true }
 similar = "2"
 spin-common = { path = "../common" }

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -15,7 +15,7 @@ spin-manifest = { path = "../manifest" }
 tempfile = "3.3.0"
 terminal = { path = "../terminal" }
 tokio = { version = "1", features = ["process"] }
-toml = "0.8.2"
+toml = { workspace = true }
 toml_edit = { version = "0.20.2", features = ["serde"] }
 tracing = { workspace = true }
 

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true }
 similar = "2"
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 tokio = { version = "1", features = ["process"] }
 toml = { workspace = true }
@@ -21,7 +21,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 glob = "0.3.1"
-tempfile = "3"
+tempfile = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 ui-testing = { path = "../ui-testing" }
 

--- a/crates/doctor/src/lib.rs
+++ b/crates/doctor/src/lib.rs
@@ -6,7 +6,7 @@ use std::{collections::VecDeque, fmt::Debug, fs, path::PathBuf};
 use anyhow::{ensure, Context, Result};
 use async_trait::async_trait;
 use spin_common::ui::quoted_path;
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 
 /// Diagnoses for app manifest format problems.
 pub mod manifest;
@@ -81,7 +81,7 @@ pub struct PatientApp {
     /// Path to an app manifest file.
     pub manifest_path: PathBuf,
     /// Parsed app manifest TOML document.
-    pub manifest_doc: Document,
+    pub manifest_doc: DocumentMut,
 }
 
 impl PatientApp {
@@ -100,7 +100,7 @@ impl PatientApp {
             )
         })?;
 
-        let manifest_doc: Document = contents.parse().with_context(|| {
+        let manifest_doc: DocumentMut = contents.parse().with_context(|| {
             format!(
                 "Couldn't parse manifest file at {} as valid TOML",
                 quoted_path(&path)

--- a/crates/doctor/src/manifest.rs
+++ b/crates/doctor/src/manifest.rs
@@ -3,7 +3,7 @@ use std::fs;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use spin_common::ui::quoted_path;
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 
 use crate::Treatment;
 
@@ -22,7 +22,7 @@ pub trait ManifestTreatment {
     fn summary(&self) -> String;
 
     /// Attempt to fix this problem. See [`Treatment::treat`].
-    async fn treat_manifest(&self, doc: &mut Document) -> Result<()>;
+    async fn treat_manifest(&self, doc: &mut DocumentMut) -> Result<()>;
 }
 
 #[async_trait]

--- a/crates/doctor/src/manifest/trigger.rs
+++ b/crates/doctor/src/manifest/trigger.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, ensure, Context, Result};
 use async_trait::async_trait;
 use toml::Value;
-use toml_edit::{Document, InlineTable, Item, Table};
+use toml_edit::{DocumentMut, InlineTable, Item, Table};
 
 use crate::{Diagnosis, Diagnostic, PatientApp, Treatment};
 
@@ -149,7 +149,7 @@ impl ManifestTreatment for TriggerDiagnosis {
         }
     }
 
-    async fn treat_manifest(&self, doc: &mut Document) -> anyhow::Result<()> {
+    async fn treat_manifest(&self, doc: &mut DocumentMut) -> anyhow::Result<()> {
         match self {
             Self::MissingAppTrigger => {
                 // Get or insert missing trigger config

--- a/crates/doctor/src/manifest/version.rs
+++ b/crates/doctor/src/manifest/version.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
 use toml::Value;
-use toml_edit::{de::from_document, Document, Item};
+use toml_edit::{de::from_document, DocumentMut, Item};
 
 use crate::{Diagnosis, Diagnostic, PatientApp, Treatment};
 
@@ -96,7 +96,7 @@ impl ManifestTreatment for VersionDiagnosis {
         }
     }
 
-    async fn treat_manifest(&self, doc: &mut Document) -> anyhow::Result<()> {
+    async fn treat_manifest(&self, doc: &mut DocumentMut) -> anyhow::Result<()> {
         doc.remove(SPIN_VERSION);
 
         let item = Item::Value(match self {

--- a/crates/expressions/Cargo.toml
+++ b/crates/expressions/Cargo.toml
@@ -15,4 +15,4 @@ thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-toml = "0.5"
+toml = { workspace = true }

--- a/crates/expressions/Cargo.toml
+++ b/crates/expressions/Cargo.toml
@@ -5,13 +5,13 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 dotenvy = "0.15"
 once_cell = "1"
-serde = "1.0.188"
+serde = { workspace = true }
 spin-locked-app = { path = "../locked-app" }
-thiserror = "1"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/expressions/Cargo.toml
+++ b/crates/expressions/Cargo.toml
@@ -8,7 +8,6 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 dotenvy = "0.15"
-once_cell = "1"
 serde = { workspace = true }
 spin-locked-app = { path = "../locked-app" }
 thiserror = { workspace = true }

--- a/crates/expressions/Cargo.toml
+++ b/crates/expressions/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-dotenvy = "0.15"
 serde = { workspace = true }
 spin-locked-app = { path = "../locked-app" }
 thiserror = { workspace = true }

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-lru = "0.9.0"
+lru = "0.12"
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factors = { path = "../factors" }

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -21,7 +21,7 @@ tracing = { workspace = true }
 spin-factors-test = { path = "../factors-test" }
 spin-key-value-spin = { path = "../key-value-spin" }
 spin-key-value-redis = { path = "../key-value-redis" }
-tempfile = "3.12.0"
+tempfile = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 
 

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -5,9 +5,9 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 lru = "0.9.0"
-serde = { version = "1.0", features = ["rc"] }
+serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -14,7 +14,7 @@ spin-locked-app = { path = "../locked-app" }
 spin-world = { path = "../world" }
 table = { path = "../table" }
 tokio = { version = "1", features = ["macros", "sync", "rt"] }
-toml = "0.8"
+toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/factor-llm/Cargo.toml
+++ b/crates/factor-llm/Cargo.toml
@@ -23,7 +23,7 @@ spin-llm-remote-http = { path = "../llm-remote-http" }
 spin-locked-app = { path = "../locked-app" }
 spin-world = { path = "../world" }
 tokio = { version = "1", features = ["sync"] }
-toml = "0.8"
+toml = { workspace = true }
 tracing = { workspace = true }
 url = { version = "2", features = ["serde"] }
 

--- a/crates/factor-llm/Cargo.toml
+++ b/crates/factor-llm/Cargo.toml
@@ -14,9 +14,9 @@ llm-metal = ["llm", "spin-llm-local/metal"]
 llm-cublas = ["llm", "spin-llm-local/cublas"]
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-serde = "1.0"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
 spin-factors = { path = "../factors" }
 spin-llm-local = { path = "../llm-local", optional = true }
 spin-llm-remote-http = { path = "../llm-remote-http" }

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -5,10 +5,10 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-http = "1.1.0"
+anyhow = { workspace = true }
+http = { workspace = true }
 http-body-util = "0.1"
-hyper = "1.4.1"
+hyper = { workspace = true }
 ip_network = "0.4"
 reqwest = { version = "0.12", features = ["gzip"] }
 rustls = { workspace = true }

--- a/crates/factor-outbound-mqtt/Cargo.toml
+++ b/crates/factor-outbound-mqtt/Cargo.toml
@@ -12,7 +12,7 @@ spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-world = { path = "../world" }
 table = { path = "../table" }
-tokio = { version = "1.0", features = ["sync"] }
+tokio = { version = "1", features = ["sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/factor-outbound-mqtt/Cargo.toml
+++ b/crates/factor-outbound-mqtt/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 rumqttc = { version = "0.24", features = ["url"] }
 spin-core = { path = "../core" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -25,7 +25,7 @@ spin-world = { path = "../world" }
 table = { path = "../table" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tracing = { workspace = true }
-url = "2.3.1"
+url = { workspace = true }
 
 [dev-dependencies]
 spin-factor-variables = { path = "../factor-variables" }

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 doctest = false
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 flate2 = "1.0.17"
 # Removing default features for mysql_async to remove flate2/zlib feature
 mysql_async = { version = "0.33.0", default-features = false, features = [

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -24,7 +24,7 @@ spin-factors = { path = "../factors" }
 spin-world = { path = "../world" }
 table = { path = "../table" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
-tracing = { version = "0.1", features = ["log"] }
+tracing = { workspace = true }
 url = "2.3.1"
 
 [dev-dependencies]

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -9,13 +9,13 @@ doctest = false
 
 [dependencies]
 anyhow = { workspace = true }
-flate2 = "1.0.17"
+flate2 = "1"
 # Removing default features for mysql_async to remove flate2/zlib feature
-mysql_async = { version = "0.33.0", default-features = false, features = [
+mysql_async = { version = "0.34", default-features = false, features = [
   "native-tls-tls",
 ] }
 # Removing default features for mysql_common to remove flate2/zlib feature
-mysql_common = { version = "0.31.0", default-features = false }
+mysql_common = { version = "0.32", default-features = false }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-expressions = { path = "../expressions" }

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -30,7 +30,7 @@ webpki-roots = "0.26"
 spin-factors-test = { path = "../factors-test" }
 tempfile = "3.10.1"
 tokio = { version = "1", features = ["macros", "rt"] }
-toml = "0.8"
+toml = { workspace = true }
 wasmtime-wasi = { workspace = true }
 
 [features]

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -8,9 +8,9 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 futures-util = "0.3"
 http = { workspace = true }
-ipnet = "2.9.0"
+ipnet = "2"
 rustls = { workspace = true }
-rustls-pemfile = { version = "2.1.2", optional = true }
+rustls-pemfile = { version = "2", optional = true }
 rustls-pki-types = "1.7.0"
 serde = { workspace = true }
 spin-expressions = { path = "../expressions" }

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -22,13 +22,13 @@ spin-manifest = { path = "../manifest" }
 spin-serde = { path = "../serde" }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }
-url = "2.4.1"
+url = { workspace = true }
 urlencoding = "2.1"
 webpki-roots = "0.26"
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 toml = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -5,14 +5,14 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 futures-util = "0.3"
-http = "1.1.0"
+http = { workspace = true }
 ipnet = "2.9.0"
 rustls = { workspace = true }
 rustls-pemfile = { version = "2.1.2", optional = true }
 rustls-pki-types = "1.7.0"
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true }
 spin-expressions = { path = "../expressions" }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factor-wasi = { path = "../factor-wasi" }

--- a/crates/factor-outbound-pg/Cargo.toml
+++ b/crates/factor-outbound-pg/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 native-tls = "0.2.11"
 postgres-native-tls = "0.5.0"
 spin-core = { path = "../core" }

--- a/crates/factor-outbound-redis/Cargo.toml
+++ b/crates/factor-outbound-redis/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 redis = { version = "0.21", features = ["tokio-comp", "tokio-native-tls-comp", "aio"] }
 spin-core = { path = "../core" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }

--- a/crates/factor-sqlite/Cargo.toml
+++ b/crates/factor-sqlite/Cargo.toml
@@ -16,7 +16,7 @@ spin-locked-app = { path = "../locked-app" }
 spin-world = { path = "../world" }
 table = { path = "../table" }
 tokio = "1"
-toml = "0.8"
+toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/factor-sqlite/Cargo.toml
+++ b/crates/factor-sqlite/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait = "0.1"
-serde = { version = "1.0", features = ["rc"] }
+async-trait = { workspace = true }
+serde = { workspace = true }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }
 spin-world = { path = "../world" }

--- a/crates/factor-variables/Cargo.toml
+++ b/crates/factor-variables/Cargo.toml
@@ -14,7 +14,7 @@ spin-expressions = { path = "../expressions" }
 spin-factors = { path = "../factors" }
 spin-world = { path = "../world" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
-toml = "0.8"
+toml = { workspace = true }
 tracing = { workspace = true }
 vaultrs = "0.6.2"
 

--- a/crates/factor-variables/Cargo.toml
+++ b/crates/factor-variables/Cargo.toml
@@ -9,7 +9,7 @@ azure_core = { git = "https://github.com/azure/azure-sdk-for-rust", rev = "8c4ca
 azure_identity = { git = "https://github.com/azure/azure-sdk-for-rust", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
 azure_security_keyvault = { git = "https://github.com/azure/azure-sdk-for-rust", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
 dotenvy = "0.15"
-serde = { version = "1.0", features = ["rc"] }
+serde = { workspace = true }
 spin-expressions = { path = "../expressions" }
 spin-factors = { path = "../factors" }
 spin-world = { path = "../world" }

--- a/crates/factor-wasi/Cargo.toml
+++ b/crates/factor-wasi/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 bytes = "1.0"
 cap-primitives = "3.0.0"
 spin-common = { path = "../common" }

--- a/crates/factor-wasi/Cargo.toml
+++ b/crates/factor-wasi/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
-bytes = "1.0"
+bytes = { workspace = true }
 cap-primitives = "3.0.0"
 spin-common = { path = "../common" }
 spin-factors = { path = "../factors" }

--- a/crates/factors-executor/Cargo.toml
+++ b/crates/factors-executor/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-factors = { path = "../factors" }

--- a/crates/factors-test/Cargo.toml
+++ b/crates/factors-test/Cargo.toml
@@ -10,7 +10,7 @@ spin-app = { path = "../app" }
 spin-factors = { path = "../factors" }
 spin-factors-derive = { path = "../factors-derive", features = ["expander"] }
 spin-loader = { path = "../loader" }
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 toml = { workspace = true }
 
 [lints]

--- a/crates/factors-test/Cargo.toml
+++ b/crates/factors-test/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 spin-app = { path = "../app" }
 spin-factors = { path = "../factors" }
 spin-factors-derive = { path = "../factors-derive", features = ["expander"] }

--- a/crates/factors-test/Cargo.toml
+++ b/crates/factors-test/Cargo.toml
@@ -11,7 +11,7 @@ spin-factors = { path = "../factors" }
 spin-factors-derive = { path = "../factors-derive", features = ["expander"] }
 spin-loader = { path = "../loader" }
 tempfile = "3.10.1"
-toml = "0.8.14"
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/factors/Cargo.toml
+++ b/crates/factors/Cargo.toml
@@ -5,11 +5,11 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-serde = "1.0"
+anyhow = { workspace = true }
+serde = { workspace = true }
 spin-app = { path = "../app" }
 spin-factors-derive = { path = "../factors-derive" }
-thiserror = "1.0"
+thiserror = { workspace = true }
 # TODO: make this optional and behind a feature flag
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/factors/Cargo.toml
+++ b/crates/factors/Cargo.toml
@@ -11,7 +11,7 @@ spin-app = { path = "../app" }
 spin-factors-derive = { path = "../factors-derive" }
 thiserror = "1.0"
 # TODO: make this optional and behind a feature flag
-toml = "0.8"
+toml = { workspace = true }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { workspace = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
 
 [dev-dependencies]
-toml = "0.8.2"
+toml = { workspace = true }
 
 [features]
 default = ["runtime"]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -5,14 +5,14 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-http = "1.0.0"
+anyhow = { workspace = true }
+http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 indexmap = "1"
 percent-encoding = "2"
 routefinder = "0.5.4"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 spin-app = { path = "../app", optional = true }
 spin-locked-app = { path = "../locked-app" }
 tracing = { workspace = true }

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 azure_data_cosmos = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
 azure_identity = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
 futures = "0.3.28"
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
 tokio = "1"

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
 tokio = "1"
-url = "2"
+url = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 azure_data_cosmos = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
 azure_identity = { git = "https://github.com/azure/azure-sdk-for-rust.git", rev = "8c4caa251c3903d5eae848b41bb1d02a4d65231c" }
-futures = "0.3.28"
+futures = { workspace = true }
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }

--- a/crates/key-value-redis/Cargo.toml
+++ b/crates/key-value-redis/Cargo.toml
@@ -12,7 +12,7 @@ spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
 spin-world = { path = "../world" }
 tokio = "1"
-url = "2"
+url = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/key-value-redis/Cargo.toml
+++ b/crates/key-value-redis/Cargo.toml
@@ -5,9 +5,9 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 redis = { version = "0.21", features = ["tokio-comp", "tokio-native-tls-comp"] }
-serde = { version = "1.0", features = ["rc"] }
+serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
 spin-world = { path = "../world" }

--- a/crates/key-value-spin/Cargo.toml
+++ b/crates/key-value-spin/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-rusqlite = { version = "0.29.0", features = ["bundled"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }

--- a/crates/key-value-spin/Cargo.toml
+++ b/crates/key-value-spin/Cargo.toml
@@ -5,10 +5,10 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 once_cell = "1"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
-serde = { version = "1.0", features = ["rc"] }
+serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
 spin-world = { path = "../world" }

--- a/crates/key-value-spin/Cargo.toml
+++ b/crates/key-value-spin/Cargo.toml
@@ -6,7 +6,6 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-once_cell = "1"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 serde = { workspace = true }
 spin-core = { path = "../core" }

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 candle = { git = "https://github.com/huggingface/candle", rev = "b80348d22f8f0dadb6cc4101bde031d5de69a9a5", package = "candle-core" }
 candle-nn = { git = "https://github.com/huggingface/candle", rev = "b80348d22f8f0dadb6cc4101bde031d5de69a9a5" }
 chrono = "0.4.26"
@@ -17,7 +17,7 @@ lru = "0.9.0"
 num_cpus = "1"
 rand = "0.8.5"
 safetensors = "0.3.3"
-serde = { version = "1.0.150", features = ["derive"] }
+serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -13,7 +13,7 @@ llm = { git = "https://github.com/rustformers/llm", rev = "2f6ffd4435799ceaa1d1b
   "tokenizers-remote",
   "llama",
 ], default-features = false }
-lru = "0.9.0"
+lru = "0.12"
 num_cpus = "1"
 rand = { workspace = true }
 safetensors = "0.3.3"

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -23,7 +23,7 @@ spin-core = { path = "../core" }
 spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
 tokenizers = "0.13.4"
-tokio = { version = "1.32.0", features = ["macros", "sync"] }
+tokio = { version = "1", features = ["macros", "sync"] }
 tracing = { workspace = true }
 
 [features]

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -8,14 +8,14 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 candle = { git = "https://github.com/huggingface/candle", rev = "b80348d22f8f0dadb6cc4101bde031d5de69a9a5", package = "candle-core" }
 candle-nn = { git = "https://github.com/huggingface/candle", rev = "b80348d22f8f0dadb6cc4101bde031d5de69a9a5" }
-chrono = "0.4.26"
+chrono = "0.4"
 llm = { git = "https://github.com/rustformers/llm", rev = "2f6ffd4435799ceaa1d1bcb5a8790e5b3e0c5663", features = [
   "tokenizers-remote",
   "llama",
 ], default-features = false }
 lru = "0.9.0"
 num_cpus = "1"
-rand = "0.8.5"
+rand = { workspace = true }
 safetensors = "0.3.3"
 serde = { workspace = true }
 spin-common = { path = "../common" }

--- a/crates/llm-remote-http/Cargo.toml
+++ b/crates/llm-remote-http/Cargo.toml
@@ -5,11 +5,11 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-http = "0.2"
+anyhow = { workspace = true }
+http = { workspace = true }
 reqwest = { version = "0.11", features = ["gzip", "json"] }
-serde = { version = "1.0.150", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
 tracing = { workspace = true }

--- a/crates/llm-remote-http/Cargo.toml
+++ b/crates/llm-remote-http/Cargo.toml
@@ -6,8 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-http = { workspace = true }
-reqwest = { version = "0.11", features = ["gzip", "json"] }
+reqwest = { version = "0.12", features = ["gzip", "json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-telemetry = { path = "../telemetry" }

--- a/crates/llm-remote-http/src/lib.rs
+++ b/crates/llm-remote-http/src/lib.rs
@@ -90,7 +90,7 @@ impl RemoteHttpLlmEngine {
         tracing::info!("Sending remote inference request to {infer_url}");
 
         let resp = client
-            .request(http::Method::POST, infer_url)
+            .request(reqwest::Method::POST, infer_url)
             .headers(headers)
             .body(body)
             .send()
@@ -137,7 +137,7 @@ impl RemoteHttpLlmEngine {
 
         let resp = client
             .request(
-                http::Method::POST,
+                reqwest::Method::POST,
                 self.url.join("/embed").map_err(|_| {
                     wasi_llm::Error::RuntimeError("Failed to create URL".to_string())
                 })?,

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -33,7 +33,7 @@ terminal = { path = "../terminal" }
 thiserror = "1.0.49"
 tokio = "1.23"
 tokio-util = "0.6"
-toml = "0.8.2"
+toml = { workspace = true }
 tracing = { workspace = true }
 walkdir = "2.3.2"
 wasm-pkg-loader = "0.4.1"

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -11,18 +11,18 @@ bytes = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
 glob = { workspace = true }
-indexmap = { version = "1" }
+indexmap = "2"
 itertools = { workspace = true }
-lazy_static = "1.4.0"
-mime_guess = { version = "2.0" }
-path-absolutize = { version = "3.0.11", features = ["use_unix_paths_on_wasm"] }
+lazy_static = "1"
+mime_guess = "2"
+path-absolutize = { version = "3", features = ["use_unix_paths_on_wasm"] }
 regex = { workspace = true }
 reqwest = "0.12"
-semver = "1.0"
+semver = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-shellexpand = "3.1"
+shellexpand = "3"
 spin-common = { path = "../common" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-locked-app = { path = "../locked-app" }
@@ -31,12 +31,12 @@ spin-serde = { path = "../serde" }
 tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
-tokio = "1.23"
-tokio-util = "0.6"
+tokio = "1"
+tokio-util = "0.7"
 toml = { workspace = true }
 tracing = { workspace = true }
-walkdir = "2.3.2"
-wasm-pkg-loader = "0.4.1"
+walkdir = "2"
+wasm-pkg-loader = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -5,8 +5,8 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1"
-async-trait = "0.1.52"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 bytes = "1.1.0"
 dirs = "4.0"
 futures = "0.3.17"
@@ -19,8 +19,8 @@ path-absolutize = { version = "3.0.11", features = ["use_unix_paths_on_wasm"] }
 regex = "1.5.4"
 reqwest = "0.11.9"
 semver = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 sha2 = "0.10.8"
 shellexpand = "3.1"
 spin-common = { path = "../common" }
@@ -30,7 +30,7 @@ spin-manifest = { path = "../manifest" }
 spin-serde = { path = "../serde" }
 tempfile = "3.8.0"
 terminal = { path = "../terminal" }
-thiserror = "1.0.49"
+thiserror = { workspace = true }
 tokio = "1.23"
 tokio-util = "0.6"
 toml = { workspace = true }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = "1.1.0"
 dirs = "4.0"
-futures = "0.3.17"
+futures = { workspace = true }
 glob = "0.3.0"
 indexmap = { version = "1" }
 itertools = "0.10.3"
@@ -17,7 +17,7 @@ lazy_static = "1.4.0"
 mime_guess = { version = "2.0" }
 path-absolutize = { version = "3.0.11", features = ["use_unix_paths_on_wasm"] }
 regex = "1.5.4"
-reqwest = "0.11.9"
+reqwest = "0.12"
 semver = "1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = "1.1.0"
-dirs = "4.0"
+dirs = { workspace = true }
 futures = { workspace = true }
 glob = "0.3.0"
 indexmap = { version = "1" }
@@ -21,14 +21,14 @@ reqwest = "0.12"
 semver = "1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10.8"
+sha2 = { workspace = true }
 shellexpand = "3.1"
 spin-common = { path = "../common" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-locked-app = { path = "../locked-app" }
 spin-manifest = { path = "../manifest" }
 spin-serde = { path = "../serde" }
-tempfile = "3.8.0"
+tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
 tokio = "1.23"

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -12,7 +12,7 @@ dirs = { workspace = true }
 futures = { workspace = true }
 glob = "0.3.0"
 indexmap = { version = "1" }
-itertools = "0.10.3"
+itertools = { workspace = true }
 lazy_static = "1.4.0"
 mime_guess = { version = "2.0" }
 path-absolutize = { version = "3.0.11", features = ["use_unix_paths_on_wasm"] }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -39,7 +39,7 @@ walkdir = "2.3.2"
 wasm-pkg-loader = "0.4.1"
 
 [dev-dependencies]
-tokio = { version = "1.23", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 ui-testing = { path = "../ui-testing" }
 
 [features]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -7,16 +7,16 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-bytes = "1.1.0"
+bytes = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
-glob = "0.3.0"
+glob = { workspace = true }
 indexmap = { version = "1" }
 itertools = { workspace = true }
 lazy_static = "1.4.0"
 mime_guess = { version = "2.0" }
 path-absolutize = { version = "3.0.11", features = ["use_unix_paths_on_wasm"] }
-regex = "1.5.4"
+regex = { workspace = true }
 reqwest = "0.12"
 semver = "1.0"
 serde = { workspace = true }

--- a/crates/locked-app/Cargo.toml
+++ b/crates/locked-app/Cargo.toml
@@ -5,9 +5,9 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 spin-serde = { path = "../serde" }
-thiserror = "1.0"
+thiserror = { workspace = true }

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-indexmap = { version = "1", features = ["serde"] }
+indexmap = { version = "2", features = ["serde"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { workspace = true }
 spin-serde = { path = "../serde" }

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -18,7 +18,7 @@ wasm-pkg-common = "0.4.1"
 
 [dev-dependencies]
 anyhow = { workspace = true }
-glob = "0.3.1"
+glob = { workspace = true }
 serde_json = { workspace = true }
 ui-testing = { path = "../ui-testing" }
 

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -13,7 +13,7 @@ spin-serde = { path = "../serde" }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
 toml = { version = "0.8.0", features = ["preserve_order"] }
-url = "2.4.1"
+url = { workspace = true }
 wasm-pkg-common = "0.4.1"
 
 [dev-dependencies]

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -5,21 +5,21 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = { workspace = true }
 indexmap = { version = "1", features = ["serde"] }
 semver = { version = "1.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 spin-serde = { path = "../serde" }
 terminal = { path = "../terminal" }
-thiserror = "1"
+thiserror = { workspace = true }
 toml = { version = "0.8.0", features = ["preserve_order"] }
 url = "2.4.1"
 wasm-pkg-common = "0.4.1"
 
 [dev-dependencies]
-anyhow = "1.0.75"
+anyhow = { workspace = true }
 glob = "0.3.1"
-serde_json = "1.0"
+serde_json = { workspace = true }
 ui-testing = { path = "../ui-testing" }
 
 [[test]]

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -6,16 +6,16 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-async-compression = { version = "0.4.3", features = ["gzip", "tokio"] }
+async-compression = { version = "0.4", features = ["gzip", "tokio"] }
 # Fork with nested async-std dependency bumped to satisfy Windows build; branch/revision is protected
 async-tar = { git = "https://github.com/vdice/async-tar", rev = "71e037f9652971e7a55b412a8e47a37b06f9c29d" }
-base64 = "0.21"
+base64 = "0.22"
 chrono = "0.4"
 # Fork with updated auth to support ACR login
 # Ref https://github.com/camallo/dkregistry-rs/pull/263
 dirs = { workspace = true }
 dkregistry = { git = "https://github.com/fermyon/dkregistry-rs", rev = "161cf2b66996ed97c7abaf046e38244484814de3" }
-docker_credential = "1.0"
+docker_credential = "1"
 futures-util = "0.3"
 itertools = { workspace = true }
 oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "7e4ce9be9bcd22e78a28f06204931f10c44402ba" }
@@ -28,6 +28,6 @@ spin-locked-app = { path = "../locked-app" }
 spin-manifest = { path = "../manifest" }
 tempfile = { workspace = true }
 tokio = { version = "1", features = ["fs"] }
-tokio-util = { version = "0.7.9", features = ["compat"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 tracing = { workspace = true }
-walkdir = "2.3"
+walkdir = "2"

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -17,7 +17,7 @@ dirs = { workspace = true }
 dkregistry = { git = "https://github.com/fermyon/dkregistry-rs", rev = "161cf2b66996ed97c7abaf046e38244484814de3" }
 docker_credential = "1.0"
 futures-util = "0.3"
-itertools = "0.12.1"
+itertools = { workspace = true }
 oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "7e4ce9be9bcd22e78a28f06204931f10c44402ba" }
 reqwest = "0.12"
 serde = { workspace = true }

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -19,7 +19,7 @@ docker_credential = "1.0"
 futures-util = "0.3"
 itertools = "0.12.1"
 oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "7e4ce9be9bcd22e78a28f06204931f10c44402ba" }
-reqwest = "0.11"
+reqwest = "0.12"
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-common = { path = "../common" }

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -13,7 +13,7 @@ base64 = "0.21"
 chrono = "0.4"
 # Fork with updated auth to support ACR login
 # Ref https://github.com/camallo/dkregistry-rs/pull/263
-dirs = "4.0"
+dirs = { workspace = true }
 dkregistry = { git = "https://github.com/fermyon/dkregistry-rs", rev = "161cf2b66996ed97c7abaf046e38244484814de3" }
 docker_credential = "1.0"
 futures-util = "0.3"
@@ -26,7 +26,7 @@ spin-common = { path = "../common" }
 spin-loader = { path = "../loader" }
 spin-locked-app = { path = "../locked-app" }
 spin-manifest = { path = "../manifest" }
-tempfile = "3.3"
+tempfile = { workspace = true }
 tokio = { version = "1", features = ["fs"] }
 tokio-util = { version = "0.7.9", features = ["compat"] }
 tracing = { workspace = true }

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 async-compression = { version = "0.4.3", features = ["gzip", "tokio"] }
 # Fork with nested async-std dependency bumped to satisfy Windows build; branch/revision is protected
 async-tar = { git = "https://github.com/vdice/async-tar", rev = "71e037f9652971e7a55b412a8e47a37b06f9c29d" }
@@ -20,8 +20,8 @@ futures-util = "0.3"
 itertools = "0.12.1"
 oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "7e4ce9be9bcd22e78a28f06204931f10c44402ba" }
 reqwest = "0.11"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 spin-common = { path = "../common" }
 spin-loader = { path = "../loader" }
 spin-locked-app = { path = "../locked-app" }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-bytes = "1.1"
+bytes = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = { workspace = true }
 fd-lock = "3.0.12"

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 bytes = "1.1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "4.0"
@@ -15,13 +15,13 @@ is-terminal = "0.4"
 path-absolutize = "3.0.11"
 reqwest = { version = "0.11", features = ["json"] }
 semver = { version = "1.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 spin-common = { path = "../common" }
 tar = "0.4.38"
 tempfile = "3.3.0"
 terminal = { path = "../terminal" }
-thiserror = "1"
+thiserror = { workspace = true }
 tokio = { version = "1.23", features = ["fs", "process", "rt", "macros"] }
 tracing = { workspace = true }
 url = { version = "2.2.2", features = ["serde"] }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 bytes = "1.1"
 chrono = { version = "0.4", features = ["serde"] }
-dirs = "4.0"
+dirs = { workspace = true }
 fd-lock = "3.0.12"
 flate2 = "1.0.17"
 is-terminal = "0.4"
@@ -19,7 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 spin-common = { path = "../common" }
 tar = "0.4.38"
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
 tokio = { version = "1.23", features = ["fs", "process", "rt", "macros"] }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -22,6 +22,6 @@ tar = "0.4.38"
 tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
-tokio = { version = "1.23", features = ["fs", "process", "rt", "macros"] }
+tokio = { version = "1", features = ["fs", "process", "rt", "macros"] }
 tracing = { workspace = true }
 url = { version = "2.2.2", features = ["serde"] }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -9,19 +9,19 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = { workspace = true }
-fd-lock = "3.0.12"
-flate2 = "1.0.17"
+fd-lock = "4"
+flate2 = "1"
 is-terminal = "0.4"
-path-absolutize = "3.0.11"
+path-absolutize = "3"
 reqwest = { version = "0.12", features = ["json"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-common = { path = "../common" }
-tar = "0.4.38"
+tar = "0.4"
 tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["fs", "process", "rt", "macros"] }
 tracing = { workspace = true }
-url = { version = "2.2.2", features = ["serde"] }
+url = { version = "2", features = ["serde"] }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -13,7 +13,7 @@ fd-lock = "3.0.12"
 flate2 = "1.0.17"
 is-terminal = "0.4"
 path-absolutize = "3.0.11"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/runtime-config/Cargo.toml
+++ b/crates/runtime-config/Cargo.toml
@@ -28,7 +28,7 @@ spin-key-value-redis = { path = "../key-value-redis" }
 spin-key-value-spin = { path = "../key-value-spin" }
 spin-sqlite = { path = "../sqlite" }
 spin-trigger = { path = "../trigger" }
-toml = "0.8"
+toml = { workspace = true }
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }

--- a/crates/runtime-factors/Cargo.toml
+++ b/crates/runtime-factors/Cargo.toml
@@ -14,7 +14,7 @@ llm-metal = ["spin-factor-llm/llm-metal"]
 llm-cublas = ["spin-factor-llm/llm-cublas"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 spin-common = { path = "../common" }
 spin-factor-key-value = { path = "../factor-key-value" }

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -5,8 +5,8 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 base64 = "0.22.1"
 semver = { version = "1.0", features = ["serde"] }
-serde = "1.0.189"
+serde = { workspace = true }
 wasm-pkg-common = "0.4.1"

--- a/crates/sqlite-inproc/Cargo.toml
+++ b/crates/sqlite-inproc/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 rand = { workspace = true }
-rusqlite = { version = "0.29.0", features = ["bundled"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-world = { path = "../world" }
 tokio = "1"

--- a/crates/sqlite-inproc/Cargo.toml
+++ b/crates/sqlite-inproc/Cargo.toml
@@ -5,8 +5,8 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 once_cell = "1"
 rand = "0.8"
 rusqlite = { version = "0.29.0", features = ["bundled"] }

--- a/crates/sqlite-inproc/Cargo.toml
+++ b/crates/sqlite-inproc/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-once_cell = "1"
 rand = { workspace = true }
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 spin-factor-sqlite = { path = "../factor-sqlite" }

--- a/crates/sqlite-inproc/Cargo.toml
+++ b/crates/sqlite-inproc/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 once_cell = "1"
-rand = "0.8"
+rand = { workspace = true }
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-world = { path = "../world" }

--- a/crates/sqlite-libsql/Cargo.toml
+++ b/crates/sqlite-libsql/Cargo.toml
@@ -9,11 +9,11 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 # We don't actually use rusqlite itself, but we'd like the same bundled
 # libsqlite3-sys as used by spin-sqlite-inproc.
-libsql = { version = "0.3.2", features = ["remote"], default-features = false }
-rusqlite = { version = "0.29.0", features = ["bundled"] }
+libsql = { version = "0.5", features = ["remote"], default-features = false }
+rusqlite = { version = "0.32", features = ["bundled"] }
 spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-world = { path = "../world" }
-sqlparser = "0.34"
+sqlparser = "0.51"
 tokio = { version = "1", features = ["full"] }
 
 [lints]

--- a/crates/sqlite-libsql/Cargo.toml
+++ b/crates/sqlite-libsql/Cargo.toml
@@ -5,8 +5,8 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1.68"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 # We don't actually use rusqlite itself, but we'd like the same bundled
 # libsqlite3-sys as used by spin-sqlite-inproc.
 libsql = { version = "0.3.2", features = ["remote"], default-features = false }

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -5,8 +5,8 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-async-trait = "0.1"
-serde = { version = "1.0", features = ["rc"] }
+async-trait = { workspace = true }
+serde = { workspace = true }
 spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -15,4 +15,4 @@ spin-sqlite-libsql = { path = "../sqlite-libsql" }
 spin-world = { path = "../world" }
 table = { path = "../table" }
 tokio = "1"
-toml = "0.8"
+toml = { workspace = true }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { version = "0.17.0", default-features = false, features = ["http-proto", "trace", "http", "reqwest-client", "metrics", "grpc-tonic", "logs"] }
 opentelemetry-semantic-conventions = "0.14.0"
 terminal = { path = "../terminal" }
-tracing = { version = "0.1.37", features = ["log"] }
+tracing = { workspace = true }
 tracing-appender = "0.2.2"
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["smallvec", "fmt", "ansi", "std", "env-filter", "json", "registry"] }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -10,9 +10,9 @@ http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
 once_cell = "1.19.0"
 opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { version = "0.17.0", default-features = false, features = ["http-proto", "trace", "http", "reqwest-client", "metrics", "grpc-tonic", "logs"] }
 opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry_sdk = { workspace = true }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }
 tracing-appender = "0.2.2"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -9,14 +9,14 @@ anyhow = { workspace = true }
 http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
 opentelemetry = { workspace = true }
-opentelemetry-otlp = { version = "0.17.0", default-features = false, features = ["http-proto", "trace", "http", "reqwest-client", "metrics", "grpc-tonic", "logs"] }
-opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry-otlp = { version = "0.25", default-features = false, features = ["http-proto", "trace", "http", "reqwest-client", "metrics", "grpc-tonic", "logs"] }
+opentelemetry-semantic-conventions = "0.25"
 opentelemetry_sdk = { workspace = true }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }
-tracing-appender = "0.2.2"
+tracing-appender = "0.2"
 tracing-opentelemetry = { workspace = true }
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["smallvec", "fmt", "ansi", "std", "env-filter", "json", "registry"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "fmt", "ansi", "std", "env-filter", "json", "registry"] }
 url = { workspace = true }
 
 [features]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -18,7 +18,7 @@ tracing = { workspace = true }
 tracing-appender = "0.2.2"
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["smallvec", "fmt", "ansi", "std", "env-filter", "json", "registry"] }
-url = "2.2.2"
+url = { workspace = true }
 
 [features]
 tracing-log-compat = ["tracing-subscriber/tracing-log", "tracing-opentelemetry/tracing-log"]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -8,7 +8,6 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
-once_cell = "1.19.0"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { version = "0.17.0", default-features = false, features = ["http-proto", "trace", "http", "reqwest-client", "metrics", "grpc-tonic", "logs"] }
 opentelemetry-semantic-conventions = "0.14.0"

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -29,7 +29,7 @@ spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
 tempfile = "3.3.0"
 tokio = { version = "1.23", features = ["fs", "process", "rt", "macros"] }
-toml = "0.5"
+toml = { workspace = true }
 toml_edit = "0.20.2"
 url = "2.2.2"
 walkdir = "2"

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -5,8 +5,8 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 bytes = "1.1"
 console = "0.15"
 dialoguer = "0.10"
@@ -24,7 +24,7 @@ path-absolutize = "3.0.13"
 pathdiff = "0.2.1"
 regex = "1.5.4"
 semver = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
 tempfile = "3.3.0"

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -30,6 +30,6 @@ spin-manifest = { path = "../manifest" }
 tempfile = { workspace = true }
 tokio = { version = "1", features = ["fs", "process", "rt", "macros"] }
 toml = { workspace = true }
-toml_edit = "0.20.2"
+toml_edit = "0.22"
 url = { workspace = true }
 walkdir = "2"

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
 tempfile = { workspace = true }
-tokio = { version = "1.23", features = ["fs", "process", "rt", "macros"] }
+tokio = { version = "1", features = ["fs", "process", "rt", "macros"] }
 toml = { workspace = true }
 toml_edit = "0.20.2"
 url = { workspace = true }

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = { workspace = true }
 bytes = "1.1"
 console = "0.15"
 dialoguer = "0.10"
-dirs = "3.0"
+dirs = { workspace = true }
 fs_extra = "1.2"
 heck = "0.4"
 indexmap = { version = "1", features = ["serde"] }
@@ -27,9 +27,9 @@ semver = "1.0"
 serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 tokio = { version = "1.23", features = ["fs", "process", "rt", "macros"] }
 toml = { workspace = true }
 toml_edit = "0.20.2"
-url = "2.2.2"
+url = { workspace = true }
 walkdir = "2"

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -11,19 +11,19 @@ bytes = { workspace = true }
 console = "0.15"
 dialoguer = "0.10"
 dirs = { workspace = true }
-fs_extra = "1.2"
-heck = "0.4"
-indexmap = { version = "1", features = ["serde"] }
+fs_extra = "1"
+heck = "0.5"
+indexmap = { version = "2", features = ["serde"] }
 itertools = { workspace = true }
-lazy_static = "1.4.0"
+lazy_static = "1"
 liquid = "0.26"
 liquid-core = "0.26"
 liquid-derive = "0.26"
 liquid-lib = "0.26"
-path-absolutize = "3.0.13"
-pathdiff = "0.2.1"
+path-absolutize = "3"
+pathdiff = "0.2"
 regex = { workspace = true }
-semver = "1.0"
+semver = "1"
 serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -14,12 +14,12 @@ dirs = { workspace = true }
 fs_extra = "1.2"
 heck = "0.4"
 indexmap = { version = "1", features = ["serde"] }
-itertools = "0.10.3"
+itertools = { workspace = true }
 lazy_static = "1.4.0"
-liquid = "0.23"
-liquid-core = "0.23"
-liquid-derive = "0.23"
-liquid-lib = "0.23"
+liquid = "0.26"
+liquid-core = "0.26"
+liquid-derive = "0.26"
+liquid-lib = "0.26"
 path-absolutize = "3.0.13"
 pathdiff = "0.2.1"
 regex = "1.5.4"

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-bytes = "1.1"
+bytes = { workspace = true }
 console = "0.15"
 dialoguer = "0.10"
 dirs = { workspace = true }
@@ -22,7 +22,7 @@ liquid-derive = "0.26"
 liquid-lib = "0.26"
 path-absolutize = "3.0.13"
 pathdiff = "0.2.1"
-regex = "1.5.4"
+regex = { workspace = true }
 semver = "1.0"
 serde = { workspace = true }
 spin-common = { path = "../common" }

--- a/crates/templates/src/toml.rs
+++ b/crates/templates/src/toml.rs
@@ -21,7 +21,7 @@ mod test {
 
     #[test]
     fn if_path_does_not_exist_then_get_at_is_none() {
-        let document = toml::toml! {
+        let document: toml::Value = toml::toml! {
             name = "test"
 
             [application.redis.trigger]
@@ -29,7 +29,8 @@ mod test {
 
             [[trigger.redis]]
             channel = "messages"
-        };
+        }
+        .into();
 
         assert!(get_at(document.clone(), &["name", "snort"]).is_none());
         assert!(get_at(document.clone(), &["snort", "fie"]).is_none());
@@ -45,7 +46,7 @@ mod test {
 
     #[test]
     fn if_path_does_exist_then_get_at_finds_it() {
-        let document = toml::toml! {
+        let document: toml::Value = toml::toml! {
             name = "test"
 
             [application.redis.trigger]
@@ -53,7 +54,8 @@ mod test {
 
             [[trigger.redis]]
             channel = "messages"
-        };
+        }
+        .into();
 
         assert!(get_at(document.clone(), &["name"])
             .expect("should find name")

--- a/crates/templates/src/writer.rs
+++ b/crates/templates/src/writer.rs
@@ -69,12 +69,12 @@ impl TemplateOutput {
 }
 
 fn merge_toml(existing: &str, target: &str, text: &str) -> anyhow::Result<String> {
-    use toml_edit::{Document, Entry, Item};
+    use toml_edit::{DocumentMut, Entry, Item};
 
-    let mut doc: Document = existing
+    let mut doc: DocumentMut = existing
         .parse()
         .context("Can't merge into the existing manifest - it's not valid TOML")?;
-    let merging: Document = text
+    let merging: DocumentMut = text
         .parse()
         .context("Can't merge snippet - it's not valid TOML")?;
     let merging = merging.as_table();

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -6,5 +6,4 @@ edition = { workspace = true }
 
 [dependencies]
 atty = "0.2"
-once_cell = "1.0"
 termcolor = "1.2"

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -6,4 +6,4 @@ edition = { workspace = true }
 
 [dependencies]
 atty = "0.2"
-termcolor = "1.2"
+termcolor = "1"

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -3,11 +3,11 @@
 //! This library is used by Spin to print out messages in an appropriate format
 //! that is easy for users to read. This is not meant as a general purpose library.
 
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 use termcolor::{ColorSpec, StandardStream, StandardStreamLock, WriteColor};
 
-static COLOR_OUT: OnceCell<StandardStream> = OnceCell::new();
-static COLOR_ERR: OnceCell<StandardStream> = OnceCell::new();
+static COLOR_OUT: OnceLock<StandardStream> = OnceLock::new();
+static COLOR_ERR: OnceLock<StandardStream> = OnceLock::new();
 
 /// A wrapper around a standard stream lock that resets the color on drop
 pub struct ColorText(StandardStreamLock<'static>);

--- a/crates/test-codegen-macro/Cargo.toml
+++ b/crates/test-codegen-macro/Cargo.toml
@@ -10,6 +10,6 @@ doctest = false
 test = false
 
 [dependencies]
-heck = "0.4.0"
-quote = "1.0.32"
-syn = "2.0"
+heck = "0.5"
+quote = "1"
+syn = "2"

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -35,7 +35,7 @@ spin-telemetry = { path = "../telemetry" }
 spin-trigger = { path = "../trigger" }
 spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
-tokio = { version = "1.23", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = "3"
 futures = { workspace = true }
-futures-util = "0.3.8"
+futures-util = "0.3"
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -38,7 +38,7 @@ terminal = { path = "../terminal" }
 tokio = { version = "1.23", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 tracing = { workspace = true }
-url = "2.4.1"
+url = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -8,12 +8,12 @@ edition = { workspace = true }
 doctest = false
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 clap = "3"
 futures = "0.3"
 futures-util = "0.3.8"
-http = "1.0.0"
+http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { version = "0.1.2", features = ["tokio"] }
@@ -22,7 +22,7 @@ percent-encoding = "2"
 rustls = { workspace = true }
 rustls-pemfile = "2.1.2"
 rustls-pki-types = "1.7"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 serde_json = "1"
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = "3"
-futures = "0.3"
+futures = { workspace = true }
 futures-util = "0.3.8"
 http = { workspace = true }
 http-body-util = { workspace = true }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -16,8 +16,8 @@ futures-util = "0.3"
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { version = "0.1.2", features = ["tokio"] }
-indexmap = "1"
+hyper-util = { version = "0.1", features = ["tokio"] }
+indexmap = "2"
 percent-encoding = "2"
 rustls = { workspace = true }
 rustls-pemfile = "2.1.2"
@@ -42,7 +42,7 @@ url = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
-webpki-roots = { version = "0.26.0" }
+webpki-roots = { version = "0.26" }
 
 [lints]
 workspace = true

--- a/crates/trigger-redis/Cargo.toml
+++ b/crates/trigger-redis/Cargo.toml
@@ -18,7 +18,7 @@ spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }
 spin-trigger = { path = "../trigger" }
 spin-world = { path = "../world" }
-tokio = { version = "1.39.3", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt"] }
 tracing = { workspace = true }
 
 [lints]

--- a/crates/trigger-redis/Cargo.toml
+++ b/crates/trigger-redis/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
-redis = { version = "0.26.1", features = ["tokio-comp"] }
+redis = { version = "0.27", features = ["tokio-comp"] }
 serde = { workspace = true }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factors = { path = "../factors" }

--- a/crates/trigger-redis/Cargo.toml
+++ b/crates/trigger-redis/Cargo.toml
@@ -8,11 +8,11 @@ edition = { workspace = true }
 doctest = false
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 futures = "0.3"
 redis = { version = "0.26.1", features = ["tokio-comp"] }
-serde = "1.0.188"
+serde = { workspace = true }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }

--- a/crates/trigger-redis/Cargo.toml
+++ b/crates/trigger-redis/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 redis = { version = "0.26.1", features = ["tokio-comp"] }
 serde = { workspace = true }
 spin-factor-variables = { path = "../factor-variables" }

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -33,7 +33,7 @@ spin-factor-wasi = { path = "../factor-wasi" }
 spin-factors = { path = "../factors" }
 spin-factors-executor = { path = "../factors-executor" }
 spin-telemetry = { path = "../telemetry" }
-tokio = { version = "1.23", features = ["fs", "rt"] }
+tokio = { version = "1", features = ["fs", "rt"] }
 toml = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -15,12 +15,12 @@ rust-version.workspace = true
 unsafe-aot-compilation = []
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 ctrlc = { version = "3.2", features = ["termination"] }
 futures = "0.3"
 sanitize-filename = "0.5"
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true }
 serde_json = "1"
 spin-app = { path = "../app" }
 spin-common = { path = "../common" }

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -18,7 +18,7 @@ unsafe-aot-compilation = []
 anyhow = { workspace = true }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 ctrlc = { version = "3.2", features = ["termination"] }
-futures = "0.3"
+futures = { workspace = true }
 sanitize-filename = "0.5"
 serde = { workspace = true }
 serde_json = "1"

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -39,7 +39,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 spin-world = { path = "../world" }
-tempfile = "3.12"
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -34,7 +34,7 @@ spin-factors = { path = "../factors" }
 spin-factors-executor = { path = "../factors-executor" }
 spin-telemetry = { path = "../telemetry" }
 tokio = { version = "1.23", features = ["fs", "rt"] }
-toml = "0.8"
+toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ui-testing/Cargo.toml
+++ b/crates/ui-testing/Cargo.toml
@@ -7,6 +7,6 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 dirs = { workspace = true }
-libtest-mimic = "0.6.1"
-snapbox = "0.4.12"
+libtest-mimic = "0.7"
+snapbox = "0.4"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ui-testing/Cargo.toml
+++ b/crates/ui-testing/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-dirs = "4.0"
+dirs = { workspace = true }
 libtest-mimic = "0.6.1"
 snapbox = "0.4.12"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ui-testing/Cargo.toml
+++ b/crates/ui-testing/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 dirs = "4.0"
 libtest-mimic = "0.6.1"
 snapbox = "0.4.12"

--- a/crates/world/Cargo.toml
+++ b/crates/world/Cargo.toml
@@ -5,5 +5,5 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 wasmtime = { workspace = true }

--- a/examples/spin-timer/Cargo.toml
+++ b/examples/spin-timer/Cargo.toml
@@ -12,7 +12,7 @@ serde = "1.0.188"
 spin-factors = { path = "../../crates/factors" }
 spin-runtime-factors = { path = "../../crates/runtime-factors" }
 spin-trigger = { path = "../../crates/trigger" }
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-scoped = "0.2.0"
 wasmtime = "22.0.0"
 

--- a/tests/conformance-tests/Cargo.toml
+++ b/tests/conformance-tests/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 testing-framework = { path = "../testing-framework" }
 conformance-tests = { workspace = true }
 test-environment = { workspace = true }

--- a/tests/runtime-tests/Cargo.toml
+++ b/tests/runtime-tests/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 env_logger = "0.10.0"
 log = "0.4"
 testing-framework = { path = "../testing-framework" }

--- a/tests/test-components/Cargo.toml
+++ b/tests/test-components/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 
 [build-dependencies]
-cargo_toml = "0.17.1"
-wit-component = "0.19.0"
+cargo_toml = "0.17"
+wit-component = "0.217"

--- a/tests/test-components/components/Cargo.lock
+++ b/tests/test-components/components/Cargo.lock
@@ -12,9 +12,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "async-trait"

--- a/tests/test-components/components/integration-http-outbound-post/Cargo.toml
+++ b/tests/test-components/components/integration-http-outbound-post/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 anyhow = "1.0.71"
 futures = "0.3.28"
 hex = "0.4.3"
-sha2 = "0.10.6"
+sha2 = "0.10"
 url = "2.4.0"
 spin-sdk = "2.2.0"

--- a/tests/test-components/components/integration-wasi-http-streaming/Cargo.toml
+++ b/tests/test-components/components/integration-wasi-http-streaming/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 anyhow = "1.0.71"
 futures = "0.3.28"
 hex = "0.4.3"
-sha2 = "0.10.6"
+sha2 = "0.10"
 url = "2.4.0"
 spin-sdk = "2.2.0"

--- a/tests/test-components/helper/Cargo.toml
+++ b/tests/test-components/helper/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 wit-bindgen = { version = "0.16.0", optional = true }
-anyhow = "1.0"
+anyhow = { workspace = true }
 
 [features]
 default = ["define-component"]

--- a/tests/testing-framework/Cargo.toml
+++ b/tests/testing-framework/Cargo.toml
@@ -9,7 +9,7 @@ fslock = "0.2.1"
 http = "1.0"
 http-body-util = "0.1.0"
 log = "0.4"
-nix = "0.26.1"
+nix = "0.29"
 regex = "1.10.2"
 reqwest = { workspace = true }
 temp-dir = "0.1.11"
@@ -22,5 +22,5 @@ spin-runtime-factors = { path = "../../crates/runtime-factors" }
 spin-trigger = { path = "../../crates/trigger" }
 spin-trigger-http = { path = "../../crates/trigger-http" }
 toml = { workspace = true }
-tokio = "1.23"
+tokio = "1"
 wasmtime-wasi-http = { workspace = true }

--- a/tests/testing-framework/Cargo.toml
+++ b/tests/testing-framework/Cargo.toml
@@ -21,6 +21,6 @@ spin-loader = { path = "../../crates/loader" }
 spin-runtime-factors = { path = "../../crates/runtime-factors" }
 spin-trigger = { path = "../../crates/trigger" }
 spin-trigger-http = { path = "../../crates/trigger-http" }
-toml = "0.8.6"
+toml = { workspace = true }
 tokio = "1.23"
 wasmtime-wasi-http = { workspace = true }


### PR DESCRIPTION
Bumping the versions of lots of dependencies. Typically just bumping minor versions, but this does remove a few dependencies from the dependency graph.

I also moved to use workspace dependencies for a lot of common dependencies. This should make upgrades easier in the future. 

Overall, we end up with around 10 fewer crates in the crate graph. 