### PR TITLE
Implement wasi-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7065,6 +7065,7 @@ version = "2.8.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "spin-locked-app",
  "thiserror",
  "tokio",

--- a/crates/expressions/Cargo.toml
+++ b/crates/expressions/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
 spin-locked-app = { path = "../locked-app" }
 thiserror = { workspace = true }
 

--- a/crates/factor-variables/src/host.rs
+++ b/crates/factor-variables/src/host.rs
@@ -1,5 +1,5 @@
 use spin_factors::anyhow;
-use spin_world::{async_trait, v1, v2::variables};
+use spin_world::{async_trait, v1, v2::variables, wasi::config as wasi_config};
 use tracing::{instrument, Level};
 
 use crate::InstanceState;
@@ -33,6 +33,41 @@ impl v1::config::Host for InstanceState {
     }
 
     fn convert_error(&mut self, err: v1::config::Error) -> anyhow::Result<v1::config::Error> {
+        Ok(err)
+    }
+}
+
+#[async_trait]
+impl wasi_config::store::Host for InstanceState {
+    async fn get(&mut self, key: String) -> Result<Option<String>, wasi_config::store::Error> {
+        match <Self as variables::Host>::get(self, key).await {
+            Ok(value) => Ok(Some(value)),
+            Err(variables::Error::Undefined(_)) => Ok(None),
+            Err(variables::Error::InvalidName(_)) => Ok(None), // this is the guidance from https://github.com/WebAssembly/wasi-runtime-config/pull/19)
+            Err(variables::Error::Provider(msg)) => Err(wasi_config::store::Error::Upstream(msg)),
+            Err(variables::Error::Other(msg)) => Err(wasi_config::store::Error::Io(msg)),
+        }
+    }
+
+    async fn get_all(&mut self) -> Result<Vec<(String, String)>, wasi_config::store::Error> {
+        let all = self
+            .expression_resolver
+            .resolve_all(&self.component_id)
+            .await;
+        all.map_err(|e| {
+            match expressions_to_variables_err(e) {
+                variables::Error::Undefined(msg) => wasi_config::store::Error::Io(msg), // this shouldn't happen but just in case
+                variables::Error::InvalidName(msg) => wasi_config::store::Error::Io(msg), // this shouldn't happen but just in case
+                variables::Error::Provider(msg) => wasi_config::store::Error::Upstream(msg),
+                variables::Error::Other(msg) => wasi_config::store::Error::Io(msg),
+            }
+        })
+    }
+
+    fn convert_error(
+        &mut self,
+        err: wasi_config::store::Error,
+    ) -> anyhow::Result<wasi_config::store::Error> {
         Ok(err)
     }
 }

--- a/crates/factor-variables/src/lib.rs
+++ b/crates/factor-variables/src/lib.rs
@@ -31,6 +31,7 @@ impl Factor for VariablesFactor {
     fn init<T: Send + 'static>(&mut self, mut ctx: InitContext<T, Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::config::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::variables::add_to_linker)?;
+        ctx.link_bindings(spin_world::wasi::config::store::add_to_linker)?;
         Ok(())
     }
 

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -28,6 +28,7 @@ wasmtime::component::bindgen!({
         "fermyon:spin/sqlite@2.0.0/error" => v2::sqlite::Error,
         "fermyon:spin/sqlite/error" => v1::sqlite::Error,
         "fermyon:spin/variables@2.0.0/error" => v2::variables::Error,
+        "wasi:config/store/error" => wasi::config::store::Error,
     },
     trappable_imports: true,
 });

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -28,7 +28,7 @@ wasmtime::component::bindgen!({
         "fermyon:spin/sqlite@2.0.0/error" => v2::sqlite::Error,
         "fermyon:spin/sqlite/error" => v1::sqlite::Error,
         "fermyon:spin/variables@2.0.0/error" => v2::variables::Error,
-        "wasi:config/store/error" => wasi::config::store::Error,
+        "wasi:config/store@0.2.0-draft-2024-09-27/error" => wasi::config::store::Error,
     },
     trappable_imports: true,
 });

--- a/tests/runtime-tests/tests/variables/spin.toml
+++ b/tests/runtime-tests/tests/variables/spin.toml
@@ -1,0 +1,17 @@
+spin_manifest_version = "1"
+authors = [""]
+description = ""
+name = "variables"
+trigger = { type = "http" }
+version = "0.1.0"
+
+[variables]
+variable = { default = "value" }
+
+[[component]]
+id = "variables"
+source = "%{source=variables}"
+[component.trigger]
+route = "/..."
+[component.config]
+variable = "{{ variable }}"

--- a/tests/runtime-tests/tests/wasi-config/spin.toml
+++ b/tests/runtime-tests/tests/wasi-config/spin.toml
@@ -1,0 +1,17 @@
+spin_manifest_version = "1"
+authors = [""]
+description = ""
+name = "wasi-config"
+trigger = { type = "http" }
+version = "0.1.0"
+
+[variables]
+variable = { default = "value" }
+
+[[component]]
+id = "wasi-config"
+source = "%{source=wasi-config}"
+[component.trigger]
+route = "/..."
+[component.config]
+variable = "{{ variable }}"

