### PR TITLE
fix(templates/http-go): Remove scheduler flag from http-go build command

### DIFF
--- a/crates/componentize/src/lib.rs
+++ b/crates/componentize/src/lib.rs
@@ -440,8 +440,9 @@ mod tests {
         let mut cmd = process::Command::new("tinygo");
         cmd.arg("build")
             .current_dir("tests/go-case")
-            .arg("-target=wasi")
+            .arg("-target=wasip1")
             .arg("-gc=leaking")
+            .arg("-buildmode=c-shared")
             .arg("-no-debug")
             .arg("-o")
             .arg(out_dir.join("go_case.wasm"))

--- a/crates/componentize/tests/go-case/main.go
+++ b/crates/componentize/tests/go-case/main.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
 	"errors"
-	"strings"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"strings"
 
-	spinredis "github.com/fermyon/spin/sdk/go/redis"
-	spinhttp "github.com/fermyon/spin/sdk/go/http"
 	spinconfig "github.com/fermyon/spin/sdk/go/config"
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
+	spinredis "github.com/fermyon/spin/sdk/go/redis"
 )
 
 func init() {
@@ -65,5 +65,3 @@ func execute(v []string) error {
 
 	return nil
 }
-
-func main() {}

--- a/crates/componentize/tests/go-case/spin.toml
+++ b/crates/componentize/tests/go-case/spin.toml
@@ -12,4 +12,4 @@ allowed_http_hosts = []
 [component.trigger]
 route = "/..."
 [component.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm ."

--- a/templates/http-go/content/spin.toml
+++ b/templates/http-go/content/spin.toml
@@ -14,5 +14,5 @@ component = "{{project-name | kebab_case}}"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "tinygo build -target=wasip1 -gc=leaking -scheduler=none -buildmode=c-shared -no-debug -o main.wasm ."
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm ."
 watch = ["**/*.go", "go.mod"]

--- a/templates/http-go/metadata/snippets/component.txt
+++ b/templates/http-go/metadata/snippets/component.txt
@@ -6,6 +6,6 @@ component = "{{project-name | kebab_case}}"
 source = "{{ output-path }}/main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "tinygo build -target=wasip1 -gc=leaking -scheduler=none -buildmode=c-shared -no-debug -o main.wasm ."
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm ."
 workdir = "{{ output-path }}"
 watch = ["**/*.go", "go.mod"]

--- a/templates/redis-go/content/spin.toml
+++ b/templates/redis-go/content/spin.toml
@@ -17,4 +17,4 @@ component = "{{project-name | kebab_case}}"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm ."


### PR DESCRIPTION
This removes the `-scheduler=none` flag from the build command in the http-go template. Including this flag prevents Spin applications using `http.Transport` from compiling.

```
❯ spin build
Building component http-roundtrip-test with `tinygo build -target=wasip1 -gc=leaking -scheduler=none -buildmode=c-shared -no-debug -o main.wasm .`
/opt/homebrew/Cellar/tinygo/0.35.0/src/net/http/transfer.go:213:2: attempted to start a goroutine without a scheduler
Error: Build command for component http-roundtrip-test failed with status Exited(1)
```