### PR TITLE
chore(*): post-3.0.0 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "conformance-tests",
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tests"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -6876,7 +6876,7 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "serde 1.0.210",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "spin-build"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "serde 1.0.210",
@@ -6903,7 +6903,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6975,7 +6975,7 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -6987,7 +6987,7 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7013,7 +7013,7 @@ dependencies = [
 
 [[package]]
 name = "spin-compose"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7045,7 +7045,7 @@ dependencies = [
 
 [[package]]
 name = "spin-doctor"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7066,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7079,7 +7079,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-key-value"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "lru",
@@ -7101,7 +7101,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-llm"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-http"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -7145,7 +7145,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mqtt"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "rumqttc",
@@ -7162,7 +7162,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mysql"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -7180,7 +7180,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -7210,7 +7210,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-pg"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7230,7 +7230,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-redis"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "redis 0.25.4",
@@ -7247,7 +7247,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-sqlite"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "async-trait",
  "spin-factors",
@@ -7261,7 +7261,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-variables"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "spin-expressions",
  "spin-factors",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-wasi"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7287,7 +7287,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "serde 1.0.210",
@@ -7300,7 +7300,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-derive"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "expander",
  "proc-macro2",
@@ -7310,7 +7310,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-executor"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "spin-app",
@@ -7323,7 +7323,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-test"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "spin-app",
  "spin-factors",
@@ -7334,7 +7334,7 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "azure_core",
@@ -7367,7 +7367,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "redis 0.27.2",
@@ -7380,7 +7380,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-spin"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -7393,7 +7393,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-local"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -7413,7 +7413,7 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "reqwest 0.12.7",
@@ -7426,7 +7426,7 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -7453,7 +7453,7 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7465,7 +7465,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "glob",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7512,7 +7512,7 @@ dependencies = [
 
 [[package]]
 name = "spin-plugins"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7537,11 +7537,11 @@ dependencies = [
 
 [[package]]
 name = "spin-resource-table"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 
 [[package]]
 name = "spin-runtime-config"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "spin-common",
@@ -7572,7 +7572,7 @@ dependencies = [
 
 [[package]]
 name = "spin-runtime-factors"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -7598,7 +7598,7 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7609,7 +7609,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "serde 1.0.210",
  "spin-factor-sqlite",
@@ -7621,7 +7621,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7633,7 +7633,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7645,7 +7645,7 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -7661,7 +7661,7 @@ dependencies = [
 
 [[package]]
 name = "spin-templates"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "dialoguer",
@@ -7690,7 +7690,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -7718,7 +7718,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-redis"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
@@ -7769,7 +7769,7 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "azure_core",
  "azure_identity",
@@ -7787,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "async-trait",
  "wasmtime",
@@ -8089,7 +8089,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "termcolor",
 ]
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "ui-testing"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [workspace.package]
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/examples/http-rust/Cargo.lock
+++ b/examples/http-rust/Cargo.lock
@@ -179,7 +179,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "http",
- "serde",
  "spin-sdk",
 ]
 

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.4"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -150,7 +150,7 @@ dependencies = [
  "rustix",
  "slab",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.2.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a07789659a4d385b79b18b9127fc27e1a59e1e89117c78c5ea3b806f016374"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel 2.3.1",
  "async-io",
@@ -181,14 +181,13 @@ dependencies = [
  "futures-lite 2.3.0",
  "rustix",
  "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32"
 dependencies = [
  "async-io",
  "async-lock",
@@ -199,7 +198,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -328,7 +327,7 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.8.5",
- "reqwest 0.12.7",
+ "reqwest 0.12.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -626,7 +625,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -759,18 +758,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b765ed4349e66bedd9b88c7691da42e24c7f62067a6be17ddffa949367b6e17"
+checksum = "69792bd40d21be8059f7c709f44200ded3bbd073df7eb3fa3c282b387c7ffa5b"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eaa2aece6237198afd32bff57699e08d4dccb8d3902c214fc1e6ba907247ca4"
+checksum = "38da1eb6f7d8cdfa92f05acfae63c9a1d7a337e49ce7a2d0769c7fa03a2613a5"
 dependencies = [
  "serde",
  "serde_derive",
@@ -778,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351824439e59d42f0e4fa5aac1d13deded155120043565769e55cd4ad3ca8ed9"
+checksum = "709f5567a2bff9f06edf911a7cb5ebb091e4c81701714dc6ab574d08b4a69a0d"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -801,33 +800,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0ce0273d7a493ef8f31f606849a4e931c19187a4923f5f87fc1f2b13109981"
+checksum = "72d39a6b194c069fd091ca1f17b9d86ff1a4627ccad8806095828f61989a691f"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f72016ac35579051913f4f07f6b36c509ed69412d852fd44c8e1d7b7fa6d92a"
+checksum = "18f81aefad1f80ed4132ae33f40b92779eeb57edeb1e28bb24424a4098c963a2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db28951d21512c4fd0554ef179bfb11e4eb6815062957a9173824eee5de0c46c"
+checksum = "6adbaac785ad4683c4f199686f9e15c1471f52ae2f4c013a3be039b4719db754"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ebe592a2f81af9237cf9be29dd3854ecb72108cfffa59e85ef12389bf939e3"
+checksum = "70b85ed43567e13782cd1b25baf42a8167ee57169a60dfd3d7307c6ca3839da0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -836,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4437db9d60c7053ac91ded0802740c2ccf123ee6d6898dd906c34f8c530cd119"
+checksum = "8349f71373bb69c6f73992c6c1606236a66c8134e7a60e04e03fbd64b1aa7dcf"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -848,15 +847,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230cb33572b9926e210f2ca28145f2bc87f389e1456560932168e2591feb65c1"
+checksum = "464a6b958ce05e0c237c8b25508012b6c644e8c37348213a8c786ba29e28cfdb"
 
 [[package]]
 name = "cranelift-native"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364524ac7aef7070b1141478724abebeec297d4ea1e87ad8b8986465e91146d9"
+checksum = "ffc4acaf6894ee323ff4e9ce786bec09f0ebbe49941e8012f1c1052f1d965034"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -865,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0572cbd9d136a62c0f39837b6bce3b0978b96b8586794042bec0c214668fd6f5"
+checksum = "b878860895cca97454ef8d8b12bfda9d0889dd49efee175dba78d54ff8363ec2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2033,7 +2032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2527,7 +2526,7 @@ dependencies = [
  "bytes",
  "http 1.1.0",
  "opentelemetry",
- "reqwest 0.12.7",
+ "reqwest 0.12.5",
 ]
 
 [[package]]
@@ -2544,7 +2543,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.2",
- "reqwest 0.12.7",
+ "reqwest 0.12.5",
  "thiserror",
  "tokio",
  "tonic",
@@ -2752,9 +2751,9 @@ checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "polling"
-version = "3.7.3"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -2762,7 +2761,7 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2814,6 +2813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
 dependencies = [
  "bytes",
+ "chrono",
  "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]
@@ -3175,7 +3175,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
  "tower-service",
@@ -3184,14 +3184,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -3221,7 +3221,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration 0.6.0",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -3231,7 +3231,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "tracing",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "spin-compose"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,17 +3796,18 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "futures",
  "spin-locked-app",
  "thiserror",
 ]
 
 [[package]]
 name = "spin-factor-key-value"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "lru",
@@ -3816,6 +3817,7 @@ dependencies = [
  "spin-locked-app",
  "spin-resource-table",
  "spin-world",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -3823,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-llm"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3840,14 +3842,14 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-http"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "http 1.1.0",
  "http-body-util",
  "hyper 1.4.1",
  "ip_network",
- "reqwest 0.12.7",
+ "reqwest 0.12.5",
  "rustls 0.23.12",
  "spin-factor-outbound-networking",
  "spin-factors",
@@ -3863,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mqtt"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "rumqttc",
@@ -3878,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mysql"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -3894,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3919,9 +3921,10 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-pg"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
+ "chrono",
  "native-tls",
  "postgres-native-tls",
  "spin-core",
@@ -3936,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-redis"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "redis 0.25.4",
@@ -3950,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-sqlite"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "async-trait",
  "spin-factors",
@@ -3963,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-variables"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "spin-expressions",
  "spin-factors",
@@ -3973,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-wasi"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3986,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3999,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-derive"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4008,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-executor"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "spin-app",
@@ -4018,9 +4021,10 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
+ "azure_core",
  "azure_data_cosmos",
  "azure_identity",
  "futures",
@@ -4031,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "redis 0.27.2",
@@ -4044,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-spin"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -4057,10 +4061,10 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
- "reqwest 0.12.7",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "spin-telemetry",
@@ -4070,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4082,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4098,11 +4102,11 @@ dependencies = [
 
 [[package]]
 name = "spin-resource-table"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 
 [[package]]
 name = "spin-runtime-config"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "spin-common",
@@ -4129,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "spin-runtime-factors"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4155,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4166,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "serde",
  "spin-factor-sqlite",
@@ -4178,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4190,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4202,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -4218,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4244,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "azure_core",
  "azure_identity",
@@ -4262,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "async-trait",
  "wasmtime",
@@ -4352,9 +4356,6 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -4376,18 +4377,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -4395,16 +4385,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4456,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "2.8.0-pre0"
+version = "3.1.0-pre0"
 dependencies = [
  "termcolor",
 ]
@@ -5272,9 +5252,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01f9cb9636ed42a7ec5a09d785c0643590199dc7372dc22c7e2ba7a31a97d4"
+checksum = "f38dbf42dc56a6fe41ccd77211ea8ec90855de05e52cd00df5a0a3bca87d6147"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -5328,18 +5308,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5b20797419d6baf2296db2354f864e8bb3447cacca9d151ce7700ae08b4460"
+checksum = "30e0c7f9983c2d60109a939d9ab0e0df301901085c3608e1c22c27c98390a027"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272d5939e989c5b54e3fa83ef420e4a6dba3995c3065626066428b2f73ad1e06"
+checksum = "e52eaa50abc14a9a2550d05e99e5e72d43ba75ea99cac1a440b61f1b9b87cd11"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5357,9 +5337,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26593c4b18c76ca3c3fbdd813d6692256537b639b851d8a6fe827e3d6966fc01"
+checksum = "0929ffffaca32dd8770b56848c94056036963ca05de25fb47cac644e20262168"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5372,15 +5352,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ed562fbb0cbed20a56c369c8de146c1de06a48c19e26ed9aa45f073514ee60"
+checksum = "fdc29d2b56629d66d2fd791d1b46471d0016e0d684ed2dc299e870d127082268"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f389b789cbcb53a8499131182135dea21d7d97ad77e7fb66830f69479ef0e68c"
+checksum = "f8c8af1197703f4de556a274384adf5db36a146f9892bc9607bad16881e75c80"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5403,9 +5383,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b72debe8899f19bedf66f7071310f06ef62de943a1369ba9b373613e77dd3d"
+checksum = "3f1b5af7bac868c5bce3b78a366a10677caacf6e6467c156301297e36ed31f3e"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -5430,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b8d4d504266ee598204f9e69cea8714499cc7c5aeddaa9b3f76aaace8b0680"
+checksum = "665ccc1bb0f28496e6fa02e94c575ee9ad6e3202c7df8591e5dda78106d5aa4a"
 dependencies = [
  "anyhow",
  "cc",
@@ -5445,9 +5425,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ed7f0bbb9da3252c252b05fcd5fd42672db161e6276aa96e92059500247d8c"
+checksum = "106731c6ebe1d551362ee8c876d450bdc2d517988b20eb3653dc4837b1949437"
 dependencies = [
  "object 0.36.0",
  "once_cell",
@@ -5457,9 +5437,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930bc1325bc0448be6a11754156d770f56f6c3a61f440e9567f36cd2ea3065"
+checksum = "5d7314e32c624f645ad7d6b9fc3ac89eb7d2b9aa06695d6445cec087958ec27d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5469,15 +5449,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055a181b8d03998511294faea14798df436503f14d7fd20edcf7370ec583e80a"
+checksum = "f75cba1a8cc327839f493cfc3036c9de3d077d59ab76296bc710ee5f95be5391"
 
 [[package]]
 name = "wasmtime-types"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8340d976673ac3fdacac781f2afdc4933920c1adc738c3409e825dab3955399"
+checksum = "c6d83a7816947a4974e2380c311eacb1db009b8bad86081dc726b705603c93c7"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -5489,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b0c1f76891f778db9602ee3fbb4eb7e9a3f511847d1fb1b69eddbcea28303c"
+checksum = "6879a8e168aef3fe07335343b7fbede12fa494215e83322e173d4018e124a846"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5554,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a702ff5eff3b37c11453ec8b54ec444bb9f2c689c7a7af382766c52df86b1e9b"
+checksum = "6baca2a919a288df653246069868b4de80f07e9679a8ef9b78ad79fc658ffd12"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5571,9 +5551,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fca2cbb5bb390f65d4434c19bf8d9873dfc60f10802918ebcd6f819a38d703"
+checksum = "3f571f63ac1d532e986eb3973bbef3a45e4ae83de521a8d573b0fe0594dc9608"
 dependencies = [
  "anyhow",
  "heck",
@@ -5733,9 +5713,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.23.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d716f7c87db8ea79f1dc69f7344354b6256451bccca422ac4c3e0d607d144532"
+checksum = "01cd1dc56c5a45d509ff06e7ca8817eaa9ec3240096f07e71915d5d528658e8a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5754,37 +5734,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -5802,16 +5752,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -5831,18 +5772,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -5853,9 +5793,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5865,9 +5805,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5877,15 +5817,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5895,9 +5829,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5907,9 +5841,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5919,9 +5853,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5931,9 +5865,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -5949,6 +5883,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/examples/spin-wagi-http/http-rust/Cargo.lock
+++ b/examples/spin-wagi-http/http-rust/Cargo.lock
@@ -152,7 +152,6 @@ name = "goodbyerust"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes",
  "http",
  "spin-sdk",
 ]


### PR DESCRIPTION
With the 3.0.0 tag cut, bump to 3.1.0-pre0 on main to indicate the next anticipated release