### PR TITLE
convert issue template to form

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,9 +1,36 @@
 ---
 name: Share a suggestion
 about: Suggest an improvement, new feature, or something we could do better
-title: ''
 labels: ''
-assignees: ''
-
+body:
+  - type: markdown
+    id: preface
+    attributes:
+      value: "Thank you for submitting a suggestion for Spin!"
+  - type: input
+    id: version
+    attributes:
+      label: "What is the version of your Spin CLI?"
+      description: "You can use te command `spin --version` to get it."
+  - type: textarea
+    id: description
+    attributes:
+      label: "What is your suggestion?"
+      validations:
+        required: true
+  - type: textarea
+    id: "usecase"
+    attributes:
+      label: "Why would this improve Spin?"
+      description: "Please describe your use case or scenario."
+    validations:
+      required: true
+  - type: checkboxes
+    id: contributing
+    attributes:
+      label: "Are you willing to submit PRs to contribute to this feature or improvement?"
+      description: "This is not required and we are happy to guide you in the contribution process."
+      options:
+        - label: Yes, I am willing to implement it.
 ---
 


### PR DESCRIPTION
- Was inspired by the ORAS issue form and specifically that they have a checkbox for indicating whether the person filing the issue is interested in contributing. Would love to know what folks think about this? https://github.com/oras-project/oras/issues/new?assignees=&labels=enhancement%2Ctriage&projects=&template=feature-request.yaml

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms