### PR TITLE
Telemetry fixes

### DIFF
--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -85,7 +85,7 @@ impl key_value::HostStore for KeyValueDispatch {
         .await)
     }
 
-    #[instrument(name = "spin_key_value.get", skip(self, store), err(level = Level::INFO), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.get", skip(self, store, key), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn get(
         &mut self,
         store: Resource<key_value::Store>,
@@ -95,7 +95,7 @@ impl key_value::HostStore for KeyValueDispatch {
         Ok(store.get(&key).await)
     }
 
-    #[instrument(name = "spin_key_value.set", skip(self, store, value), err(level = Level::INFO), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.set", skip(self, store, key, value), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn set(
         &mut self,
         store: Resource<key_value::Store>,
@@ -106,7 +106,7 @@ impl key_value::HostStore for KeyValueDispatch {
         Ok(store.set(&key, &value).await)
     }
 
-    #[instrument(name = "spin_key_value.delete", skip(self, store), err(level = Level::INFO), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.delete", skip(self, store, key), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn delete(
         &mut self,
         store: Resource<key_value::Store>,
@@ -116,7 +116,7 @@ impl key_value::HostStore for KeyValueDispatch {
         Ok(store.delete(&key).await)
     }
 
-    #[instrument(name = "spin_key_value.exists", skip(self, store), err(level = Level::INFO), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.exists", skip(self, store, key), err(level = Level::INFO), fields(otel.kind = "client"))]
     async fn exists(
         &mut self,
         store: Resource<key_value::Store>,

--- a/crates/factor-outbound-mysql/src/host.rs
+++ b/crates/factor-outbound-mysql/src/host.rs
@@ -52,7 +52,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
         self.open_connection(&address).await
     }
 
-    #[instrument(name = "spin_outbound_mysql.execute", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_mysql.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
     async fn execute(
         &mut self,
         connection: Resource<Connection>,
@@ -66,7 +66,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
             .await?)
     }
 
