### PR TITLE
docs(sips/006-spin-plugins): Fix typo in `package.os` field definition: `osx` -> `macos`

### DIFF
--- a/docs/content/sips/006-spin-plugins.md
+++ b/docs/content/sips/006-spin-plugins.md
@@ -159,7 +159,7 @@ A Spin plugin is defined by a Spin Plugin Manifest which is a JSON file that con
                         "type": "string",
                         "enum": [
                             "linux",
-                            "osx",
+                            "macos",
                             "windows"
                         ]
                     },


### PR DESCRIPTION
At the time of writing (Spin v3.1.2), the `Os` enum is [defined][0] as follows:

```rs
enum Os {
    Linux,
    Macos,
    Windows,
}
```

This commit adjust the SIP to match the implementation by renaming `osx` to `macos`. Note that the SIP later on uses `macos` as part of the URL in one of the examples.

## Background 

Our team is using the [Nix](https://nix.dev/) to package (build from source and "install") a Spin plugin that we developed. In process we created a Nix function to generate the spin plugin manifest file by compiling the source code, archiving and hashing it and filling the rest of manifest fields, following the SIP006 spec. Specifically, we were mapping Nix kernel name to spin plugin package `os` like so:

```nix
{
  linux = "linux";
  darwin = "osx";
}.${hostPlatform.parsed.kernel.name};
```

Testing on macOS immediately highlighted the problem:

```
invalid manifest for plugin '' at /nix/store/ycqy6f0pqg8c7fm894hbgjg5cfss4sw3-trigger-oracle.json: unknown variant `osx`, expected one of `linux`, `macos`, `windows` at line 9 column 17
```

[0]: https://github.com/fermyon/spin/blob/v3.1.2/crates/plugins/src/manifest.rs#L113