### PR TITLE
Implement AWS key value store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
 name = "async-priority-channel"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +520,329 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-config"
+version = "1.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.2.0",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.2.0",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6355a9536b92daf4c4b7d4d4f60dd08ea780259ed80bac0312f2e1df4398176"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.2.0",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53dcf5e7d9bd1517b8b998e170e650047cea8a2b85fe1835abe3210713e541b7"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand 2.2.0",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.31",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +1006,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -863,6 +1202,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -3433,6 +3782,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.31",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
@@ -3442,7 +3807,7 @@ dependencies = [
  "hyper 0.14.31",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -5225,6 +5590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6196,6 +6567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6386,9 +6763,9 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -6523,6 +6900,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -6530,7 +6919,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -6545,9 +6934,21 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -6586,6 +6987,16 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -6659,6 +7070,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -7591,6 +8012,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-key-value-aws"
+version = "3.1.0-pre0"
+dependencies = [
+ "anyhow",
+ "async-once-cell",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "serde",
+ "spin-core",
+ "spin-factor-key-value",
+]
+
+[[package]]
 name = "spin-key-value-azure"
 version = "3.1.0-pre0"
 dependencies = [
@@ -7797,6 +8232,7 @@ dependencies = [
  "spin-factor-wasi",
  "spin-factors",
  "spin-factors-test",
+ "spin-key-value-aws",
  "spin-key-value-azure",
  "spin-key-value-redis",
  "spin-key-value-spin",
@@ -8638,6 +9074,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
@@ -9171,6 +9617,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wac-graph"
@@ -10704,6 +11156,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yaml-rust2"

--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -283,6 +283,9 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         keys: Vec<String>,
     ) -> std::result::Result<Vec<(String, Option<Vec<u8>>)>, wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(bucket)?;
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
         store.get_many(keys).await.map_err(to_wasi_err)
     }
 
@@ -293,6 +296,9 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         key_values: Vec<(String, Vec<u8>)>,
     ) -> std::result::Result<(), wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(bucket)?;
+        if key_values.is_empty() {
+            return Ok(());
+        }
         store.set_many(key_values).await.map_err(to_wasi_err)
     }
 
@@ -303,6 +309,9 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         keys: Vec<String>,
     ) -> std::result::Result<(), wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(bucket)?;
+        if keys.is_empty() {
+            return Ok(());
+        }
         store.delete_many(keys).await.map_err(to_wasi_err)
     }
 }

--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -283,10 +283,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         keys: Vec<String>,
     ) -> std::result::Result<Vec<(String, Option<Vec<u8>>)>, wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(bucket)?;
-        store
-            .get_many(keys.iter().map(|k| k.to_string()).collect())
-            .await
-            .map_err(to_wasi_err)
+        store.get_many(keys).await.map_err(to_wasi_err)
     }
 
     #[instrument(name = "spin_key_value.set_many", skip(self, bucket, key_values), err(level = Level::INFO), fields(otel.kind = "client"))]
@@ -306,10 +303,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         keys: Vec<String>,
     ) -> std::result::Result<(), wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(bucket)?;
-        store
-            .delete_many(keys.iter().map(|k| k.to_string()).collect())
-            .await
-            .map_err(to_wasi_err)
+        store.delete_many(keys).await.map_err(to_wasi_err)
     }
 }
 

--- a/crates/factor-key-value/src/util.rs
+++ b/crates/factor-key-value/src/util.rs
@@ -260,10 +260,12 @@ impl Store for CachingStore {
             }
         }
 
