### PR TITLE
fix(release.yml): skip docker job if ref isn't main or tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,9 @@ jobs:
   docker:
     runs-on: "ubuntu-20.04"
     needs: [build-and-sign, build-spin-static]
+    # Only build/push Docker images if this is a v* tag or if this is main/canary
+    # i.e. skip for v* release branches
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fix for CI failures like this [v3.0 branch run](https://github.com/fermyon/spin/actions/runs/11673687718/job/32506064226#step:5:18).  Skips running the Docker job if the ref isn't the main branch or a tag.