### PR TITLE
ref(*): replace wasm32-wasi with wasm32-wasip1

### DIFF
--- a/.devcontainer/bootstrap.sh
+++ b/.devcontainer/bootstrap.sh
@@ -2,4 +2,4 @@
 rustup update stable && rustup default stable && rustup component add clippy rustfmt
 
 # Installs wasm32 compiler targets
-rustup target add wasm32-wasi wasm32-unknown-unknown
+rustup target add wasm32-wasip1 wasm32-unknown-unknown

--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -95,7 +95,7 @@ runs:
         rustup default ${{ inputs.rust-version }}
 
     - name: "Install Wasm Rust target"
-      run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown
+      run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
       if: ${{ inputs.rust-wasm == 'true' }}
       shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
 
       # Install all the toolchain dependencies
       - name: Install Rust wasm target
-        run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown
+        run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
       - uses: goto-bus-stop/setup-zig@v2
       - uses: actions/setup-go@v4
         with:
@@ -281,7 +281,7 @@ jobs:
         run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
+        run: rustup target add wasm32-wasip1 wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi wasm32-wasip1 wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
+        run: rustup target add wasm32-wasip1 wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ and then follow the
 language guides, and the [guide on writing Spin applications](https://developer.fermyon.com/spin/configuration/).
 
 ## Usage
-Below is an example of using the `spin` CLI to create a new Spin application.  To run the example you will need to install the `wasm32-wasi` target for Rust.
+Below is an example of using the `spin` CLI to create a new Spin application.  To run the example you will need to install the `wasm32-wasip1` target for Rust.
 
 ```bash
-$ rustup target add wasm32-wasi
+$ rustup target add wasm32-wasip1
 ```
 
 First, run the `spin new` command to create a Spin application from a template.
@@ -55,7 +55,7 @@ Running the `spin new` command created a `hello-rust` directory with all the nec
 ```bash
 # Compile to Wasm by executing the `build` command.
 $ spin build
-Executing the build command for component hello-rust: cargo build --target wasm32-wasi --release
+Executing the build command for component hello-rust: cargo build --target wasm32-wasip1 --release
     Finished release [optimized] target(s) in 0.03s
 Successfully ran the build command for the Spin components.
 

--- a/build.rs
+++ b/build.rs
@@ -58,8 +58,8 @@ fn main() {
 
         println!(
             r#"
-error: the `wasm32-wasi` target is not installed
-    = help: consider downloading the target with `rustup{} target add wasm32-wasi`"#,
+error: the `wasm32-wasip1` target is not installed
+    = help: consider downloading the target with `rustup{} target add wasm32-wasip1`"#,
             toolchain_override
         );
         process::exit(1);
@@ -75,7 +75,7 @@ error: the `wasm32-wasi` target is not installed
 fn build_wasm_test_program(name: &'static str, root: &'static str) {
     build_target_dep(root, Path::new("target/test-programs").join(name))
         .release()
-        .target("wasm32-wasi")
+        .target("wasm32-wasip1")
         .build();
     println!("cargo:rerun-if-changed={root}/Cargo.toml");
     println!("cargo:rerun-if-changed={root}/Cargo.lock");
@@ -85,7 +85,7 @@ fn build_wasm_test_program(name: &'static str, root: &'static str) {
 fn has_wasm32_wasi_target() -> bool {
     // Using rustc here for systems that don't have rustup
     let output = run(
-        vec!["rustc", "--print=target-libdir", "--target=wasm32-wasi"],
+        vec!["rustc", "--print=target-libdir", "--target=wasm32-wasip1"],
         None,
         None,
     );
@@ -110,7 +110,7 @@ fn cargo_build(dir: &str) {
             "cargo",
             "build",
             "--target",
-            "wasm32-wasi",
+            "wasm32-wasip1",
             "--release",
             // Ensure that even if `CARGO_TARGET_DIR` is set
             // that we're still building into the right dir.

--- a/crates/componentize/README.md
+++ b/crates/componentize/README.md
@@ -12,7 +12,7 @@ the original module exported.
 This crate requires a [Rust](https://rustup.rs/) installation v1.68 or later and a couple of Wasm targets:
 
 ```shell
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/crates/componentize/src/lib.rs
+++ b/crates/componentize/src/lib.rs
@@ -413,7 +413,7 @@ mod tests {
         run_spin(
             &fs::read(concat!(
                 env!("OUT_DIR"),
-                "/wasm32-wasi/release/rust_case_02.wasm"
+                "/wasm32-wasip1/release/rust_case_02.wasm"
             ))
             .await?,
         )
@@ -426,7 +426,7 @@ mod tests {
         run_spin(
             &fs::read(concat!(
                 env!("OUT_DIR"),
-                "/wasm32-wasi/release/rust_case_08.wasm"
+                "/wasm32-wasip1/release/rust_case_08.wasm"
             ))
             .await?,
         )
@@ -458,7 +458,7 @@ mod tests {
         run_command(
             &fs::read(concat!(
                 env!("OUT_DIR"),
-                "/wasm32-wasi/release/rust-command.wasm"
+                "/wasm32-wasip1/release/rust-command.wasm"
             ))
             .await?,
         )
@@ -471,7 +471,7 @@ mod tests {
         cmd.arg("build")
             .current_dir(format!("tests/{name}"))
             .arg("--release")
-            .arg("--target=wasm32-wasi")
+            .arg("--target=wasm32-wasip1")
             .env("CARGO_TARGET_DIR", out_dir);
 
         let status = cmd.status().unwrap();

--- a/crates/componentize/tests/rust-case-0.2/Makefile
+++ b/crates/componentize/tests/rust-case-0.2/Makefile
@@ -1,5 +1,5 @@
-spin-abi-conformance.wasm: target/wasm32-wasi/release/spin-rust.wasm
+spin-abi-conformance.wasm: target/wasm32-wasip1/release/spin-rust.wasm
 	cp $< $@
 
-target/wasm32-wasi/release/spin-rust.wasm: src/main.rs Cargo.toml
-	cargo build --target wasm32-wasi --release
+target/wasm32-wasip1/release/spin-rust.wasm: src/main.rs Cargo.toml
+	cargo build --target wasm32-wasip1 --release

--- a/crates/core/tests/core-wasi-test/.cargo/config.toml
+++ b/crates/core/tests/core-wasi-test/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/crates/doctor/src/rustlang/target.rs
+++ b/crates/doctor/src/rustlang/target.rs
@@ -37,8 +37,8 @@ async fn diagnose_rust_wasi_target() -> Result<Vec<TargetDiagnosis>> {
     // - if rustup is not present, check if cargo is present
     //   - if not, return RustNotInstalled
     //   - if so, warn but return empty list (Rust is installed but not via rustup, so we can't perform a diagnosis - bit of an edge case this one, and the user probably knows what they're doing...?)
-    // - if rustup is present but the list does not contain wasm32-wasi, return WasmTargetNotInstalled
-    // - if the list does contain wasm32-wasi, return an empty list
+    // - if rustup is present but the list does not contain wasm32-wasip1, return WasmTargetNotInstalled
+    // - if the list does contain wasm32-wasip1, return an empty list
     // NOTE: this does not currently check against the Rust SDK MSRV - that could
     // be a future enhancement or separate diagnosis, but at least the Rust compiler
     // should give a clear error for that!
@@ -49,7 +49,7 @@ async fn diagnose_rust_wasi_target() -> Result<Vec<TargetDiagnosis>> {
         RustupStatus::RustupNotInstalled => match get_cargo_status().await? {
             CargoStatus::Installed => {
                 terminal::warn!(
-                    "Spin Doctor can't determine if the Rust wasm32-wasi target is installed."
+                    "Spin Doctor can't determine if the Rust wasm32-wasip1 target is installed."
                 );
                 vec![]
             }
@@ -81,7 +81,7 @@ async fn get_rustup_target_status() -> Result<RustupStatus> {
         }
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            if stdout.lines().any(|line| line == "wasm32-wasi") {
+            if stdout.lines().any(|line| line == "wasm32-wasip1") {
                 RustupStatus::AllInstalled
             } else {
                 RustupStatus::WasiNotInstalled
@@ -119,7 +119,7 @@ async fn get_cargo_status() -> Result<CargoStatus> {
 pub enum TargetDiagnosis {
     /// Rust is not installed: neither cargo nor rustup is present
     RustNotInstalled,
-    /// The Rust wasm32-wasi target is not installed: rustup is present but the target isn't
+    /// The Rust wasm32-wasip1 target is not installed: rustup is present but the target isn't
     WasmTargetNotInstalled,
 }
 
@@ -128,7 +128,7 @@ impl Diagnosis for TargetDiagnosis {
         match self {
             Self::RustNotInstalled => "The Rust compiler isn't installed".into(),
             Self::WasmTargetNotInstalled => {
-                "The required Rust target 'wasm32-wasi' isn't installed".into()
+                "The required Rust target 'wasm32-wasip1' isn't installed".into()
             }
         }
     }
@@ -142,16 +142,16 @@ impl Diagnosis for TargetDiagnosis {
 impl Treatment for TargetDiagnosis {
     fn summary(&self) -> String {
         match self {
-            Self::RustNotInstalled => "Install the Rust compiler and the wasm32-wasi target",
-            Self::WasmTargetNotInstalled => "Install the Rust wasm32-wasi target",
+            Self::RustNotInstalled => "Install the Rust compiler and the wasm32-wasip1 target",
+            Self::WasmTargetNotInstalled => "Install the Rust wasm32-wasip1 target",
         }
         .into()
     }
 
     async fn dry_run(&self, _patient: &PatientApp) -> Result<String> {
         let message = match self {
-            Self::RustNotInstalled => "Download and run the Rust installer from https://rustup.rs, with the `--target wasm32-wasi` option",
-            Self::WasmTargetNotInstalled => "Run the following command:\n    `rustup target add wasm32-wasi`",
+            Self::RustNotInstalled => "Download and run the Rust installer from https://rustup.rs, with the `--target wasm32-wasip1` option",
+            Self::WasmTargetNotInstalled => "Run the following command:\n    `rustup target add wasm32-wasip1`",
         };
         Ok(message.into())
     }
@@ -184,7 +184,7 @@ async fn run_rust_installer() -> Result<std::process::ExitStatus> {
     let script = resp.bytes().await?;
 
     let mut cmd = std::process::Command::new("sh");
-    cmd.args(["-s", "--", "--target", "wasm32-wasi"]);
+    cmd.args(["-s", "--", "--target", "wasm32-wasip1"]);
     cmd.stdin(std::process::Stdio::piped());
     let mut shell = cmd.spawn()?;
     let mut stdin = shell.stdin.take().unwrap();
@@ -213,14 +213,14 @@ async fn run_rust_installer() -> Result<std::process::ExitStatus> {
     std::fs::write(&installer_path, &installer_bin)?;
 
     let mut cmd = std::process::Command::new(installer_path);
-    cmd.args(["--target", "wasm32-wasi"]);
+    cmd.args(["--target", "wasm32-wasip1"]);
     let status = cmd.status()?;
     Ok(status)
 }
 
 fn install_wasi_target() -> Result<()> {
     let mut cmd = std::process::Command::new("rustup");
-    cmd.args(["target", "add", "wasm32-wasi"]);
+    cmd.args(["target", "add", "wasm32-wasip1"]);
     let status = cmd.status()?;
     anyhow::ensure!(
         status.success(),

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -876,8 +876,8 @@ mod tests {
         assert!(cargo2.contains("name = \"hello-2\""));
 
         let spin_toml = tokio::fs::read_to_string(&spin_toml_path).await.unwrap();
-        assert!(spin_toml.contains("source = \"hello/target/wasm32-wasi/release/hello.wasm\""));
-        assert!(spin_toml.contains("source = \"encore/target/wasm32-wasi/release/hello_2.wasm\""));
+        assert!(spin_toml.contains("source = \"hello/target/wasm32-wasip1/release/hello.wasm\""));
+        assert!(spin_toml.contains("source = \"encore/target/wasm32-wasip1/release/hello_2.wasm\""));
     }
 
     #[tokio::test]

--- a/examples/http-rust/.cargo/config.toml
+++ b/examples/http-rust/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/http-rust/spin.toml
+++ b/examples/http-rust/spin.toml
@@ -11,8 +11,8 @@ route = "/hello"
 component = "hello"
 
 [component.hello]
-source = "target/wasm32-wasi/release/http_rust.wasm"
+source = "target/wasm32-wasip1/release/http_rust.wasm"
 description = "A simple component that returns hello."
 [component.hello.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -165,6 +165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
 name = "async-process"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +268,329 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "aws-config"
+version = "1.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8efdda6a491bb4640d35b99b0a4b93f75ce7d6e3a1937c3e902d3cb23d0a179c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ada54e5f26ac246dc79727def52f7f8ed38915cb47781e2a72213957dc3a7d5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
 
 [[package]]
 name = "axum"
@@ -423,6 +752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +841,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1171,6 +1520,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,12 +1957,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1747,7 +2122,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.30",
+ "log",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1763,7 +2140,7 @@ dependencies = [
  "hyper 0.14.30",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2032,7 +2409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2504,9 +2881,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803801d3d3b71cd026851a53f974ea03df3d179cb758b260136a6c9e22e196af"
+checksum = "0f3cebff57f7dbd1255b44d8bddc2cebeb0ea677dbaa2e25a3070a91b318f660"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2517,10 +2894,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.25.0"
+name = "opentelemetry-appender-tracing"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8c2b76e5f7848a289aa9666dbe56b16f8a22a4c5246ef37a14941818d2913"
+checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2531,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596b1719b3cab83addb20bcbffdf21575279d9436d9ccccfe651a3bf0ab5ab06"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -2547,13 +2936,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c43620e8f93359eb7e627a3b16ee92d8585774986f24f2ab010817426c5ce61"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2563,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da0d6b47a3dbc6e9c9e36a0520e25cf943e046843818faaa3f87365a548c82"
+checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -2580,6 +2970,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -2593,6 +2984,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "overload"
@@ -3135,6 +3532,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,7 +3662,7 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
  "rustls-webpki 0.102.7",
  "thiserror",
@@ -3397,6 +3800,18 @@ dependencies = [
  "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4020,6 +4435,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-key-value-aws"
+version = "3.1.0-pre0"
+dependencies = [
+ "anyhow",
+ "async-once-cell",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "serde",
+ "spin-core",
+ "spin-factor-key-value",
+]
+
+[[package]]
 name = "spin-key-value-azure"
 version = "3.1.0-pre0"
 dependencies = [
@@ -4122,6 +4551,7 @@ dependencies = [
  "spin-factor-variables",
  "spin-factor-wasi",
  "spin-factors",
+ "spin-key-value-aws",
  "spin-key-value-azure",
  "spin-key-value-redis",
  "spin-key-value-spin",
@@ -4212,6 +4642,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "terminal",
@@ -4636,9 +5067,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4695,9 +5126,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4790,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eabc56d23707ad55ba2a0750fc24767125d5a0f51993ba41ad2c441cc7b8dea"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -5002,6 +5433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "wac-graph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5186,17 +5623,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-common"
-version = "0.4.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7a687d110f68a65227a644c7040c7720220e8cb0bb8c803e2b5dcb7fd72468"
+checksum = "8ca6fb1d9c267809e4e9db5cfea0907dd818bf88b682b3ef609fa104b68c305f"
 dependencies = [
  "anyhow",
- "dirs 5.0.1",
+ "bytes",
+ "etcetera",
+ "futures-util",
  "http 1.1.0",
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
+ "tokio",
  "toml",
  "tracing",
 ]
@@ -5956,6 +6397,12 @@ dependencies = [
  "thiserror",
  "wast 35.0.2",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"

--- a/examples/spin-timer/app-example/spin.toml
+++ b/examples/spin-timer/app-example/spin.toml
@@ -17,15 +17,15 @@ interval_secs = 10
 component = "five"
 
 [component.three]
-source = "target/wasm32-wasi/release/timer_app_example.wasm"
+source = "target/wasm32-wasip1/release/timer_app_example.wasm"
 [component.three.variables]
 message = "Fizz"
 [component.three.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 
 [component.five]
-source = "target/wasm32-wasi/release/timer_app_example.wasm"
+source = "target/wasm32-wasip1/release/timer_app_example.wasm"
 [component.five.variables]
 message = "Buzz"
 [component.five.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/spin-wagi-http/http-rust/.cargo/config.toml
+++ b/examples/spin-wagi-http/http-rust/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/spin-wagi-http/spin.toml
+++ b/examples/spin-wagi-http/spin.toml
@@ -22,6 +22,6 @@ source = "wagi-http-cpp/main.wasm"
 command = "make build -C wagi-http-cpp"
 
 [component.goodbye]
-source = "http-rust/target/wasm32-wasi/release/goodbyerust.wasm"
+source = "http-rust/target/wasm32-wasip1/release/goodbyerust.wasm"
 [component.goodbye.build]
-command = "cargo build --target wasm32-wasi --release --manifest-path http-rust/Cargo.toml"
+command = "cargo build --target wasm32-wasip1 --release --manifest-path http-rust/Cargo.toml"

--- a/examples/spin-wagi-http/wagi-http-cpp/Makefile
+++ b/examples/spin-wagi-http/wagi-http-cpp/Makefile
@@ -2,4 +2,4 @@
 WASI_CC ?= /opt/wasi-sdk/bin/clang++
 
 build:
-	$(WASI_CC) --target=wasm32-wasi main.cpp -o main.wasm
+	$(WASI_CC) --target=wasm32-wasip1 main.cpp -o main.wasm

--- a/examples/vault-variable-test/spin.toml
+++ b/examples/vault-variable-test/spin.toml
@@ -14,12 +14,12 @@ component = "vault-variable-test"
 secret = { required = true }
 
 [component.vault-variable-test]
-source = "target/wasm32-wasi/release/vault_variable_test.wasm"
+source = "target/wasm32-wasip1/release/vault_variable_test.wasm"
 allowed_outbound_hosts = []
 
 [component.vault-variable-test.variables]
 token = "{{ secret }}"
 
 [component.vault-variable-test.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/examples/wagi-http-rust/.cargo/config.toml
+++ b/examples/wagi-http-rust/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/wagi-http-rust/spin.toml
+++ b/examples/wagi-http-rust/spin.toml
@@ -12,6 +12,6 @@ component = "env"
 executor = { type = "wagi" }
 
 [component.env]
-source = "target/wasm32-wasi/release/wagihelloworld.wasm"
+source = "target/wasm32-wasip1/release/wagihelloworld.wasm"
 [component.env.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         };
         rustTarget = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" "rust-analyzer" ];
-          targets = [ "wasm32-wasi" "wasm32-unknown-unknown" ];
+          targets = [ "wasm32-wasip1" "wasm32-unknown-unknown" ];
         };
       in
       with pkgs;

--- a/templates/http-c/content/spin.toml
+++ b/templates/http-c/content/spin.toml
@@ -15,5 +15,5 @@ executor = { type = "wagi" }
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "zig build-exe -O ReleaseSmall -target wasm32-wasi main.c -lc"
+command = "zig build-exe -O ReleaseSmall -target wasm32-wasip1 main.c -lc"
 watch = ["**/*.c"]

--- a/templates/http-rust/metadata/snippets/component.txt
+++ b/templates/http-rust/metadata/snippets/component.txt
@@ -3,9 +3,9 @@ route = "{{http-path}}"
 component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
-source = "{{ output-path }}/target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
+source = "{{ output-path }}/target/wasm32-wasip1/release/{{project-name | snake_case}}.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "{{ output-path }}"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/http-zig/content/spin.toml
+++ b/templates/http-zig/content/spin.toml
@@ -15,5 +15,5 @@ executor = { type = "wagi" }
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "zig build-exe -O ReleaseSmall -target wasm32-wasi src/main.zig"
+command = "zig build-exe -O ReleaseSmall -target wasm32-wasip1 src/main.zig"
 watch = ["src/**/*.zig"]

--- a/templates/redis-rust/metadata/snippets/component.txt
+++ b/templates/redis-rust/metadata/snippets/component.txt
@@ -3,9 +3,9 @@ channel = "{{redis-channel}}"
 component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
-source = "{{ output-path }}/target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
+source = "{{ output-path }}/target/wasm32-wasip1/release/{{project-name | snake_case}}.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "{{ output-path }}"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/tests/test-components/build.rs
+++ b/tests/test-components/build.rs
@@ -39,7 +39,7 @@ fn main() {
         cargo
             .current_dir(crate_path)
             .arg("build")
-            .arg("--target=wasm32-wasi")
+            .arg("--target=wasm32-wasip1")
             .env("RUSTFLAGS", rustflags())
             .env("CARGO_TARGET_DIR", &out_dir);
         eprintln!("running: {cargo:?}");
@@ -49,7 +49,7 @@ fn main() {
         let package_name = manifest.package.expect("manifest has no package").name;
         let binary_name = package_name.replace(['-', '.'], "_");
         let mut wasm_path = out_dir
-            .join("wasm32-wasi")
+            .join("wasm32-wasip1")
             .join("debug")
             .join(format!("{binary_name}.wasm"));
 

--- a/tests/testcases/legacy-apps-test/README.md
+++ b/tests/testcases/legacy-apps-test/README.md
@@ -35,7 +35,7 @@ cp main.wasm longevity-go.wasm
 spin new http-rust http-rust-test
 cd http-rust-test
 spin build
-cp target/wasm32-wasi/release/http_rust_test.wasm longevity-rust.wasm
+cp target/wasm32-wasip1/release/http_rust_test.wasm longevity-rust.wasm
 ```
 
 ```

--- a/tests/testcases/redis-smoke-test/spin.toml
+++ b/tests/testcases/redis-smoke-test/spin.toml
@@ -11,4 +11,4 @@ source = "%{source=redis-smoke-test}"
 [component.trigger]
 channel = "my-channel"
 [component.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/tests/testcases/wasi-http-streaming/spin.toml
+++ b/tests/testcases/wasi-http-streaming/spin.toml
@@ -14,5 +14,5 @@ component = "wasi-http-async"
 source = "%{source=integration-wasi-http-streaming}"
 allowed_outbound_hosts = ["http://*:*", "https://*:*"]
 [component.wasi-http-async.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]


### PR DESCRIPTION
- Replaces the remaining uses of the wasm32-wasi target with wasm32-wasip1 per https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html#renaming-wasm32-wasi-to-wasm32-wasip1
  - This includes corresponding 'spin doctor' logic, build.rs, examples and other updates