### PR TITLE
CI now needs wasm32-wasip1

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -95,7 +95,7 @@ runs:
         rustup default ${{ inputs.rust-version }}
 
     - name: "Install Wasm Rust target"
-      run: rustup target add wasm32-wasi && rustup target add wasm32-wasip1 &&rustup target add wasm32-unknown-unknown
+      run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown
       if: ${{ inputs.rust-wasm == 'true' }}
       shell: bash
 

--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -95,7 +95,7 @@ runs:
         rustup default ${{ inputs.rust-version }}
 
     - name: "Install Wasm Rust target"
-      run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+      run: rustup target add wasm32-wasi && rustup target add wasm32-wasip1 &&rustup target add wasm32-unknown-unknown
       if: ${{ inputs.rust-wasm == 'true' }}
       shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
 
       # Install all the toolchain dependencies
       - name: Install Rust wasm target
-        run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+        run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown
       - uses: goto-bus-stop/setup-zig@v2
       - uses: actions/setup-go@v4
         with:
@@ -281,7 +281,7 @@ jobs:
         run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
+        run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
+        run: rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-wasip1 --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-wasip1 --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
+        run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
PR checks for https://github.com/fermyon/spin/pull/2927 didn't catch this.  But it's now needed for smoke testing the templates.
