### PR TITLE
Relax wasi 0.2 constraint

### DIFF
--- a/crates/http/src/trigger.rs
+++ b/crates/http/src/trigger.rs
@@ -27,10 +27,8 @@ pub enum HandlerType {
 pub const WASI_HTTP_EXPORT_2023_10_18: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-10-18";
 /// The `incoming-handler` export for `wasi:http` version rc-2023-11-10
 pub const WASI_HTTP_EXPORT_2023_11_10: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-11-10";
-/// The `incoming-handler` export for `wasi:http` version 0.2.0
-pub const WASI_HTTP_EXPORT_0_2_0: &str = "wasi:http/incoming-handler@0.2.0";
-/// The `incoming-handler` export for `wasi:http` version 0.2.1
-pub const WASI_HTTP_EXPORT_0_2_1: &str = "wasi:http/incoming-handler@0.2.1";
+/// The `incoming-handler` export prefix for all `wasi:http` 0.2 versions
+pub const WASI_HTTP_EXPORT_0_2_PREFIX: &str = "wasi:http/incoming-handler@0.2";
 /// The `inbound-http` export for `fermyon:spin`
 pub const SPIN_HTTP_EXPORT: &str = "fermyon:spin/inbound-http";
 
@@ -58,8 +56,8 @@ impl HandlerType {
             match name {
                 WASI_HTTP_EXPORT_2023_10_18 => set(HandlerType::Wasi2023_10_18)?,
                 WASI_HTTP_EXPORT_2023_11_10 => set(HandlerType::Wasi2023_11_10)?,
-                WASI_HTTP_EXPORT_0_2_0 | WASI_HTTP_EXPORT_0_2_1 => set(HandlerType::Wasi0_2)?,
                 SPIN_HTTP_EXPORT => set(HandlerType::Spin)?,
+                name if name.starts_with(WASI_HTTP_EXPORT_0_2_PREFIX) => set(HandlerType::Wasi0_2)?,
                 _ => {}
             }
         }
@@ -69,8 +67,7 @@ impl HandlerType {
                 "Expected component to export one of \
                 `{WASI_HTTP_EXPORT_2023_10_18}`, \
                 `{WASI_HTTP_EXPORT_2023_11_10}`, \
-                `{WASI_HTTP_EXPORT_0_2_0}`, \
-                `{WASI_HTTP_EXPORT_0_2_1}`, \
+                `{WASI_HTTP_EXPORT_0_2_PREFIX}.*`, \
                  or `{SPIN_HTTP_EXPORT}` but it exported none of those"
             )
         })


### PR DESCRIPTION
* Addresses #2928 by relaxing wasi constraint
* Tested with a Leptos Spin app, verified that this allows using `wasi` crate version 0.13 without locking patch version