### PR TITLE
Install templates from remote tarball

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8355,7 +8355,9 @@ name = "spin-templates"
 version = "3.1.0-pre0"
 dependencies = [
  "anyhow",
+ "bytes",
  "dialoguer",
+ "flate2",
  "fs_extra",
  "heck 0.5.0",
  "indexmap 2.6.0",
@@ -8367,10 +8369,12 @@ dependencies = [
  "path-absolutize",
  "pathdiff",
  "regex",
+ "reqwest 0.12.9",
  "semver",
  "serde",
  "spin-common",
  "spin-manifest",
+ "tar",
  "tempfile",
  "tokio",
  "toml",

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -6,9 +6,11 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = { workspace = true }
 dialoguer = "0.11"
 fs_extra = "1"
 heck = "0.5"
+flate2 = "1"
 indexmap = { version = "2", features = ["serde"] }
 itertools = { workspace = true }
 lazy_static = "1"
@@ -18,10 +20,12 @@ liquid-derive = "0.26"
 path-absolutize = "3"
 pathdiff = "0.2"
 regex = { workspace = true }
+reqwest = { workspace = true }
 semver = "1"
 serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
+tar = "0.4"
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "process", "rt", "macros"] }
 toml = { workspace = true }

--- a/crates/templates/src/reader.rs
+++ b/crates/templates/src/reader.rs
@@ -118,6 +118,7 @@ pub(crate) fn parse_manifest_toml(text: impl AsRef<str>) -> anyhow::Result<RawTe
 pub(crate) enum RawInstalledFrom {
     Git { git: String },
     File { dir: String },
+    RemoteTar { url: String },
 }
 
 pub(crate) fn parse_installed_from(text: impl AsRef<str>) -> Option<RawInstalledFrom> {

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -37,6 +37,7 @@ pub struct Template {
 enum InstalledFrom {
     Git(String),
     Directory(String),
+    RemoteTar(String),
     Unknown,
 }
 
@@ -254,6 +255,7 @@ impl Template {
         match &self.installed_from {
             InstalledFrom::Git(repo) => repo,
             InstalledFrom::Directory(path) => path,
+            InstalledFrom::RemoteTar(url) => url,
             InstalledFrom::Unknown => "",
         }
     }
@@ -625,6 +627,7 @@ fn read_install_record(layout: &TemplateLayout) -> InstalledFrom {
     match installed_from_text.and_then(parse_installed_from) {
         Some(RawInstalledFrom::Git { git }) => InstalledFrom::Git(git),
         Some(RawInstalledFrom::File { dir }) => InstalledFrom::Directory(dir),
+        Some(RawInstalledFrom::RemoteTar { url }) => InstalledFrom::RemoteTar(url),
         None => InstalledFrom::Unknown,
     }
 }


### PR DESCRIPTION
Fixes #2955.

```
$ rm -rf ~/.local/share/spin/templates/
$ spin templates install --tar https://github.com/fermyon/spin/archive/refs/tags/v3.0.0.tar.gz
Copying remote template source
Installing template http-go...
Installing template redis-go...
Installing template http-grain...
Installing template http-empty...
Installing template redis-rust...
Installing template static-fileserver...
Installing template http-rust...
Installing template http-zig...
Installing template redirect...
Installing template http-c...
Installing template http-php...
Installed 11 template(s)

+------------------------------------------------------------------------+
| Name                Description                                        |
+========================================================================+
| http-c              HTTP request handler using C and the Zig toolchain |
| http-empty          HTTP application with no components                |
| http-go             HTTP request handler using (Tiny)Go                |
| http-grain          HTTP request handler using Grain                   |
| http-php            HTTP request handler using PHP                     |
| http-rust           HTTP request handler using Rust                    |
| http-zig            HTTP request handler using Zig                     |
| redirect            Redirects a HTTP route                             |
| redis-go            Redis message handler using (Tiny)Go               |
| redis-rust          Redis message handler using Rust                   |
| static-fileserver   Serves static files from an asset directory        |
+------------------------------------------------------------------------+
```