--- a/tests/test-components/components/Cargo.lock
+++ b/tests/test-components/components/Cargo.lock
@@ -907,6 +907,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wasi-config"
+version = "0.1.0"
+dependencies = [
+ "helper",
+ "wit-bindgen 0.16.0",
+]
+
+[[package]]
 name = "wasi-http-rc-2023-11-10"
 version = "0.1.0"
 dependencies = [

--- a/tests/test-components/components/wasi-config/Cargo.toml
+++ b/tests/test-components/components/wasi-config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wasi-config"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+helper = { path = "../../helper" }
+wit-bindgen = "0.16.0"

--- a/tests/test-components/components/wasi-config/README.md
+++ b/tests/test-components/components/wasi-config/README.md
@@ -1,0 +1,8 @@
+# Variables
+
+Tests the wasi:config interface.
+
+## Expectations
+
+This test component expects the following to be true:
+* Only the variable named "variable" is defined with value "value"

--- a/tests/test-components/components/wasi-config/src/lib.rs
+++ b/tests/test-components/components/wasi-config/src/lib.rs
@@ -1,0 +1,23 @@
+use helper::ensure_matches;
+
+use bindings::wasi::config::store::{get, get_all};
+
+helper::define_component!(Component);
+
+impl Component {
+    fn main() -> Result<(), String> {
+        ensure_matches!(get("variable"), Ok(Some(val)) if val == "value");
+        ensure_matches!(get("non_existent"), Ok(None));
+
+        let expected_all = vec![
+            ("variable".to_owned(), "value".to_owned()),
+        ];
+        ensure_matches!(get_all(), Ok(val) if val == expected_all);
+
+        ensure_matches!(get("invalid-name"), Ok(None));
+        ensure_matches!(get("invalid!name"), Ok(None));
+        ensure_matches!(get("4invalidname"), Ok(None));
+
+        Ok(())
+    }
+}

--- a/wit/deps/spin@3.0.0/world.wit
+++ b/wit/deps/spin@3.0.0/world.wit
@@ -9,4 +9,5 @@ world http-trigger {
 /// The imports needed for a guest to run on a Spin host
 world platform {
   include fermyon:spin/platform@2.0.0;
+  import wasi:config/store@0.2.0-draft;
 }

--- a/wit/deps/spin@3.0.0/world.wit
+++ b/wit/deps/spin@3.0.0/world.wit
@@ -9,5 +9,5 @@ world http-trigger {
 /// The imports needed for a guest to run on a Spin host
 world platform {
   include fermyon:spin/platform@2.0.0;
-  import wasi:config/store@0.2.0-draft;
+  import wasi:config/store@0.2.0-draft-2024-09-27;
 }

--- a/wit/deps/wasi-runtime-config-2024-09-27/store.wit
+++ b/wit/deps/wasi-runtime-config-2024-09-27/store.wit
@@ -1,0 +1,30 @@
+interface store {
+    /// An error type that encapsulates the different errors that can occur fetching configuration values.
+    variant error {
+        /// This indicates an error from an "upstream" config source. 
+        /// As this could be almost _anything_ (such as Vault, Kubernetes ConfigMaps, KeyValue buckets, etc), 
+        /// the error message is a string.
+        upstream(string),
+        /// This indicates an error from an I/O operation. 
+        /// As this could be almost _anything_ (such as a file read, network connection, etc), 
+        /// the error message is a string. 
+        /// Depending on how this ends up being consumed, 
+        /// we may consider moving this to use the `wasi:io/error` type instead. 
+        /// For simplicity right now in supporting multiple implementations, it is being left as a string.
+        io(string),
+    }
+
+    /// Gets a configuration value of type `string` associated with the `key`. 
+    /// 
+    /// The value is returned as an `option<string>`. If the key is not found,
+    /// `Ok(none)` is returned. If an error occurs, an `Err(error)` is returned.
+    get: func(
+        /// A string key to fetch
+        key: string
+    ) -> result<option<string>, error>;
+
+    /// Gets a list of configuration key-value pairs of type `string`.
+    /// 
+    /// If an error occurs, an `Err(error)` is returned.
+    get-all: func() -> result<list<tuple<string, string>>, error>;
+}

--- a/wit/deps/wasi-runtime-config-2024-09-27/world.wit
+++ b/wit/deps/wasi-runtime-config-2024-09-27/world.wit
@@ -1,0 +1,6 @@
+package wasi:config@0.2.0-draft;
+
+world imports {
+    /// The interface for wasi:config/store
+    import store;
+}

--- a/wit/deps/wasi-runtime-config-2024-09-27/world.wit
+++ b/wit/deps/wasi-runtime-config-2024-09-27/world.wit
@@ -1,4 +1,4 @@
-package wasi:config@0.2.0-draft;
+package wasi:config@0.2.0-draft-2024-09-27;
 
 world imports {
     /// The interface for wasi:config/store


### PR DESCRIPTION
Fixes #2868.

This has the same considerations as our wasi-observe and wasi-keyvalue implementations in terms of versioning the Spin worlds - I mashed it into the existing Spin 2 worlds for development and testing but know that is not sustainable.  (At this point, I'm assuming all this lot will be punted into a new Spin 3 world.)

I'm publishing this mostly to:

1. see if it works
2. give us the chance to look at implementation considerations and decide if we need to offer feedback to upstream proposal

(Regarding 2, it felt like we have some errors that don't map nicely to the proposal.  I ended up using the `io` error variant for anything that wasn't a provider error, which feels potentially misleading.  @kate-goldenring I'd value your thoughts on this!)