-    #[instrument(name = "spin_outbound_mysql.query", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_mysql.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
     async fn query(
         &mut self,
         connection: Resource<Connection>,

--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -21,6 +21,7 @@ pub use config::{
 };
 
 pub use runtime_config::ComponentTlsConfigs;
+use url::Url;
 
 pub type SharedFutureResult<T> = Shared<BoxFuture<'static, Result<Arc<T>, Arc<anyhow::Error>>>>;
 
@@ -246,5 +247,24 @@ pub trait DisallowedHostHandler: Send + Sync {
 impl<F: Fn(&str, &str) + Send + Sync> DisallowedHostHandler for F {
     fn handle_disallowed_host(&self, scheme: &str, authority: &str) {
         self(scheme, authority);
+    }
+}
+
+/// Records the address host, port, and database as fields on the current tracing span.
+///
+/// This should only be called from within a function that has been instrumented with a span.
+///
+/// The following fields must be pre-declared as empty on the span or they will not show up.
+/// ```
+/// use tracing::field::Empty;
+/// #[tracing::instrument(fields(db.address = Empty, server.port = Empty, db.namespace = Empty))]
+/// fn open() {}
+/// ```
+pub fn record_address_fields(address: &str) {
+    if let Ok(url) = Url::parse(address) {
+        let span = tracing::Span::current();
+        span.record("db.address", url.host_str().unwrap_or_default());
+        span.record("server.port", url.port().unwrap_or_default());
+        span.record("db.namespace", url.path().trim_start_matches('/'));
     }
 }

--- a/crates/factor-outbound-pg/src/host.rs
+++ b/crates/factor-outbound-pg/src/host.rs
@@ -77,7 +77,7 @@ impl<C: Send + Sync + Client> v2::HostConnection for InstanceState<C> {
         self.open_connection(&address).await
     }
 
-    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
     async fn execute(
         &mut self,
         connection: Resource<Connection>,
@@ -91,7 +91,7 @@ impl<C: Send + Sync + Client> v2::HostConnection for InstanceState<C> {
             .await?)
     }
 
-    #[instrument(name = "spin_outbound_pg.query", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
     async fn query(
         &mut self,
         connection: Resource<Connection>,

--- a/crates/factor-sqlite/src/host.rs
+++ b/crates/factor-sqlite/src/host.rs
@@ -83,7 +83,7 @@ impl v2::HostConnection for InstanceState {
             .map(Resource::new_own)
     }
 
-    #[instrument(name = "spin_sqlite.execute", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query, sqlite.backend = Empty))]
+    #[instrument(name = "spin_sqlite.execute", skip(self, connection, parameters), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query, sqlite.backend = Empty))]
     async fn execute(
         &mut self,
         connection: Resource<v2::Connection>,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use anyhow::{bail, Result};
+use opentelemetry::global;
 use opentelemetry_otlp::MetricsExporterBuilder;
 use opentelemetry_sdk::{
     metrics::{
@@ -56,6 +57,8 @@ pub(crate) fn otel_metrics_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
         .with_reader(reader)
         .with_resource(resource)
         .build();
+
+    global::set_meter_provider(meter_provider.clone());
 
     Ok(MetricsLayer::new(meter_provider))
 }

--- a/crates/telemetry/src/traces.rs
+++ b/crates/telemetry/src/traces.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::bail;
-use opentelemetry::trace::TracerProvider;
+use opentelemetry::{global, trace::TracerProvider};
 use opentelemetry_otlp::SpanExporterBuilder;
 use opentelemetry_sdk::{
     resource::{EnvResourceDetector, TelemetryResourceDetector},
@@ -35,7 +35,7 @@ pub(crate) fn otel_tracing_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
     );
 
     // This will configure the exporter based on the OTEL_EXPORTER_* environment variables.
-    let exporter: SpanExporterBuilder = match OtlpProtocol::traces_protocol_from_env() {
+    let exporter_builder: SpanExporterBuilder = match OtlpProtocol::traces_protocol_from_env() {
         OtlpProtocol::Grpc => opentelemetry_otlp::new_exporter().tonic().into(),
         OtlpProtocol::HttpProtobuf => opentelemetry_otlp::new_exporter().http().into(),
         OtlpProtocol::HttpJson => bail!("http/json OTLP protocol is not supported"),
@@ -43,9 +43,11 @@ pub(crate) fn otel_tracing_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
 
     let tracer_provider = opentelemetry_otlp::new_pipeline()
         .tracing()
-        .with_exporter(exporter)
+        .with_exporter(exporter_builder)
         .with_trace_config(opentelemetry_sdk::trace::Config::default().with_resource(resource))
         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    global::set_tracer_provider(tracer_provider.clone());
 
     let env_filter = match EnvFilter::try_from_env("SPIN_OTEL_TRACING_LEVEL") {
         Ok(filter) => filter,

--- a/crates/telemetry/src/traces.rs
+++ b/crates/telemetry/src/traces.rs
@@ -34,10 +34,7 @@ pub(crate) fn otel_tracing_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
         ],
     );
 
-    // This will configure the exporter based on the OTEL_EXPORTER_* environment variables. We
-    // currently default to using the HTTP exporter but in the future we could select off of the
-    // combination of OTEL_EXPORTER_OTLP_PROTOCOL and OTEL_EXPORTER_OTLP_TRACES_PROTOCOL to
-    // determine whether we should use http/protobuf or grpc.
+    // This will configure the exporter based on the OTEL_EXPORTER_* environment variables.
     let exporter: SpanExporterBuilder = match OtlpProtocol::traces_protocol_from_env() {
         OtlpProtocol::Grpc => opentelemetry_otlp::new_exporter().tonic().into(),
         OtlpProtocol::HttpProtobuf => opentelemetry_otlp::new_exporter().http().into(),


### PR DESCRIPTION
## Summary

- Fixes bug that slipped in with #2834.
- Improves a comment.
- Removes potentially sensitive values from OTel traces.

## Questions

- Do we want to remove DB addresses from OTel traces b/c they might contain credentials inline?
- Do we want to remove key values everywhere from OTel traces? This seems valuable enough to me that I think we should just keep it and document it.

Fixe #2816 