### PR TITLE
fix #2974 -- use redis::aio::ConnectionManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+dependencies = [
+ "fastrand 2.2.0",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,7 +4473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6493,6 +6502,31 @@ dependencies = [
  "combine",
  "futures-util",
  "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff21dd025d2d3d2a6ad6788c0f7153f82d063216a7638f70367aac5790fea5da"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itertools 0.13.0",
+ "itoa",
  "native-tls",
  "num-bigint",
  "percent-encoding",
@@ -8059,7 +8093,7 @@ name = "spin-key-value-redis"
 version = "3.2.0-pre0"
 dependencies = [
  "anyhow",
- "redis 0.27.5",
+ "redis 0.28.0",
  "serde",
  "spin-core",
  "spin-factor-key-value",

--- a/crates/factor-key-value/src/util.rs
+++ b/crates/factor-key-value/src/util.rs
@@ -156,6 +156,10 @@ struct CachingStore {
 
 #[async_trait]
 impl Store for CachingStore {
+    async fn after_open(&self) -> Result<(), Error> {
+        self.inner.after_open().await
+    }
+
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, Error> {
         // Retrieve the specified value from the cache, lazily populating the cache as necessary.
 

--- a/crates/key-value-redis/Cargo.toml
+++ b/crates/key-value-redis/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-redis = { version = "0.27", features = ["tokio-comp", "tokio-native-tls-comp"] }
+redis = { version = "0.28", features = ["tokio-comp", "tokio-native-tls-comp", "connection-manager"] }
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }


### PR DESCRIPTION
Fixes #2974

This replaces the use of `redis::aio::MultiplexedConnection` with `redis::aio::ConnectionManager` which automatically attempts to retry connecting upon error. See [this](https://docs.rs/redis/latest/redis/aio/struct.ConnectionManager.html#behavior) for behavior of `ConnectionManager`. To handle *not* passing on the first error to the user as described by "When a command sent to the server fails with an error that represents a “connection dropped” condition, that error will be passed on to the user..." relevant implementations of `Store` now implement `after_open()` which will to try ping the connection to trigger the automatic retry.