### PR TITLE
add ability for plugins to be fetched from authenticated URLs

### DIFF
--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -209,6 +209,7 @@ fn installer_for(plugin_name: &str) -> Install {
         remote_manifest_src: None,
         override_compatibility_check: false,
         version: None,
+        auth_header_value: None,
     }
 }
 


### PR DESCRIPTION
This PR enables users to set a `SPIN_PLUGIN_AUTH_HEADER` environment variable that will then be set on the outgoing request. For example, the header would have a value like `token <gh_token>` to get a plugin from a private repo.

If this would be better served as a flag like `spin plugins install <secret_plugin> --auth-header "token <gh_token>", I would be happy to update this PR. 