### PR TITLE
Clearer progress info for multi-command builds

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -81,8 +81,31 @@ fn build_components(
 fn build_component(build_info: ComponentBuildInfo, app_dir: &Path) -> Result<()> {
     match build_info.build {
         Some(b) => {
-            for command in b.commands() {
-                terminal::step!("Building", "component {} with `{}`", build_info.id, command);
+            let command_count = b.commands().len();
+
+            if command_count > 1 {
+                terminal::step!(
+                    "Building",
+                    "component {} ({} commands)",
+                    build_info.id,
+                    command_count
+                );
+            }
+
+            for (index, command) in b.commands().enumerate() {
+                if command_count > 1 {
+                    terminal::step!(
+                        "Running build step",
+                        "{}/{} for component {} with '{}'",
+                        index + 1,
+                        command_count,
+                        build_info.id,
+                        command
+                    );
+                } else {
+                    terminal::step!("Building", "component {} with `{}`", build_info.id, command);
+                }
+
                 let workdir = construct_workdir(app_dir, b.workdir.as_ref())?;
                 if b.workdir.is_some() {
                     println!("Working directory: {}", quoted_path(&workdir));

--- a/crates/manifest/src/schema/common.rs
+++ b/crates/manifest/src/schema/common.rs
@@ -94,7 +94,7 @@ pub struct ComponentBuildConfig {
 
 impl ComponentBuildConfig {
     /// The commands to execute for the build
-    pub fn commands(&self) -> impl Iterator<Item = &String> {
+    pub fn commands(&self) -> impl ExactSizeIterator<Item = &String> {
         let as_vec = match &self.command {
             Commands::Single(cmd) => vec![cmd],
             Commands::Multiple(cmds) => cmds.iter().collect(),


### PR DESCRIPTION
Fixes #2993.

New output for multi-command build:

![image](https://github.com/user-attachments/assets/4da1a8a7-5905-4b87-b6fd-effa2c57c82c)

Unchanged for single-command build:

![image](https://github.com/user-attachments/assets/20f2e7c7-ad77-4a9c-84a5-e6650a0e435b)
