### PR TITLE
Run build steps on docs-only PRs so that all maintainers can merge them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["main", "v*"]
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
-      - "tests/README.md"
 
 # Serialize workflow runs per ref
 # Cancel any outdated, in-flight runs for refs other than 'main'


### PR DESCRIPTION
Currently, PRs that only touch documents (e.g. SIPs, governance stuff, etc.) do not run the build workflow.  This is great because it saves waiting for a build whose results can't have changed.  Unfortunately, since we introduced required checks, it has meant that the required checks do not run on such PRs, so ordinary mortal maintainers can't merge them - we need to instead ping the administrators on high Olympus.  So merging a docs PR now ends up being _more_ effort and time, the problem that not running the build was meant to solve.

This PR proposes to resume running the build on these PRs.

Got a docs PR and want to merge it without waiting for the build?  You can still do that by pinging an admin and getting them to bypass the checks, just like you have to do today.  This PR just enables an alternative "mash that auto merge button and move on with your life" strategy.