-        let keys_and_values = self.inner.get_many(not_found).await?;
-        for (key, value) in keys_and_values {
-            found.push((key.clone(), value.clone()));
-            state.cache.put(key, value);
+        if !not_found.is_empty() {
+            let keys_and_values = self.inner.get_many(not_found).await?;
+            for (key, value) in keys_and_values {
+                found.push((key.clone(), value.clone()));
+                state.cache.put(key, value);
+            }
         }
 
         Ok(found)

--- a/crates/factor-key-value/src/util.rs
+++ b/crates/factor-key-value/src/util.rs
@@ -251,6 +251,11 @@ impl Store for CachingStore {
         keys: Vec<String>,
     ) -> anyhow::Result<Vec<(String, Option<Vec<u8>>)>, Error> {
         let mut state = self.state.lock().await;
+
+        // Flush any outstanding writes first in case entries have been popped off the end of the LRU cache prior
+        // to their corresponding writes reaching the backing store.
+        state.flush().await?;
+
         let mut found: Vec<(String, Option<Vec<u8>>)> = Vec::new();
         let mut not_found: Vec<String> = Vec::new();
         for key in keys {

--- a/crates/key-value-aws/Cargo.toml
+++ b/crates/key-value-aws/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "spin-key-value-aws"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+async-once-cell = "0.5.4"
+aws-config = "1.1.7"
+aws-credential-types = "1.1.7"
+aws-sdk-dynamodb = "1.49.0"
+serde = { workspace = true }
+spin-core = { path = "../core" }
+spin-factor-key-value = { path = "../factor-key-value" }
+
+[lints]
+workspace = true

--- a/crates/key-value-aws/src/lib.rs
+++ b/crates/key-value-aws/src/lib.rs
@@ -1,0 +1,65 @@
+mod store;
+
+use serde::Deserialize;
+use spin_factor_key_value::runtime_config::spin::MakeKeyValueStore;
+use store::{
+    KeyValueAwsDynamo, KeyValueAwsDynamoAuthOptions, KeyValueAwsDynamoRuntimeConfigOptions,
+};
+
+/// A key-value store that uses AWS Dynamo as the backend.
+#[derive(Default)]
+pub struct AwsKeyValueStore {
+    _priv: (),
+}
+
+impl AwsKeyValueStore {
+    /// Creates a new `AwsKeyValueStore`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Runtime configuration for the AWS Dynamo key-value store.
+#[derive(Deserialize)]
+pub struct AwsDynamoKeyValueRuntimeConfig {
+    /// The access key for the AWS Dynamo DB account role.
+    access_key: Option<String>,
+    /// The secret key for authorization on the AWS Dynamo DB account.
+    secret_key: Option<String>,
+    /// The token for authorization on the AWS Dynamo DB account.
+    token: Option<String>,
+    /// The AWS region where the database is located
+    region: String,
+    /// The AWS Dynamo DB table.
+    table: String,
+}
+
+impl MakeKeyValueStore for AwsKeyValueStore {
+    const RUNTIME_CONFIG_TYPE: &'static str = "aws_dynamo";
+
+    type RuntimeConfig = AwsDynamoKeyValueRuntimeConfig;
+
+    type StoreManager = KeyValueAwsDynamo;
+
+    fn make_store(
+        &self,
+        runtime_config: Self::RuntimeConfig,
+    ) -> anyhow::Result<Self::StoreManager> {
+        let AwsDynamoKeyValueRuntimeConfig {
+            access_key,
+            secret_key,
+            token,
+            region,
+            table,
+        } = runtime_config;
+        let auth_options = match (access_key, secret_key) {
+            (Some(access_key), Some(secret_key)) => {
+                KeyValueAwsDynamoAuthOptions::RuntimeConfigValues(
+                    KeyValueAwsDynamoRuntimeConfigOptions::new(access_key, secret_key, token),
+                )
+            }
+            _ => KeyValueAwsDynamoAuthOptions::Environmental,
+        };
+        KeyValueAwsDynamo::new(region, table, auth_options)
+    }
+}

--- a/crates/key-value-aws/src/lib.rs
+++ b/crates/key-value-aws/src/lib.rs
@@ -30,6 +30,9 @@ pub struct AwsDynamoKeyValueRuntimeConfig {
     token: Option<String>,
     /// The AWS region where the database is located
     region: String,
+    /// Boolean determining whether to use strongly consistent reads.
+    /// Defaults to `false` but can be set to `true` to improve atomicity
+    consistent_read: Option<bool>,
     /// The AWS Dynamo DB table.
     table: String,
 }
@@ -50,6 +53,7 @@ impl MakeKeyValueStore for AwsDynamoKeyValueStore {
             secret_key,
             token,
             region,
+            consistent_read,
             table,
         } = runtime_config;
         let auth_options = match (access_key, secret_key) {
@@ -60,6 +64,11 @@ impl MakeKeyValueStore for AwsDynamoKeyValueStore {
             }
             _ => KeyValueAwsDynamoAuthOptions::Environmental,
         };
-        KeyValueAwsDynamo::new(region, table, auth_options)
+        KeyValueAwsDynamo::new(
+            region,
+            consistent_read.unwrap_or(false),
+            table,
+            auth_options,
+        )
     }
 }

--- a/crates/key-value-aws/src/lib.rs
+++ b/crates/key-value-aws/src/lib.rs
@@ -8,11 +8,11 @@ use store::{
 
 /// A key-value store that uses AWS Dynamo as the backend.
 #[derive(Default)]
-pub struct AwsKeyValueStore {
+pub struct AwsDynamoKeyValueStore {
     _priv: (),
 }
 
-impl AwsKeyValueStore {
+impl AwsDynamoKeyValueStore {
     /// Creates a new `AwsKeyValueStore`.
     pub fn new() -> Self {
         Self::default()
@@ -34,7 +34,7 @@ pub struct AwsDynamoKeyValueRuntimeConfig {
     table: String,
 }
 
-impl MakeKeyValueStore for AwsKeyValueStore {
+impl MakeKeyValueStore for AwsDynamoKeyValueStore {
     const RUNTIME_CONFIG_TYPE: &'static str = "aws_dynamo";
 
     type RuntimeConfig = AwsDynamoKeyValueRuntimeConfig;

--- a/crates/key-value-aws/src/store.rs
+++ b/crates/key-value-aws/src/store.rs
@@ -1,0 +1,232 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use aws_config::{BehaviorVersion, Region, SdkConfig};
+use aws_credential_types::Credentials;
+use aws_sdk_dynamodb::{
+    config::{ProvideCredentials, SharedCredentialsProvider},
+    primitives::Blob,
+    types::AttributeValue,
+    Client,
+};
+use spin_core::async_trait;
+use spin_factor_key_value::{log_error, Error, Store, StoreManager};
+
+pub struct KeyValueAwsDynamo {
+    table: String,
+    region: String,
+    client: async_once_cell::Lazy<
+        Client,
+        std::pin::Pin<Box<dyn std::future::Future<Output = Client> + Send>>,
+    >,
+}
+
+/// AWS Dynamo Key / Value runtime config literal options for authentication
+#[derive(Clone, Debug)]
+pub struct KeyValueAwsDynamoRuntimeConfigOptions {
+    access_key: String,
+    secret_key: String,
+    token: Option<String>,
+}
+
+impl KeyValueAwsDynamoRuntimeConfigOptions {
+    pub fn new(access_key: String, secret_key: String, token: Option<String>) -> Self {
+        Self {
+            access_key,
+            secret_key,
+            token,
+        }
+    }
+}
+
+impl ProvideCredentials for KeyValueAwsDynamoRuntimeConfigOptions {
+    fn provide_credentials<'a>(
+        &'a self,
+    ) -> aws_credential_types::provider::future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        aws_credential_types::provider::future::ProvideCredentials::ready(Ok(Credentials::new(
+            self.access_key.clone(),
+            self.secret_key.clone(),
+            self.token.clone(),
+            None, // Optional expiration time
+            "spin_custom_aws_provider",
+        )))
+    }
+}
+
+/// AWS Dynamo Key / Value enumeration for the possible authentication options
+#[derive(Clone, Debug)]
+pub enum KeyValueAwsDynamoAuthOptions {
+    /// Runtime Config values indicates credentials have been specified directly
+    RuntimeConfigValues(KeyValueAwsDynamoRuntimeConfigOptions),
+    /// Environmental indicates that the environment variables of the process should be used to
+    /// create the SDK Config for the Dynamo client. This will use the AWS Rust SDK's
+    /// aws_config::load_defaults to derive credentials based on what environment variables
+    /// have been set.
+    ///
+    /// See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html for options.
+    Environmental,
+}
+
+impl KeyValueAwsDynamo {
+    pub fn new(
+        region: String,
+        table: String,
+        auth_options: KeyValueAwsDynamoAuthOptions,
+    ) -> Result<Self> {
+        let region_clone = region.clone();
+        let client_fut: std::pin::Pin<Box<dyn std::future::Future<Output = Client> + Send>> =
+            Box::pin(async move {
+                let config = match auth_options {
+                    KeyValueAwsDynamoAuthOptions::RuntimeConfigValues(config) => {
+                        SdkConfig::builder()
+                            .credentials_provider(SharedCredentialsProvider::new(config))
+                            .region(Region::new(region_clone))
+                            .behavior_version(BehaviorVersion::latest())
+                            .build()
+                    }
+                    KeyValueAwsDynamoAuthOptions::Environmental => {
+                        aws_config::load_defaults(BehaviorVersion::latest()).await
+                    }
+                };
+                Client::new(&config)
+            });
+
+        Ok(Self {
+            client: async_once_cell::Lazy::from_future(client_fut),
+            table,
+            region,
+        })
+    }
+}
+
+#[async_trait]
+impl StoreManager for KeyValueAwsDynamo {
+    async fn get(&self, name: &str) -> Result<Arc<dyn Store>, Error> {
+        Ok(Arc::new(AwsDynamoStore {
+            _name: name.to_owned(),
+            client: self.client.get_unpin().await.clone(),
+            table: self.table.clone(),
+        }))
+    }
+
+    fn is_defined(&self, _store_name: &str) -> bool {
+        true
+    }
+
+    fn summary(&self, _store_name: &str) -> Option<String> {
+        Some(format!(
+            "AWS DynamoDB region: {:?}, table: {}",
+            self.region, self.table
+        ))
+    }
+}
+
+struct AwsDynamoStore {
+    _name: String,
+    client: Client,
+    table: String,
+}
+
+const PK: &str = "PK";
+const VAL: &str = "val";
+
+#[async_trait]
+impl Store for AwsDynamoStore {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        let item = self.get_item(key).await?;
+        Ok(item)
+    }
+
+    async fn set(&self, key: &str, value: &[u8]) -> Result<(), Error> {
+        self.client
+            .put_item()
+            .table_name(self.table.clone())
+            .item(PK, AttributeValue::S(key.to_string()))
+            .item(VAL, AttributeValue::B(Blob::new(value)))
+            .send()
+            .await
+            .map_err(log_error)?;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), Error> {
+        if self.exists(key).await? {
+            self.client
+                .delete_item()
+                .table_name(self.table.clone())
+                .key(PK, AttributeValue::S(key.to_string()))
+                .send()
+                .await
+                .map_err(log_error)?;
+        }
+        Ok(())
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, Error> {
+        Ok(self.get_item(key).await?.is_some())
+    }
+
+    async fn get_keys(&self) -> Result<Vec<String>, Error> {
+        self.get_keys().await
+    }
+}
+
+impl AwsDynamoStore {
+    async fn get_item(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
+        let query = self
+            .client
+            .get_item()
+            .table_name(self.table.clone())
+            .key(PK, aws_sdk_dynamodb::types::AttributeValue::S(key.into()))
+            .send()
+            .await
+            .map_err(log_error)?;
+
+        Ok(query.item.and_then(|item| {
+            if let Some(AttributeValue::B(val)) = item.get(VAL) {
+                Some(val.clone().into_inner())
+            } else {
+                None
+            }
+        }))
+    }
+
+    async fn get_keys(&self) -> Result<Vec<String>, Error> {
+        let mut primary_keys = Vec::new();
+        let mut last_evaluated_key = None;
+
+        loop {
+            let mut scan_builder = self
+                .client
+                .scan()
+                .table_name(self.table.clone())
+                .projection_expression(PK);
+
+            if let Some(keys) = last_evaluated_key {
+                for (key, val) in keys {
+                    scan_builder = scan_builder.exclusive_start_key(key, val);
+                }
+            }
+
+            let scan_output = scan_builder.send().await.map_err(log_error)?;
+
+            if let Some(items) = scan_output.items {
+                for item in items {
+                    if let Some(AttributeValue::S(pk)) = item.get(PK) {
+                        primary_keys.push(pk.clone());
+                    }
+                }
+            }
+
+            last_evaluated_key = scan_output.last_evaluated_key;
+            if last_evaluated_key.is_none() {
+                break;
+            }
+        }
+
+        Ok(primary_keys)
+    }
+}

--- a/crates/key-value-aws/src/store.rs
+++ b/crates/key-value-aws/src/store.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use aws_config::{BehaviorVersion, Region, SdkConfig};
@@ -6,7 +6,7 @@ use aws_credential_types::Credentials;
 use aws_sdk_dynamodb::{
     config::{ProvideCredentials, SharedCredentialsProvider},
     primitives::Blob,
-    types::AttributeValue,
+    types::{AttributeValue, KeysAndAttributes},
     Client,
 };
 use spin_core::async_trait;
@@ -127,6 +127,13 @@ struct AwsDynamoStore {
     table: String,
 }
 
+// struct CompareAndSwap {
+//     key: String,
+//     client: CollectionClient,
+//     bucket_rep: u32,
+//     etag: Mutex<Option<String>>,
+// }
+
 const PK: &str = "PK";
 const VAL: &str = "val";
 
@@ -168,6 +175,30 @@ impl Store for AwsDynamoStore {
 
     async fn get_keys(&self) -> Result<Vec<String>, Error> {
         self.get_keys().await
+    }
+
+    async fn get_many(&self, keys: Vec<String>) -> Result<Vec<(String, Option<Vec<u8>>)>, Error> {
+        todo!()
+    }
+
+    async fn set_many(&self, key_values: Vec<(String, Vec<u8>)>) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn delete_many(&self, keys: Vec<String>) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn increment(&self, key: String, delta: i64) -> Result<i64, Error> {
+        todo!()
+    }
+
+    async fn new_compare_and_swap(
+        &self,
+        bucket_rep: u32,
+        key: &str,
+    ) -> Result<Arc<dyn spin_factor_key_value::Cas>, Error> {
+        todo!()
     }
 }
 

--- a/crates/key-value-azure/src/store.rs
+++ b/crates/key-value-azure/src/store.rs
@@ -92,9 +92,8 @@ impl KeyValueAzureCosmos {
 
 #[async_trait]
 impl StoreManager for KeyValueAzureCosmos {
-    async fn get(&self, name: &str) -> Result<Arc<dyn Store>, Error> {
+    async fn get(&self, _name: &str) -> Result<Arc<dyn Store>, Error> {
         Ok(Arc::new(AzureCosmosStore {
-            _name: name.to_owned(),
             client: self.client.clone(),
         }))
     }
@@ -114,7 +113,6 @@ impl StoreManager for KeyValueAzureCosmos {
 
 #[derive(Clone)]
 struct AzureCosmosStore {
-    _name: String,
     client: CollectionClient,
 }
 

--- a/crates/key-value-spin/src/store.rs
+++ b/crates/key-value-spin/src/store.rs
@@ -522,15 +522,10 @@ mod test {
         let res = kv.swap(Resource::new_own(cas.rep()), cas_final_value).await;
         match res {
             Ok(_) => panic!("expected a CAS failure"),
-            Err(err) => {
-                for cause in err.chain() {
-                    if let Some(cas_err) = cause.downcast_ref::<CasError>() {
-                        assert!(matches!(cas_err, CasError::CasFailed(_)));
-                        return Ok(());
-                    }
-                }
-                panic!("expected a CAS failure")
-            }
+            Err(err) => match err {
+                CasError::CasFailed(_) => Ok(()),
+                CasError::StoreError(_) => panic!("expected a CasFailed error"),
+            },
         }
     }
 

--- a/crates/runtime-config/Cargo.toml
+++ b/crates/runtime-config/Cargo.toml
@@ -23,6 +23,7 @@ spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factor-wasi = { path = "../factor-wasi" }
 spin-factors = { path = "../factors" }
+spin-key-value-aws = { path = "../key-value-aws" }
 spin-key-value-azure = { path = "../key-value-azure" }
 spin-key-value-redis = { path = "../key-value-redis" }
 spin-key-value-spin = { path = "../key-value-spin" }

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -401,7 +401,7 @@ pub fn key_value_config_resolver(
         .register_store_type(spin_key_value_azure::AzureKeyValueStore::new())
         .unwrap();
     key_value
-        .register_store_type(spin_key_value_aws::AwsKeyValueStore::new())
+        .register_store_type(spin_key_value_aws::AwsDynamoKeyValueStore::new())
         .unwrap();
 
     // Add handling of "default" store.

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -400,6 +400,9 @@ pub fn key_value_config_resolver(
     key_value
         .register_store_type(spin_key_value_azure::AzureKeyValueStore::new())
         .unwrap();
+    key_value
+        .register_store_type(spin_key_value_aws::AwsKeyValueStore::new())
+        .unwrap();
 
     // Add handling of "default" store.
     let default_store_path = default_store_base_path.map(|p| p.join(DEFAULT_SPIN_STORE_FILENAME));

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -33,6 +33,7 @@ wasmtime::component::bindgen!({
         "spin:postgres/postgres/error" => spin::postgres::postgres::Error,
         "wasi:config/store@0.2.0-draft-2024-09-27/error" => wasi::config::store::Error,
         "wasi:keyvalue/store/error" => wasi::keyvalue::store::Error,
+        "wasi:keyvalue/atomics/cas-error" => wasi::keyvalue::atomics::CasError,
     },
     trappable_imports: true,
 });

--- a/wit/deps/keyvalue-2024-10-17/atomic.wit
+++ b/wit/deps/keyvalue-2024-10-17/atomic.wit
@@ -13,22 +13,22 @@ interface atomics {
 
   /// The error returned by a CAS operation
   variant cas-error {
-	/// A store error occurred when performing the operation
-	store-error(error),
+    /// A store error occurred when performing the operation
+    store-error(error),
 	  /// The CAS operation failed because the value was too old. This returns a new CAS handle
 	  /// for easy retries. Implementors MUST return a CAS handle that has been updated to the
 	  /// latest version or transaction.
-	cas-failed(cas),
+	  cas-failed(cas),
   }
 
   /// A handle to a CAS (compare-and-swap) operation.
   resource cas {
-	/// Construct a new CAS operation. Implementors can map the underlying functionality
-	/// (transactions, versions, etc) as desired.
-	new: static func(bucket: borrow<bucket>, key: string) -> result<cas, error>;
-	/// Get the current value of the key (if it exists). This allows for avoiding reads if all
-	/// that is needed to ensure the atomicity of the operation
-	current: func() -> result<option<list<u8>>, error>;
+    /// Construct a new CAS operation. Implementors can map the underlying functionality
+    /// (transactions, versions, etc) as desired.
+    new: static func(bucket: borrow<bucket>, key: string) -> result<cas, error>;
+    /// Get the current value of the key (if it exists). This allows for avoiding reads if all
+    /// that is needed to ensure the atomicity of the operation
+    current: func() -> result<option<list<u8>>, error>;
   }
 
   /// Atomically increment the value associated with the key in the store by the given delta. It

--- a/wit/deps/keyvalue-2024-10-17/world.wit
+++ b/wit/deps/keyvalue-2024-10-17/world.wit
@@ -1,4 +1,4 @@
-package wasi: keyvalue@0.2.0-draft2;
+package wasi:keyvalue@0.2.0-draft2;
 
 /// The `wasi:keyvalue/imports` world provides common APIs for interacting with key-value stores.
 /// Components targeting this world will be able to do:


### PR DESCRIPTION
Hi folks! I am creating this draft PR to solicit feedback on an initial AWS key value store implementation. I appreciate any and all discussions on this PR!

Some points for thought:
1. Implementation uses DynamoDB, though for large blob storage, S3 is preferable (DynamoDB can only store <=400KB size records), see https://github.com/fermyon/spin/issues/2606. DynamoDB is cheaper and faster for performing many rapid reads/writes of small amounts of data though, and is _roughly_ in the same niche as Azure CosmosDB
2. Auth currently requires generating AWS STS token credentials and passing them to the Spin app in a runtime config file. https://github.com/spinkube/skips/pull/9/files discusses better patterns to fetch credentials. Curious to hear thoughts on how this implementation can integrate better with that proposal!
3. The [Azure key-value implementation](https://github.com/fermyon/spin/blob/main/crates/key-value-azure/src/store.rs#L64) supports reading credentials from environment variables, however the [AWS Rust SDK does not offer a synchronous API to load config](https://docs.rs/aws-config/latest/aws_config/fn.load_from_env.html) and would require the [MakeKeyValueStore::make_store function](https://github.com/fermyon/spin/blob/main/crates/factor-key-value/src/runtime_config/spin.rs#L20) to be async for all implementations -- leading to a chain of async function coloring. It is possible to [manually fill the SdkConfig object](https://docs.rs/aws-config/latest/aws_config/struct.SdkConfig.html#method.builder) and I did this to pass STS tokens from a runtime config file, but it would be ideal to rely on the [SDK's defaults and many credential loading fallbacks if possible](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html). Curious on thoughts for how to best handle env var credential loading