### PR TITLE
Introducing Fermyon Spin Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <p>Spin is a framework for building, deploying, and running fast, secure, and composable cloud microservices with WebAssembly.</p>
       <a href="https://github.com/fermyon/spin/actions/workflows/build.yml"><img src="https://github.com/fermyon/spin/actions/workflows/build.yml/badge.svg" alt="build status" /></a>
       <a href="https://discord.gg/eGN8saYqCk"><img alt="Discord" src="https://img.shields.io/discord/926888690310053918?label=Discord"></a>
+      <a href="https://gurubase.io/g/fermyon-spin"><img src="https://img.shields.io/badge/Gurubase-Ask%20Fermyon%20Spin%20Guru-006BFF" alt="Gurubase" /></a>
 </div>
 
 ## What is Spin?


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Fermyon Spin Guru](https://gurubase.io/g/fermyon-spin) to Gurubase. Fermyon Spin Guru uses the data from this repo and data from the [docs](https://developer.fermyon.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Fermyon Spin Guru", which highlights that Fermyon Spin now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Fermyon Spin Guru in Gurubase, just let me know that's totally fine.
