### PR TITLE
chore(.github): bump upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           CARGO_INCREMENTAL: 0
 
       - name: "Archive executable artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spin-ubuntu-latest
           path: target/release/spin
@@ -108,7 +108,7 @@ jobs:
           BUILD_SPIN_EXAMPLES: 0
 
       - name: "Archive executable artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spin-static-${{ matrix.config.arch }}
           path: target/${{ matrix.config.target }}/release/spin
@@ -136,7 +136,7 @@ jobs:
           CARGO_INCREMENTAL: 0
 
       - name: "Archive executable artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spin-${{ matrix.os }}
           path: target/release/spin${{ matrix.os == 'windows-latest' && '.exe' || '' }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo build --workspace --all-targets --features all-tests --features openssl/vendored
 
       - name: "Archive executable artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spin-ubuntu-latest
           path: target/debug/spin
@@ -68,7 +68,7 @@ jobs:
           verbose: true
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           name: code-coverage-report


### PR DESCRIPTION
Found a few more instances of the v3 version of the upload-artifact GH action; these need to be bumped to v4 per the [deprecation notice for v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)