### PR TITLE
Use official async-tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,8 +455,9 @@ dependencies = [
 
 [[package]]
 name = "async-tar"
-version = "0.4.2"
-source = "git+https://github.com/vdice/async-tar?rev=71e037f9652971e7a55b412a8e47a37b06f9c29d#71e037f9652971e7a55b412a8e47a37b06f9c29d"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42f905d4f623faf634bbd1e001e84e0efc24694afa64be9ad239bf6ca49e1f8"
 dependencies = [
  "async-std",
  "filetime",

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -7,8 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-compression = { version = "0.4", features = ["gzip", "tokio"] }
-# Fork with nested async-std dependency bumped to satisfy Windows build; branch/revision is protected
-async-tar = { git = "https://github.com/vdice/async-tar", rev = "71e037f9652971e7a55b412a8e47a37b06f9c29d" }
+async-tar = "0.5"
 base64 = "0.22"
 chrono = "0.4"
 # Fork with updated auth to support ACR login


### PR DESCRIPTION
Fixes #2846.

This built locally for me on Windows.  I'm pushing this to see whether it builds in CI, and if the artefacts are usable.

@vdice The dependency is used only (I believe) in the archive layers stuff (https://github.com/fermyon/spin/pull/1847).  Do we have a test case I can use to hit that?
