### PR TITLE
fix(.github): pin tailscale to 1.78.1 for deploy

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -100,6 +100,7 @@ jobs:
           oauth-client-id: ${{ secrets.TS_CI_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_CI_OAUTH_SECRET }}
           tags: tag:ci
+          version: 1.78.1
 
       - name: Deploy
         shell: bash


### PR DESCRIPTION
Explicitly sets the tailscale version to the [most recent version](https://github.com/tailscale/tailscale/releases/tag/v1.78.1) as of writing.

Otherwise, the most recent version of the action ([alas, not very recent](https://github.com/tailscale/github-action/releases/tag/v2)) uses a very old 1.42.0 version of tailscale.