### PR TITLE
Update TinyGo templates to address static init problems

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,12 +9,12 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
 # Go installation, see https://go.dev/doc/install
-ARG GO_URL="https://go.dev/dl/go1.20.1.linux-amd64.tar.gz"
+ARG GO_URL="https://go.dev/dl/go1.22.0.linux-amd64.tar.gz"
 RUN curl -sL "$GO_URL" | tar -xzf - -C /usr/local
 ENV PATH "$PATH:/usr/local/go/bin"
 
 # TinyGo installation, see https://tinygo.org/getting-started/install/linux/ for instructions
-ARG TINYGO_URL="https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_amd64.deb"
+ARG TINYGO_URL="https://github.com/tinygo-org/tinygo/releases/download/v0.35.0/tinygo_0.35.0_amd64.deb"
 RUN curl -sL "$TINYGO_URL" -o tinygo_amd64.deb && dpkg -i tinygo_amd64.deb && rm tinygo_amd64.deb
 
 # Install the gopls Go Language Server, see https://github.com/golang/tools/tree/master/gopls

--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -68,7 +68,7 @@ inputs:
     type: bool
   tinygo-version:
     description: 'tinygo version to setup'
-    default: 'v0.27.0'
+    default: 'v0.35.0'
     required: false
     type: string
 

--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -46,7 +46,7 @@ inputs:
     type: bool
   golang-version:
     description: 'golang version to setup'
-    default: '1.20'
+    default: '1.22'
     required: false
     type: string
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
           go-version: '1.20.1'
       - uses: acifani/setup-tinygo@v2
         with:
-          tinygo-version: '0.27.0'
+          tinygo-version: '0.35.0'
       - uses: actions/setup-node@v3
         with:
           node-version: '20.x'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.1'
+          go-version: '1.22'
       - uses: acifani/setup-tinygo@v2
         with:
           tinygo-version: '0.35.0'

--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -1,6 +1,6 @@
 module github.com/{{project-name | snake_case}}
 
-go 1.20
+go 1.22
 
 require github.com/fermyon/spin/sdk/go/v2 v2.2.0
 

--- a/templates/http-go/content/main.go
+++ b/templates/http-go/content/main.go
@@ -13,5 +13,3 @@ func init() {
 		fmt.Fprintln(w, "Hello Fermyon!")
 	})
 }
-
-func main() {}

--- a/templates/http-go/content/spin.toml
+++ b/templates/http-go/content/spin.toml
@@ -14,5 +14,5 @@ component = "{{project-name | kebab_case}}"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -scheduler=none -buildmode=c-shared -no-debug -o main.wasm ."
 watch = ["**/*.go", "go.mod"]

--- a/templates/http-go/metadata/snippets/component.txt
+++ b/templates/http-go/metadata/snippets/component.txt
@@ -6,6 +6,6 @@ component = "{{project-name | kebab_case}}"
 source = "{{ output-path }}/main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -scheduler=none -buildmode=c-shared -no-debug -o main.wasm ."
 workdir = "{{ output-path }}"
 watch = ["**/*.go", "go.mod"]

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -1,5 +1,5 @@
 module github.com/{{project-name | snake_case}}
 
-go 1.20
+go 1.22
 
 require github.com/fermyon/spin/sdk/go/v2 v2.2.0

--- a/templates/redis-go/content/main.go
+++ b/templates/redis-go/content/main.go
@@ -14,6 +14,3 @@ func init() {
 		return nil
 	})
 }
-
-// main functiion must be included for the compiler but is not executed.
-func main() {}


### PR DESCRIPTION
E.g. this should fix static logging objects not being ready, os.Environ(), etc.

See https://github.com/fermyon/spin/issues/2184#issuecomment-2585955161.

Marking as draft initially to verify that I haven't muddled up the changes and that I've updated CI correctly.
