### PR TITLE
Fix C and Zig templates

### DIFF
--- a/templates/http-c/content/spin.toml
+++ b/templates/http-c/content/spin.toml
@@ -15,5 +15,5 @@ executor = { type = "wagi" }
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "zig build-exe -O ReleaseSmall -target wasm32-wasip1 main.c -lc"
+command = "zig build-exe -O ReleaseSmall -target wasm32-wasi main.c -lc"
 watch = ["**/*.c"]

--- a/templates/http-zig/content/spin.toml
+++ b/templates/http-zig/content/spin.toml
@@ -15,5 +15,5 @@ executor = { type = "wagi" }
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "zig build-exe -O ReleaseSmall -target wasm32-wasip1 src/main.zig"
+command = "zig build-exe -O ReleaseSmall -target wasm32-wasi src/main.zig"
 watch = ["src/**/*.zig"]


### PR DESCRIPTION
We uh apparently got a bit uh overzealous in #2948.

Unfortunately, the integration tests tend not to catch template errors; I think they are testing for if the runtime breaks the templates in main, rather than testing the templates in the PR?
