### PR TITLE
Statically link runtime into Windows binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,6 @@ rustflags = ["-C", "target-feature=+fp16", "-C", "target-feature=+crt-static", "
 
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+crt-static", "-C", "link-self-contained=yes"]
+
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Initially setting as draft to get some artifacts (or compile errors) which I can gaze at sternly through my quizzing glass.

Might fix #1504 if it works.

Note that this does not in itself make Rust-based plugins work; any plugins that wanted to run without vcruntime would need to tweak their own builds, which is not necessarily under Spin's control.  But we can share the results of this with e.g. SpinKube for their plugin.
