### PR TITLE
Templates: add a Rust template for non-trigger components

### DIFF
--- a/templates/component-rust/content/.gitignore
+++ b/templates/component-rust/content/.gitignore
@@ -1,0 +1,2 @@
+target/
+.spin/

--- a/templates/component-rust/content/Cargo.toml.tmpl
+++ b/templates/component-rust/content/Cargo.toml.tmpl
@@ -1,0 +1,16 @@
+[package]
+name = "{{project-name | kebab_case}}"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+version = "0.1.0"
+rust-version = "1.78"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1"
+wit-bindgen = "0.36.0"
+
+[workspace]

--- a/templates/component-rust/content/component.wit
+++ b/templates/component-rust/content/component.wit
@@ -1,0 +1,9 @@
+package component:{{project-name | kebab_case}};
+
+interface {{project-name | kebab_case}} {
+  hello: func() -> string;
+}
+
+world component {
+  export {{project-name | kebab_case}};
+}

--- a/templates/component-rust/content/spin.toml
+++ b/templates/component-rust/content/spin.toml
@@ -1,0 +1,13 @@
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name | kebab_case}}"
+version = "0.1.0"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+
+[component.{{project-name | kebab_case}}]
+source = "target/wasm32-wasip2/release/{{project-name | snake_case}}.wasm"
+[component.{{project-name | kebab_case}}.build]
+command = "cargo build --target wasm32-wasip2 --release"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/component-rust/content/src/lib.rs
+++ b/templates/component-rust/content/src/lib.rs
@@ -1,0 +1,14 @@
+impl Guest for Exports {
+    fn hello() -> String {
+        "Hello from {{project-name | snake_case}}".to_string()
+    }
+}
+
+// Boilerplate below here
+use crate::exports::component::{{project-name | snake_case}}::{{project-name | snake_case}}::Guest;
+wit_bindgen::generate!({
+    world: "component",
+    path: "component.wit",
+});
+struct Exports;
+export!(Exports);

--- a/templates/component-rust/metadata/snippets/component.txt
+++ b/templates/component-rust/metadata/snippets/component.txt
@@ -1,0 +1,6 @@
+[component.{{project-name | kebab_case}}]
+source = "{{ output-path }}/target/wasm32-wasip2/release/{{project-name | snake_case}}.wasm"
+[component.{{project-name | kebab_case}}.build]
+command = "cargo build --target wasm32-wasip2 --release"
+workdir = "{{ output-path }}"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/component-rust/metadata/spin-template.toml
+++ b/templates/component-rust/metadata/spin-template.toml
@@ -1,0 +1,12 @@
+manifest_version = "1"
+id = "component-rust"
+description = "Pure Rust component to be used as a dependency for other component"
+tags = ["rust"]
+
+[add_component]
+skip_files = ["spin.toml"]
+[add_component.snippets]
+component = "component.txt"
+
+[parameters]
+project-description = { type = "string",  prompt = "Description", default = "" }


### PR DESCRIPTION
This new template makes it easy to create a component that can be used as a dependency in another component. Until now, that required fully manually setting up a component and adding it to the Spin manifest, etc.