### PR TITLE
Azure Cosmos multiple stores per container

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -141,7 +141,7 @@ impl App {
     pub fn triggers_with_type<'a>(
         &'a self,
         trigger_type: &'a str,
-    ) -> impl Iterator<Item = AppTrigger> {
+    ) -> impl Iterator<Item = AppTrigger<'a>> {
         self.triggers()
             .filter(move |trigger| trigger.locked.trigger_type == trigger_type)
     }

--- a/crates/key-value-azure/src/lib.rs
+++ b/crates/key-value-azure/src/lib.rs
@@ -2,7 +2,8 @@ mod store;
 
 use serde::Deserialize;
 use spin_factor_key_value::runtime_config::spin::MakeKeyValueStore;
-use store::{
+
+pub use store::{
     KeyValueAzureCosmos, KeyValueAzureCosmosAuthOptions, KeyValueAzureCosmosRuntimeConfigOptions,
 };
 

--- a/crates/key-value-azure/src/lib.rs
+++ b/crates/key-value-azure/src/lib.rs
@@ -8,12 +8,15 @@ use store::{
 
 /// A key-value store that uses Azure Cosmos as the backend.
 pub struct AzureKeyValueStore {
-    app_id: String,
+    app_id: Option<String>,
 }
 
 impl AzureKeyValueStore {
     /// Creates a new `AzureKeyValueStore`.
-    pub fn new(app_id: String) -> Self {
+    ///
+    /// When `app_id` is provided, the store will a partition key of `$app_id/$store_name`,
+    /// otherwise the partition key will be `id`.
+    pub fn new(app_id: Option<String>) -> Self {
         Self { app_id }
     }
 }

--- a/crates/key-value-azure/src/lib.rs
+++ b/crates/key-value-azure/src/lib.rs
@@ -7,15 +7,14 @@ use store::{
 };
 
 /// A key-value store that uses Azure Cosmos as the backend.
-#[derive(Default)]
 pub struct AzureKeyValueStore {
-    _priv: (),
+    app_id: String,
 }
 
 impl AzureKeyValueStore {
     /// Creates a new `AzureKeyValueStore`.
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(app_id: String) -> Self {
+        Self { app_id }
     }
 }
 
@@ -55,6 +54,7 @@ impl MakeKeyValueStore for AzureKeyValueStore {
             runtime_config.database,
             runtime_config.container,
             auth_options,
+            self.app_id.clone(),
         )
     }
 }

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -403,9 +403,7 @@ pub fn key_value_config_resolver(
         .register_store_type(spin_key_value_redis::RedisKeyValueStore::new())
         .unwrap();
     key_value
-        .register_store_type(spin_key_value_azure::AzureKeyValueStore::new(
-            "MY_APP".to_owned(),
-        ))
+        .register_store_type(spin_key_value_azure::AzureKeyValueStore::new(None))
         .unwrap();
     key_value
         .register_store_type(spin_key_value_aws::AwsDynamoKeyValueStore::new())

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -403,7 +403,9 @@ pub fn key_value_config_resolver(
         .register_store_type(spin_key_value_redis::RedisKeyValueStore::new())
         .unwrap();
     key_value
-        .register_store_type(spin_key_value_azure::AzureKeyValueStore::new())
+        .register_store_type(spin_key_value_azure::AzureKeyValueStore::new(
+            "MY_APP".to_owned(),
+        ))
         .unwrap();
     key_value
         .register_store_type(spin_key_value_aws::AwsDynamoKeyValueStore::new())


### PR DESCRIPTION
Fixes #2951 

This adds support in the Azure Cosmos key-value implementation for storing multiple key-value stores in a single Azure Cosmos container. 

**IMPORTANT**: This currently does not change the Spin CLI experience at all. Users of Spin CLI continue to have the 1 to 1 relationship between containers and key-value stores. This only allows Spin runtime embedders the ability to have many stores per containers. We can consider changing the default behavior for the Spin CLI in the future, but this might need to be at a major version change. 

For embedders who provide an `app_id` to the `KeyValueAzureCosmos`, stores will be created in the supplied container and each key/value pair will include a partition_key field in the form of "$app_id/$store_id".

cc @devigned 

