### PR TITLE
Expose the wasmtime/call-hook feature from spin-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ toml = "0.8"
 tracing = { version = "0.1", features = ["log"] }
 tracing-opentelemetry = { version = "0.26", default-features = false, features = ["metrics"] }
 url = "2"
-
 wasi-common-preview1 = { version = "25.0.0", package = "wasi-common", features = [
   "tokio",
 ] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,3 +19,9 @@ spin-factors-test = { path = "../factors-test" }
 spin-locked-app = { path = "../locked-app" }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 wasmtime-wasi = { workspace = true }
+
+[features]
+# Enables support for the `wasmtime::Store::call_hook` API which enables injecting custom
+# logic around all entries/exits from WebAssembly. This has a slight performance
+# cost for all host functions.
+call-hook = ["wasmtime/call-hook"]

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -19,8 +19,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }
-spin-key-value-spin = { path = "../key-value-spin" }
 spin-key-value-redis = { path = "../key-value-redis" }
+spin-key-value-spin = { path = "../key-value-spin" }
 tempfile = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 

--- a/crates/runtime-config/Cargo.toml
+++ b/crates/runtime-config/Cargo.toml
@@ -33,8 +33,8 @@ toml = { workspace = true }
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }
 spin-world = { path = "../world" }
-tokio = { version = "1", features = ["macros"] }
 tempfile = "3.2"
+tokio = { version = "1", features = ["macros"] }
 toml = "0.8"
 
 [lints]


### PR DESCRIPTION
This allows users of the `spin-core` crate to enable this feature in wasmtime if they so choose. 