### PR TITLE
[Backport v3.0] fix(release.yml): skip docker job if ref isn't main or tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,9 @@ jobs:
   docker:
     runs-on: "ubuntu-20.04"
     needs: [build-and-sign, build-spin-static]
+    # Only build/push Docker images if this is a v* tag or if this is main/canary
+    # i.e. skip for v* release branches
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Backporting #2903 to v3.0