### PR TITLE
Work around breaking change in `cross`

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -8,7 +8,7 @@ inputs:
     type: bool
   rust-version:
     description: 'Rust version to setup'
-    default: '1.79'
+    default: '1.81'
     required: false
     type: string
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.79
+  RUST_VERSION: 1.81
 
 jobs:
   dependency-review:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  RUST_VERSION: 1.79
+  RUST_VERSION: 1.81
 
 jobs:
   build-and-sign:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 homepage = "https://developer.fermyon.com/spin"
 repository = "https://github.com/fermyon/spin"
-rust-version = "1.79"
+rust-version = "1.81"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -98,6 +98,7 @@ mod integration_tests {
 
     #[test]
     #[cfg(feature = "extern-dependencies-tests")]
+    #[allow(dependency_on_unit_never_type_fallback)]
     /// Test that basic redis trigger support works
     fn redis_smoke_test() -> anyhow::Result<()> {
         use anyhow::Context;

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -204,6 +204,7 @@ pub fn http_smoke_test_template_with_route(
 
 /// Run a smoke test for a `spin new` redis template
 #[cfg(feature = "extern-dependencies-tests")]
+#[allow(dependency_on_unit_never_type_fallback)]
 pub fn redis_smoke_test_template(
     template_name: &str,
     template_url: Option<&str>,


### PR DESCRIPTION
`cross` no longer works on Rust 1.79 so we need to move to 1.81.
