### PR TITLE
Fix: disable unwinding for musl builds

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -77,6 +77,11 @@ impl Default for Config {
         inner.async_support(true);
         inner.epoch_interruption(true);
         inner.wasm_component_model(true);
+        // If targeting musl, disable native unwind to address this issue:
+        // https://github.com/fermyon/spin/issues/2889
+        // TODO: remove this when wasmtime is updated to >= v27.0.0
+        #[cfg(all(target_os = "linux", target_env = "musl"))]
+        inner.native_unwind_info(false);
 
         if use_pooling_allocator_by_default() {
             // By default enable the pooling instance allocator in Wasmtime. This


### PR DESCRIPTION
This is a patch for https://github.com/fermyon/spin/issues/2889

Alternatively, Spin could bump to Wasmtime 27.0.0 but this is an alternate if we cannot bump Wasmtime before the next release