### PR TITLE
Remove unmaintained `atty` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8216,7 +8216,6 @@ dependencies = [
 name = "terminal"
 version = "2.8.0-pre0"
 dependencies = [
- "atty",
  "termcolor",
 ]
 

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -5,5 +5,4 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-atty = "0.2"
 termcolor = "1"


### PR DESCRIPTION
`atty` is no longer maintained and the readme now suggests using `std::io::IsTerminal` instead.